### PR TITLE
fix: remove duplicate hooks declaration causing load error

### DIFF
--- a/plugins/automem/.claude-plugin/plugin.json
+++ b/plugins/automem/.claude-plugin/plugin.json
@@ -18,6 +18,5 @@
     "persistence",
     "knowledge-graph"
   ],
-  "hooks": "./hooks/hooks.json",
   "mcpServers": "./.mcp.json"
 }


### PR DESCRIPTION
## Summary

- Remove explicit `"hooks": "./hooks/hooks.json"` declaration from plugin.json

## Problem

Claude Code automatically discovers and loads `hooks/hooks.json` from the standard location. When the plugin.json also explicitly declares this same path, the file gets loaded twice, causing:

```
Failed to load hooks from .../hooks/hooks.json: Duplicate hooks file detected: 
./hooks/hooks.json resolves to already-loaded file .../hooks/hooks.json. 
The standard hooks/hooks.json is loaded automatically, so manifest.hooks 
should only reference additional hook files.
```

## Solution

Remove the explicit hooks declaration. The `hooks` field in plugin.json should only be used for **non-standard** hook file locations. The standard `hooks/hooks.json` is auto-discovered.

## Test plan

- [x] Install plugin and verify no duplicate hooks error
- [x] Verify hooks still load correctly (SessionStart, Stop, PostToolUse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)