### PR TITLE
chore(templates): standardize version markers and add personal namespace

### DIFF
--- a/templates/CLAUDE_DESKTOP_INSTRUCTIONS.md
+++ b/templates/CLAUDE_DESKTOP_INSTRUCTIONS.md
@@ -1,5 +1,7 @@
 # Memory-Enhanced Assistant
 
+<!-- automem-template-version: 1.0.0 -->
+
 You have access to AutoMem - a persistent memory system with graph relationships and semantic search. Use it strategically to provide continuity across conversations.
 
 > Tool names are client-specific. In Claude Desktop, they typically look like `mcp__<server>__<tool>`.

--- a/templates/CLAUDE_MD_MEMORY_RULES.md
+++ b/templates/CLAUDE_MD_MEMORY_RULES.md
@@ -1,5 +1,7 @@
 # AutoMem Memory Rules for CLAUDE.md
 
+<!-- automem-template-version: 1.0.0 -->
+
 Add this section to your `~/.claude/CLAUDE.md` file. The SessionStart hook will prompt memory recall automatically.
 
 ## Quick Installation
@@ -214,8 +216,5 @@ BEST PRACTICES:
 - Create relationships between related memories for graph navigation
 - Update rather than duplicate when knowledge evolves
 - Let low-importance memories (<0.3) decay naturally
-  </memory_rules>
-
-```
-
-```
+</memory_rules>
+````

--- a/templates/codex/memory-rules.md
+++ b/templates/codex/memory-rules.md
@@ -1,5 +1,5 @@
 <!-- BEGIN AUTOMEM CODEX RULES -->
-<!-- automem-codex-version: 0.9.0 -->
+<!-- automem-template-version: 1.0.0 -->
 
 ## Memory-First Development (AutoMem Codex)
 

--- a/templates/cursor/automem.mdc.template
+++ b/templates/cursor/automem.mdc.template
@@ -2,7 +2,7 @@
 description: AutoMem persistent memory - recall context at start, store decisions during work, summarize at end
 alwaysApply: true
 ---
-<!-- automem-mdc-version: {{VERSION}} -->
+<!-- automem-template-version: 1.0.0 -->
 
 # AutoMem Memory Integration
 
@@ -123,11 +123,18 @@ Summarize if multiple files modified, significant refactoring, new features, or 
 
 ## Tagging Convention
 
-ALWAYS include these tags:
+**For project-specific memories** (code, architecture, decisions):
 1. `{{PROJECT_NAME}}` - Project identifier
 2. `cursor` - Platform tag
 3. `{{CURRENT_MONTH}}` - Current month (YYYY-MM format)
 4. Component tag - Specific area (e.g., "auth", "api", "frontend")
+
+**For personal/cross-project memories** (preferences, lifestyle, relationships):
+1. `personal` - Personal namespace (instead of project tag)
+2. `{{CURRENT_MONTH}}` - Current month
+3. Category tag - Domain (e.g., "health", "preferences", "workflow")
+
+**Why separate namespaces?** Project tags help filter technical memories, but personal memories should be discoverable across all projects. Using `personal` instead of a project tag ensures preferences and lifestyle context aren't drowned out by high-importance technical memories.
 
 ## Importance Scoring
 


### PR DESCRIPTION
## Summary
- Add `automem-template-version: 1.0.0` to all templates for tracking
- Add personal namespace guidance for cross-project memories (addresses #15)
- Fix malformed markdown fence in CLAUDE_MD_MEMORY_RULES.md

## Template Changes

**Cursor template**: Added personal namespace documentation explaining when to use `personal` tag instead of project tags for cross-project memories.

**All templates**: Added version marker comment for easier tracking of template versions.

Closes #15

Made with [Cursor](https://cursor.com)