### PR TITLE
feat: Add expansion filtering params for noise reduction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,62 +1,61 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+    push:
+        branches: [main]
+    pull_request:
+        branches: [main]
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    
-    strategy:
-      matrix:
-        node-version: [18, 20, 22]
+    test:
+        runs-on: ubuntu-latest
 
-    steps:
-      - uses: actions/checkout@v4
+        strategy:
+            matrix:
+                node-version: [18, 20, 22]
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
+        steps:
+            - uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: npm ci
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  cache: "npm"
 
-      - name: Type check
-        run: npm run typecheck
+            - name: Install dependencies
+              run: npm ci
 
-      - name: Run tests
-        run: npm test
+            - name: Type check
+              run: npm run typecheck
 
-      - name: Build
-        run: npm run build
+            - name: Run tests
+              run: npm test
 
-  coverage:
-    runs-on: ubuntu-latest
-    needs: test
-    
-    steps:
-      - uses: actions/checkout@v4
+            - name: Build
+              run: npm run build
 
-      - name: Use Node.js 20
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
+    coverage:
+        runs-on: ubuntu-latest
+        needs: test
 
-      - name: Install dependencies
-        run: npm ci
+        steps:
+            - uses: actions/checkout@v4
 
-      - name: Run tests with coverage
-        run: npm run test:coverage
+            - name: Use Node.js 20
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: "npm"
 
-      - name: Upload coverage reports
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
+            - name: Install dependencies
+              run: npm ci
 
+            - name: Run tests with coverage
+              run: npm run test:coverage
+
+            - name: Upload coverage reports
+              uses: codecov/codecov-action@v4
+              with:
+                  token: ${{ secrets.CODECOV_TOKEN }}
+                  fail_ci_if_error: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased] - 0.9.0
+
+### Added
+- **Expansion filtering parameters**: Reduce noise in graph-expanded results
+  - `expand_min_importance` - Minimum importance score for expanded results (0-1)
+  - `expand_min_strength` - Minimum relation strength to follow during expansion (0-1)
+  - Server-side filtering keeps seed results intact, only filters expanded memories
+  - Addresses issue where `expand_relations=true` returned too many low-relevance memories
+
+### Changed
+- Updated `RecallMemoryArgs` interface with expansion filtering parameters
+- Updated `AutoMemClient.recallMemory()` to pass filtering params to backend
+
+### Note
+- Requires AutoMem server update to implement filtering logic
+
+## 0.8.1 - 2025-12-04
+
+### Fixed
+- **MCP spec compliance**: All tool handlers now return `structuredContent` alongside `content`
+  - Required when `outputSchema` is defined per MCP specification
+  - Fixes error: "Tool has an output schema but did not return structured content"
+- **recall_memory output**: Changed `memories` to `results` to match `outputSchema`
+- Added `dedup_removed` field to recall output
+
 ## 0.8.0 - 2025-12-02
 
 ### Changed

--- a/src/automem-client.ts
+++ b/src/automem-client.ts
@@ -141,6 +141,15 @@ export class AutoMemClient {
       params.set('relation_limit', String(args.relation_limit));
     }
 
+    // Expansion filtering (reduces noise)
+    if (typeof args.expand_min_importance === 'number') {
+      params.set('expand_min_importance', String(args.expand_min_importance));
+    }
+
+    if (typeof args.expand_min_strength === 'number') {
+      params.set('expand_min_strength', String(args.expand_min_strength));
+    }
+
     // Context hints for smarter recall
     if (args.context) {
       params.set('context', args.context);

--- a/src/index.ts
+++ b/src/index.ts
@@ -402,6 +402,18 @@ const tools: Tool[] = [
           default: 5,
           description: 'Max relations to follow per seed memory (default: 5)',
         },
+        expand_min_importance: {
+          type: 'number',
+          minimum: 0,
+          maximum: 1,
+          description: 'Minimum importance score for expanded results (default: server-side). Higher values reduce noise.',
+        },
+        expand_min_strength: {
+          type: 'number',
+          minimum: 0,
+          maximum: 1,
+          description: 'Minimum relation strength to follow during expansion (default: server-side). Only follow strong associations.',
+        },
         context: {
           type: 'string',
           description: 'Context label (e.g., "coding-style", "architecture"). Boosts matching preferences.',

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,6 +107,9 @@ export interface RecallMemoryArgs {
   auto_decompose?: boolean;
   expansion_limit?: number;
   relation_limit?: number;
+  // Expansion filtering (reduces noise in expanded results)
+  expand_min_importance?: number;
+  expand_min_strength?: number;
   // Context hints for smarter recall
   context?: string;
   language?: string;


### PR DESCRIPTION
New recall_memory parameters:
- expand_min_importance: Filter expanded results by importance (0-1)
- expand_min_strength: Only follow relations with strength >= threshold (0-1)

These are pass-through params - server-side implementation required. Addresses noise issue where expand_relations returned too many low-relevance memories.

Updated: types.ts, index.ts inputSchema, automem-client.ts, CHANGELOG.md