### PR TITLE
fix: exclude GitHub compare URLs from link checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
             --exclude 'localhost'
             --exclude '127.0.0.1'
             --exclude 'x.com/i/communities'
+            --exclude 'github.com/.*/compare/.*\.\.\..*'
             README.md
             INSTALLATION.md
             CHANGELOG.md


### PR DESCRIPTION
These URLs are generated by release-please and only become valid after the release tag is created. Excluding them prevents false positives on release PRs.

Made with [Cursor](https://cursor.com)