### PR TITLE
Define node version to be 18 or later to fix readline/promises issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "MCP server for AutoMem: AI memory storage and recall",
   "main": "dist/index.js",
   "type": "module",
+  "engines": {
+    "node": ">=18.0.0"
+  },
   "bin": {
     "mcp-automem": "dist/index.js"
   },


### PR DESCRIPTION
This solves initial install errors:

```
npm warn cli npm v10.8.2 does not support Node.js v16.13.0. This version of npm supports the following node versions: `^18.17.0 || >=20.5.0`. You can find the latest version at https://nodejs.org/.
node:internal/errors:464
    ErrorCaptureStackTrace(err);
    ^

Error [ERR_UNKNOWN_BUILTIN_MODULE]: No such built-in module: node:readline/promises
    at new NodeError (node:internal/errors:371:5)
    at ESMLoader.builtinStrategy (node:internal/modules/esm/translators:276:11)
    at ESMLoader.moduleProvider (node:internal/modules/esm/loader:236:14)
    at async link (node:internal/modules/esm/module_job:67:21) {
  code: 'ERR_UNKNOWN_BUILTIN_MODULE'
}
```