### PR TITLE
ci: add docs dispatch workflow

### DIFF
--- a/.github/workflows/docs-dispatch.yml
+++ b/.github/workflows/docs-dispatch.yml
@@ -47,7 +47,7 @@ jobs:
           AFFECTED=$(echo "$MAP" | jq -r --arg repo "$REPO_KEY" --argjson changed "$CHANGED" '
             def matches_pattern($file; $pattern):
               if ($pattern | endswith("/**")) then
-                ($file | startswith($pattern[0:-3]))
+                ($file | startswith($pattern[0:-2]))
               else
                 $file == $pattern
               end;


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that triggers on pushes to main
- Detects changed files and checks them against a file-doc mapping from automem-website
- Dispatches a `docs-update` event to automem-website when affected docs are found

## Details

- Handles edge cases (first push with null SHA, failed mapping fetch)
- Uses `peter-evans/repository-dispatch@v3` with `RELEASE_PLEASE_TOKEN`
- Only dispatches when changed files actually map to documentation pages

## Test plan

- [ ] Verify workflow runs on next push to main
- [ ] Confirm `file-doc-map.json` is accessible from automem-website repo
- [ ] Validate dispatch payload arrives correctly at automem-website