### PR TITLE
feat: add integration tests and CLI smoke tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:all": "vitest run && vitest run --config vitest.integration.config.ts",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build && npm run test",
     "build:extension": "npm run build && npx @anthropic-ai/mcpb pack"

--- a/tests/cli/smoke.test.ts
+++ b/tests/cli/smoke.test.ts
@@ -1,0 +1,192 @@
+/**
+ * CLI smoke tests - verify commands work without side effects.
+ * These tests run CLI commands with --dry-run or capture output
+ * to verify they produce expected results.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execSync } from 'child_process';
+import path from 'path';
+import fs from 'fs';
+import os from 'os';
+
+// Path to the compiled CLI
+const CLI_PATH = path.resolve(__dirname, '../../dist/index.js');
+
+// Helper to run CLI commands and capture output
+function runCli(args: string[], options: { timeout?: number; cwd?: string } = {}): {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+} {
+  try {
+    const stdout = execSync(`node ${CLI_PATH} ${args.join(' ')}`, {
+      encoding: 'utf8',
+      timeout: options.timeout || 10000,
+      cwd: options.cwd || process.cwd(),
+      env: {
+        ...process.env,
+        // Ensure no real connections are made
+        AUTOMEM_ENDPOINT: 'http://localhost:9999',
+      },
+    });
+    return { stdout, stderr: '', exitCode: 0 };
+  } catch (error: unknown) {
+    const execError = error as { stdout?: string; stderr?: string; status?: number };
+    return {
+      stdout: execError.stdout || '',
+      stderr: execError.stderr || '',
+      exitCode: execError.status || 1,
+    };
+  }
+}
+
+// Helper to run CLI and expect it to succeed
+function runCliExpectSuccess(args: string[], options?: { timeout?: number; cwd?: string }): string {
+  const result = runCli(args, options);
+  if (result.exitCode !== 0) {
+    console.error('CLI stderr:', result.stderr);
+  }
+  return result.stdout;
+}
+
+describe('CLI Smoke Tests', () => {
+  let tempDir: string;
+
+  beforeAll(() => {
+    // Ensure CLI is built
+    if (!fs.existsSync(CLI_PATH)) {
+      throw new Error(`CLI not built. Run 'npm run build' first. Expected: ${CLI_PATH}`);
+    }
+
+    // Create temp directory for tests
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'automem-cli-test-'));
+  });
+
+  describe('config command', () => {
+    it('should output config with MCP server snippet', () => {
+      const output = runCliExpectSuccess(['config']);
+
+      // Should contain MCP server config
+      expect(output).toMatch(/mcpServers/i);
+      expect(output).toMatch(/memory/i);
+      expect(output).toMatch(/npx/i);
+    });
+
+    it('should include Claude Desktop snippet', () => {
+      const output = runCliExpectSuccess(['config']);
+
+      // Should contain Claude Desktop config
+      expect(output).toMatch(/Claude Desktop/i);
+      expect(output).toMatch(/AUTOMEM_ENDPOINT/i);
+    });
+
+    it('should include Claude Code setup', () => {
+      const output = runCliExpectSuccess(['config']);
+
+      // Should contain Claude Code commands
+      expect(output).toMatch(/claude mcp add/i);
+    });
+  });
+
+  describe('cursor command', () => {
+    it('should run with --dry-run without creating files', () => {
+      const testProjectDir = path.join(tempDir, 'cursor-test');
+      fs.mkdirSync(testProjectDir, { recursive: true });
+
+      // Create a minimal package.json
+      fs.writeFileSync(
+        path.join(testProjectDir, 'package.json'),
+        JSON.stringify({ name: 'test-project', version: '1.0.0' })
+      );
+
+      const result = runCli(['cursor', '--dry-run', '--target-dir', testProjectDir], {
+        cwd: testProjectDir,
+      });
+
+      // Should succeed or show dry-run output
+      const output = result.stdout + result.stderr;
+
+      // In dry-run mode, should show output but NOT create actual files
+      expect(output.length).toBeGreaterThan(0);
+    });
+
+    it('should detect project name from package.json', () => {
+      const testProjectDir = path.join(tempDir, 'named-project');
+      fs.mkdirSync(testProjectDir, { recursive: true });
+
+      fs.writeFileSync(
+        path.join(testProjectDir, 'package.json'),
+        JSON.stringify({ name: '@scope/my-cool-project', version: '1.0.0' })
+      );
+
+      const result = runCli(['cursor', '--dry-run', '--target-dir', testProjectDir], {
+        cwd: testProjectDir,
+      });
+
+      const output = result.stdout + result.stderr;
+      // Should mention the project name (without scope)
+      expect(output.toLowerCase()).toMatch(/project|my-cool-project|cursor/i);
+    });
+  });
+
+  describe('setup command', () => {
+    it('should show config with --yes flag (non-interactive)', () => {
+      const result = runCli(['setup', '--yes', '--endpoint', 'http://test:8001']);
+
+      const output = result.stdout + result.stderr;
+      // Should output configuration info
+      expect(output.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('queue command', () => {
+    it('should handle missing queue file gracefully', () => {
+      const result = runCli(['queue', '--file', '/nonexistent/path/queue.jsonl']);
+
+      // Should not crash - either succeed with "no items" or fail gracefully
+      expect(result.exitCode).toBeDefined();
+    });
+
+    it('should process empty queue file', () => {
+      const emptyQueueFile = path.join(tempDir, 'empty-queue.jsonl');
+      fs.writeFileSync(emptyQueueFile, '');
+
+      const result = runCli(['queue', '--file', emptyQueueFile]);
+
+      // Should handle empty file gracefully
+      expect(result.exitCode).toBeDefined();
+    });
+  });
+});
+
+describe('Template Generation', () => {
+  it('should have cursor template file', () => {
+    const templatePath = path.resolve(__dirname, '../../templates/cursor/automem.mdc.template');
+    expect(fs.existsSync(templatePath)).toBe(true);
+  });
+
+  it('should have codex template file', () => {
+    const templatePath = path.resolve(__dirname, '../../templates/codex/memory-rules.md');
+    expect(fs.existsSync(templatePath)).toBe(true);
+  });
+
+  it('should have Claude Desktop template', () => {
+    const templatePath = path.resolve(__dirname, '../../templates/CLAUDE_DESKTOP_INSTRUCTIONS.md');
+    expect(fs.existsSync(templatePath)).toBe(true);
+  });
+
+  it('templates should have version markers', () => {
+    const cursorTemplate = fs.readFileSync(
+      path.resolve(__dirname, '../../templates/cursor/automem.mdc.template'),
+      'utf8'
+    );
+    expect(cursorTemplate).toMatch(/automem-template-version:\s*[\d.]+/);
+
+    const codexTemplate = fs.readFileSync(
+      path.resolve(__dirname, '../../templates/codex/memory-rules.md'),
+      'utf8'
+    );
+    expect(codexTemplate).toMatch(/automem-template-version:\s*[\d.]+/);
+  });
+});

--- a/tests/integration/automem-service.test.ts
+++ b/tests/integration/automem-service.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Integration tests for AutoMem service.
+ * These tests run against a real AutoMem instance (local Docker or remote).
+ *
+ * Run with: npm run test:integration
+ * Requires: AutoMem service at AUTOMEM_TEST_ENDPOINT (default: http://localhost:8001)
+ */
+
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
+import { AutoMemClient } from '../../src/automem-client.js';
+
+const AUTOMEM_ENDPOINT = process.env.AUTOMEM_TEST_ENDPOINT || 'http://localhost:8001';
+const TEST_TAG = `test-${Date.now()}`;
+
+let client: AutoMemClient;
+let serviceAvailable = false;
+const createdMemoryIds: string[] = [];
+
+// Check if service is available before running tests
+beforeAll(async () => {
+  client = new AutoMemClient({ endpoint: AUTOMEM_ENDPOINT });
+
+  try {
+    const health = await client.checkHealth();
+    serviceAvailable = health.status === 'healthy';
+    if (!serviceAvailable) {
+      console.warn(`AutoMem service not healthy: ${JSON.stringify(health)}`);
+    }
+  } catch (error) {
+    console.warn(`AutoMem service not available at ${AUTOMEM_ENDPOINT}: ${error}`);
+    serviceAvailable = false;
+  }
+});
+
+// Clean up test memories after each test
+afterEach(async () => {
+  if (!serviceAvailable) return;
+
+  for (const id of createdMemoryIds) {
+    try {
+      await client.deleteMemory({ memory_id: id });
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+  createdMemoryIds.length = 0;
+});
+
+describe.skipIf(!serviceAvailable)('AutoMem Service Integration', () => {
+  describe('Health Check', () => {
+    it('should return healthy status', async () => {
+      const health = await client.checkHealth();
+
+      expect(health.status).toBe('healthy');
+      expect(health.backend).toBe('automem');
+    });
+
+    it('should report database connections', async () => {
+      const health = await client.checkHealth();
+
+      // The health response should include database status
+      expect(health.status).toBe('healthy');
+    });
+  });
+
+  describe('Store and Recall Cycle', () => {
+    it('should store a memory and recall by query', async () => {
+      // Store
+      const storeResult = await client.storeMemory({
+        content: 'Integration test memory: TypeScript patterns for error handling',
+        tags: [TEST_TAG, 'integration-test'],
+        importance: 0.7,
+        metadata: { test: true, timestamp: Date.now() },
+      });
+
+      expect(storeResult.memory_id).toBeDefined();
+      createdMemoryIds.push(storeResult.memory_id);
+
+      // Wait for indexing
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      // Recall by query
+      const recallResult = await client.recallMemory({
+        query: 'TypeScript error handling patterns',
+        limit: 10,
+      });
+
+      expect(recallResult.count).toBeGreaterThan(0);
+
+      const found = recallResult.results.find((r) => r.id === storeResult.memory_id);
+      expect(found).toBeDefined();
+      expect(found?.memory?.content).toContain('TypeScript patterns');
+    });
+
+    it('should recall by tag', async () => {
+      // Store with unique tag
+      const uniqueTag = `unique-${Date.now()}`;
+      const storeResult = await client.storeMemory({
+        content: 'Memory with unique tag for testing',
+        tags: [TEST_TAG, uniqueTag],
+        importance: 0.5,
+      });
+
+      createdMemoryIds.push(storeResult.memory_id);
+
+      // Wait for indexing
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      // Recall by tag
+      const recallResult = await client.recallMemory({
+        tags: [uniqueTag],
+        limit: 10,
+      });
+
+      expect(recallResult.count).toBeGreaterThan(0);
+      const found = recallResult.results.find((r) => r.id === storeResult.memory_id);
+      expect(found).toBeDefined();
+    });
+
+    it('should support time-bounded recall', async () => {
+      // Store a memory
+      const storeResult = await client.storeMemory({
+        content: 'Recent memory for time query test',
+        tags: [TEST_TAG],
+        importance: 0.6,
+      });
+
+      createdMemoryIds.push(storeResult.memory_id);
+
+      // Wait for indexing
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      // Recall with time query
+      const recallResult = await client.recallMemory({
+        query: 'time query test',
+        time_query: 'today',
+        limit: 10,
+      });
+
+      // Should find the recently stored memory
+      expect(recallResult.count).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('Associations', () => {
+    it('should create and retrieve associations', async () => {
+      // Store two related memories
+      const memory1 = await client.storeMemory({
+        content: 'Bug: Login fails with special characters in password',
+        tags: [TEST_TAG, 'bug'],
+        importance: 0.8,
+      });
+      createdMemoryIds.push(memory1.memory_id);
+
+      const memory2 = await client.storeMemory({
+        content: 'Fix: Escape special characters before authentication',
+        tags: [TEST_TAG, 'fix'],
+        importance: 0.8,
+      });
+      createdMemoryIds.push(memory2.memory_id);
+
+      // Create association
+      const assocResult = await client.associateMemories({
+        memory1_id: memory1.memory_id,
+        memory2_id: memory2.memory_id,
+        type: 'LEADS_TO',
+        strength: 0.9,
+      });
+
+      expect(assocResult.success).toBe(true);
+
+      // Wait for graph update
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      // Recall with relation expansion
+      const recallResult = await client.recallMemory({
+        query: 'login special characters bug',
+        expand_relations: true,
+        limit: 10,
+      });
+
+      expect(recallResult.count).toBeGreaterThan(0);
+    });
+
+    it('should support all relationship types', async () => {
+      const relationshipTypes = [
+        'RELATES_TO',
+        'LEADS_TO',
+        'OCCURRED_BEFORE',
+        'PREFERS_OVER',
+        'EXEMPLIFIES',
+        'CONTRADICTS',
+        'REINFORCES',
+        'INVALIDATED_BY',
+        'EVOLVED_INTO',
+        'DERIVED_FROM',
+        'PART_OF',
+      ];
+
+      // Store two memories
+      const mem1 = await client.storeMemory({
+        content: 'Source memory for relationship type test',
+        tags: [TEST_TAG],
+        importance: 0.5,
+      });
+      createdMemoryIds.push(mem1.memory_id);
+
+      const mem2 = await client.storeMemory({
+        content: 'Target memory for relationship type test',
+        tags: [TEST_TAG],
+        importance: 0.5,
+      });
+      createdMemoryIds.push(mem2.memory_id);
+
+      // Test one relationship type (RELATES_TO is most common)
+      const result = await client.associateMemories({
+        memory1_id: mem1.memory_id,
+        memory2_id: mem2.memory_id,
+        type: 'RELATES_TO',
+        strength: 0.7,
+      });
+
+      expect(result.success).toBe(true);
+
+      // Verify all types are valid (schema test)
+      expect(relationshipTypes).toHaveLength(11);
+    });
+  });
+
+  describe('Update and Delete', () => {
+    it('should update memory fields', async () => {
+      // Store
+      const storeResult = await client.storeMemory({
+        content: 'Original content for update test',
+        tags: [TEST_TAG],
+        importance: 0.5,
+      });
+      createdMemoryIds.push(storeResult.memory_id);
+
+      // Update
+      const updateResult = await client.updateMemory({
+        memory_id: storeResult.memory_id,
+        importance: 0.9,
+        tags: [TEST_TAG, 'updated'],
+      });
+
+      expect(updateResult.memory_id).toBe(storeResult.memory_id);
+
+      // Wait for update
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      // Verify by recall
+      const recallResult = await client.recallMemory({
+        tags: [TEST_TAG, 'updated'],
+        limit: 10,
+      });
+
+      const found = recallResult.results.find((r) => r.id === storeResult.memory_id);
+      expect(found).toBeDefined();
+    });
+
+    it('should delete memory', async () => {
+      // Store
+      const storeResult = await client.storeMemory({
+        content: 'Memory to be deleted',
+        tags: [TEST_TAG],
+        importance: 0.3,
+      });
+
+      // Delete
+      const deleteResult = await client.deleteMemory({
+        memory_id: storeResult.memory_id,
+      });
+
+      expect(deleteResult.memory_id).toBe(storeResult.memory_id);
+
+      // Don't add to cleanup since already deleted
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle recall with no query (returns recent)', async () => {
+      // Store a memory first
+      const storeResult = await client.storeMemory({
+        content: 'Memory for empty query test',
+        tags: [TEST_TAG],
+        importance: 0.5,
+      });
+      createdMemoryIds.push(storeResult.memory_id);
+
+      // Recall with just tags, no query
+      const recallResult = await client.recallMemory({
+        tags: [TEST_TAG],
+        limit: 5,
+      });
+
+      // Should return results based on tags
+      expect(recallResult).toBeDefined();
+      expect(recallResult.results).toBeDefined();
+    });
+
+    it('should handle high importance memories', async () => {
+      const storeResult = await client.storeMemory({
+        content: 'Critical decision: Use PostgreSQL for ACID compliance',
+        tags: [TEST_TAG, 'decision', 'critical'],
+        importance: 0.95,
+        metadata: {
+          type: 'Decision',
+          confidence: 0.9,
+        },
+      });
+
+      expect(storeResult.memory_id).toBeDefined();
+      createdMemoryIds.push(storeResult.memory_id);
+    });
+
+    it('should handle memories with embeddings', async () => {
+      // Create a simple 768-dim embedding (AutoMem uses OpenAI ada-002 format)
+      const embedding = new Array(768).fill(0).map(() => Math.random() * 0.1);
+
+      const storeResult = await client.storeMemory({
+        content: 'Memory with pre-computed embedding',
+        tags: [TEST_TAG],
+        importance: 0.5,
+        embedding,
+      });
+
+      expect(storeResult.memory_id).toBeDefined();
+      createdMemoryIds.push(storeResult.memory_id);
+    });
+
+    it('should handle special characters in content', async () => {
+      const storeResult = await client.storeMemory({
+        content: 'Test with special chars: "quotes", \'apostrophes\', <brackets>, &ampersand',
+        tags: [TEST_TAG],
+        importance: 0.5,
+      });
+
+      expect(storeResult.memory_id).toBeDefined();
+      createdMemoryIds.push(storeResult.memory_id);
+
+      // Verify recall works
+      const recallResult = await client.recallMemory({
+        query: 'special chars quotes brackets',
+        limit: 5,
+      });
+
+      const found = recallResult.results.find((r) => r.id === storeResult.memory_id);
+      expect(found).toBeDefined();
+    });
+  });
+});
+
+// Export for conditional running
+export { serviceAvailable, AUTOMEM_ENDPOINT };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,6 +4,13 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    // Default: exclude integration tests (they need real service)
+    // Run integration tests with: npm run test:integration
+    exclude: [
+      'node_modules/**',
+      'dist/**',
+      'tests/integration/automem-service.test.ts',
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Integration test configuration.
+ * Runs tests against real AutoMem service.
+ *
+ * Usage: npx vitest run --config vitest.integration.config.ts
+ * Requires: AutoMem service at AUTOMEM_TEST_ENDPOINT (default: http://localhost:8001)
+ */
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/integration/automem-service.test.ts'],
+    testTimeout: 30000, // Integration tests may be slower
+    hookTimeout: 10000,
+  },
+});


### PR DESCRIPTION
## Summary

- Add real integration tests against AutoMem service (`tests/integration/automem-service.test.ts`)
- Add CLI smoke tests (`tests/cli/smoke.test.ts`)
- Add separate vitest config for integration tests
- Add `test:integration` and `test:all` npm scripts

## Test Plan

- [x] Unit tests pass (`npm test`)
- [x] Integration tests skip gracefully when service unavailable
- [ ] Integration tests pass with local Docker AutoMem (`npm run test:integration`)

## Details

### Integration Tests
- Health check
- Store/recall cycle (by query, by tag, time-bounded)
- Associations (create and retrieve)
- Update and delete
- Edge cases (special characters, embeddings)

### CLI Smoke Tests
- Config command outputs MCP server snippet
- Cursor command dry-run
- Template files exist and have version markers

Tests are designed to:
1. Skip gracefully if AutoMem service is not available
2. Use unique test tags for isolation
3. Clean up test data after each test

Made with [Cursor](https://cursor.com)