### PR TITLE
Fix AppleScript syntax error in smart-notify.sh

### DIFF
--- a/templates/claude-code/scripts/smart-notify.sh
+++ b/templates/claude-code/scripts/smart-notify.sh
@@ -51,5 +51,10 @@ if command -v terminal-notifier >/dev/null 2>&1; then
         -message "$MSG" \
         -sound "$SOUND"
 else
-    osascript -e "display notification \"$MSG\" with title \"Claude Code ($SESSION_DIR) - $TITLE\" sound name \"$SOUND\""
+    # Escape special characters for AppleScript (only double quotes and backslashes)
+    MSG_ESCAPED=$(printf '%s' "$MSG" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')
+    TITLE_FULL="Claude Code ($SESSION_DIR) - $TITLE"
+    TITLE_ESCAPED=$(printf '%s' "$TITLE_FULL" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g')
+
+    osascript -e "display notification \"$MSG_ESCAPED\" with title \"$TITLE_ESCAPED\" sound name \"$SOUND\""
 fi


### PR DESCRIPTION
## Description

Fixes #3

Resolves AppleScript syntax error in `smart-notify.sh` when notification messages contain special characters.

## Problem

The Stop hook was failing with syntax errors when messages contained special characters:
```
Stop hook error: Failed with non-blocking status code: 30:37: syntax error: A identifier can't go after this """. (-2740)
```

## Solution

Added proper escaping for `$MSG` and `$TITLE` variables before passing to `osascript`:
- Escape backslashes: `\` → `\\`
- Escape double quotes: `"` → `\"`
- Single quotes/apostrophes do not need escaping in AppleScript double-quoted strings

## Changes

- Updated `templates/claude-code/scripts/smart-notify.sh` line 54-60
- Added escaping logic using `sed` for backslashes and double quotes
- Added inline comment explaining the escaping strategy

## Testing

Comprehensive testing with various special characters:
- ✅ Double quotes: `Message with "double quotes"`
- ✅ Single quotes: `Message with 'single quotes'`
- ✅ Apostrophes: `Complex: "test" (with) 'apostrophe'`
- ✅ Parentheses: `Message with (parentheses)`
- ✅ Backslashes: `Backslash \ test`
- ✅ Mixed special characters: `Mixed: "quoted" and 'apostrophe' with \ backslash`

All 8 test cases passed successfully with notifications displaying correctly on macOS.

## Impact

- ✅ Fixes Stop hook errors for macOS users without `terminal-notifier` installed
- ✅ No breaking changes
- ✅ Backward compatible with existing installations
- ✅ Only affects osascript fallback path
- ✅ Terminal-notifier path unchanged (already working correctly)

## Screenshots

Notifications now display correctly with special characters instead of throwing AppleScript syntax errors.
