### PR TITLE
fix: prevent dotenv stdout noise in stdio mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,11 +37,14 @@ const isServerMode = command.length === 0;
 
 if (isServerMode) {
   // Prevent dotenv (and other deps) from writing to stdout in stdio server mode.
-  process.env.DOTENV_CONFIG_QUIET ??= "true";
+  // Note: dotenv logs if debug=true even when quiet=true, so force both off.
+  process.env.DOTENV_CONFIG_QUIET = "true";
+  process.env.DOTENV_CONFIG_DEBUG = "false";
   const logToStderr = (...args: unknown[]) => console.error(...args);
   console.log = logToStderr;
   console.info = logToStderr;
   console.debug = logToStderr;
+  console.warn = logToStderr;
 }
 
 config({ quiet: isServerMode });


### PR DESCRIPTION
## Why

Claude Desktop expects pure JSON-RPC over stdout for stdio transports. dotenv v17 can emit a stdout log line by default (or when debug is enabled), which corrupts the stream.

## What

Force dotenv quiet mode and disable dotenv debug in stdio/server mode

- Redirect console log/info/debug/warn to stderr in stdio/server mode

## Testing

- npm test