### PR TITLE
fix(hooks): add stdin parsing, truncation guards, and dedup checks

### DIFF
--- a/plugins/automem/scripts/capture-build-result.sh
+++ b/plugins/automem/scripts/capture-build-result.sh
@@ -15,11 +15,29 @@ log_message() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"
 }
 
-# Get build context
-COMMAND="${CLAUDE_LAST_COMMAND:-${CLAUDE_CONTEXT:-${TOOL_NAME:-}}}"
-OUTPUT="${CLAUDE_COMMAND_OUTPUT:-${TOOL_RESULT:-}}"
-EXIT_CODE="${CLAUDE_EXIT_CODE:-0}"
-PROJECT_NAME=$(basename "$(pwd)")
+# Check required dependencies
+if ! command -v jq >/dev/null 2>&1; then
+    echo "Warning: jq not installed - capture disabled" >&2
+    exit 0
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "Warning: python3 not installed - capture disabled" >&2
+    exit 0
+fi
+
+# Read JSON input from stdin (Claude Code hook format)
+INPUT_JSON=$(cat)
+
+# Parse JSON fields, fall back to env vars for backward compat
+COMMAND=$(echo "$INPUT_JSON" | jq -r '.tool_input.command // empty' 2>/dev/null)
+COMMAND="${COMMAND:-${CLAUDE_LAST_COMMAND:-${CLAUDE_CONTEXT:-${TOOL_NAME:-}}}}"
+OUTPUT=$(echo "$INPUT_JSON" | jq -r '.tool_response // empty' 2>/dev/null)
+OUTPUT="${OUTPUT:-${CLAUDE_COMMAND_OUTPUT:-${TOOL_RESULT:-}}}"
+EXIT_CODE=$(echo "$INPUT_JSON" | jq -r '.tool_response | if type == "object" then (.exit_code // .exitCode // 0) else 0 end' 2>/dev/null)
+EXIT_CODE="${EXIT_CODE:-${CLAUDE_EXIT_CODE:-0}}"
+CWD=$(echo "$INPUT_JSON" | jq -r '.cwd // empty' 2>/dev/null)
+PROJECT_NAME=$(basename "${CWD:-$(pwd)}")
 BUILD_TOOL="unknown"
 
 # Skip non-build commands
@@ -118,6 +136,7 @@ AUTOMEM_ERRORS="$ERRORS" \
 AUTOMEM_EXIT_CODE="$EXIT_CODE" \
 AUTOMEM_COMMAND="$COMMAND" \
 python3 - <<'PY'
+import hashlib
 import json
 import os
 from datetime import datetime, timezone
@@ -160,8 +179,32 @@ def to_int(value, default=0):
     except (TypeError, ValueError):
         return default
 
+def truncate(text, max_len):
+    """Truncate text to max_len to prevent oversized queue entries."""
+    if text and len(text) > max_len:
+        return text[:max_len] + "..."
+    return text
+
+def content_hash(text):
+    return hashlib.md5(text.encode("utf-8")).hexdigest()
+
+def is_duplicate(queue_path, new_content, lookback=20):
+    """Skip if identical content already queued recently."""
+    new_hash = content_hash(new_content)
+    try:
+        with open(queue_path, "r", encoding="utf-8") as f:
+            for line in f.readlines()[-lookback:]:
+                try:
+                    if content_hash(json.loads(line.strip()).get("content", "")) == new_hash:
+                        return True
+                except (json.JSONDecodeError, KeyError):
+                    continue
+    except FileNotFoundError:
+        pass
+    return False
+
 record = {
-    "content": os.environ.get("AUTOMEM_CONTENT", ""),
+    "content": truncate(os.environ.get("AUTOMEM_CONTENT", ""), 1500),
     "tags": ["build", os.environ.get("AUTOMEM_BUILD_TOOL", "unknown"), os.environ.get("AUTOMEM_PROJECT", "")],
     "importance": float(os.environ.get("AUTOMEM_IMPORTANCE", "0.5")),
     "type": os.environ.get("AUTOMEM_TYPE", "Context"),
@@ -172,7 +215,7 @@ record = {
         "warnings": to_int(os.environ.get("AUTOMEM_WARNINGS", "0")),
         "errors": to_int(os.environ.get("AUTOMEM_ERRORS", "0")),
         "exit_code": to_int(os.environ.get("AUTOMEM_EXIT_CODE", "0")),
-        "command": os.environ.get("AUTOMEM_COMMAND", ""),
+        "command": truncate(os.environ.get("AUTOMEM_COMMAND", ""), 500),
         "project": os.environ.get("AUTOMEM_PROJECT", ""),
     },
     "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
@@ -180,6 +223,8 @@ record = {
 
 queue_path = os.environ.get("AUTOMEM_QUEUE", "")
 if queue_path:
+    if is_duplicate(queue_path, record["content"]):
+        raise SystemExit(0)
     os.makedirs(os.path.dirname(queue_path), exist_ok=True)
     with open(queue_path, "a", encoding="utf-8") as handle:
         lock_file(handle)

--- a/plugins/automem/scripts/capture-deployment.sh
+++ b/plugins/automem/scripts/capture-deployment.sh
@@ -15,11 +15,29 @@ log_message() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"
 }
 
-# Get deployment context
-COMMAND="${CLAUDE_LAST_COMMAND:-${CLAUDE_CONTEXT:-${TOOL_NAME:-}}}"
-OUTPUT="${CLAUDE_COMMAND_OUTPUT:-${TOOL_RESULT:-}}"
-EXIT_CODE="${CLAUDE_EXIT_CODE:-0}"
-PROJECT_NAME=$(basename "$(pwd)")
+# Check required dependencies
+if ! command -v jq >/dev/null 2>&1; then
+    echo "Warning: jq not installed - capture disabled" >&2
+    exit 0
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "Warning: python3 not installed - capture disabled" >&2
+    exit 0
+fi
+
+# Read JSON input from stdin (Claude Code hook format)
+INPUT_JSON=$(cat)
+
+# Parse JSON fields, fall back to env vars for backward compat
+COMMAND=$(echo "$INPUT_JSON" | jq -r '.tool_input.command // empty' 2>/dev/null)
+COMMAND="${COMMAND:-${CLAUDE_LAST_COMMAND:-${CLAUDE_CONTEXT:-${TOOL_NAME:-}}}}"
+OUTPUT=$(echo "$INPUT_JSON" | jq -r '.tool_response // empty' 2>/dev/null)
+OUTPUT="${OUTPUT:-${CLAUDE_COMMAND_OUTPUT:-${TOOL_RESULT:-}}}"
+EXIT_CODE=$(echo "$INPUT_JSON" | jq -r '.tool_response | if type == "object" then (.exit_code // .exitCode // 0) else 0 end' 2>/dev/null)
+EXIT_CODE="${EXIT_CODE:-${CLAUDE_EXIT_CODE:-0}}"
+CWD=$(echo "$INPUT_JSON" | jq -r '.cwd // empty' 2>/dev/null)
+PROJECT_NAME=$(basename "${CWD:-$(pwd)}")
 
 # Skip non-deploy commands
 if [ -z "$COMMAND" ] || ! echo "$COMMAND" | grep -qiE "(^|\\s)(deploy|railway|vercel|netlify|heroku|kubectl|k8s|kubernetes|docker|gcloud|aws|cloudfront|firebase|gh pages)"; then
@@ -116,11 +134,6 @@ if git rev-parse --git-dir > /dev/null 2>&1; then
 fi
 
 # Queue memory for processing with safe JSON encoding and file locking
-if ! command -v jq >/dev/null 2>&1; then
-    log_message "jq not available; cannot encode deployment memory"
-    exit 1
-fi
-
 DEPLOY_PLATFORM="${DEPLOY_PLATFORM:-unknown}"
 DEPLOY_ENV="${DEPLOY_ENV:-production}"
 PROJECT_NAME="${PROJECT_NAME:-unknown}"
@@ -146,7 +159,7 @@ if ! MEMORY_RECORD=$(jq -c -n \
     --argjson exit_code "$EXIT_CODE" \
     'def optional($value): if $value == "" then null else $value end;
     {
-      content: $content,
+      content: ($content | .[0:1500]),
       tags: ["deployment", "platform:\($platform)", "env:\($env)", "project:\($project)"],
       importance: $importance,
       type: $type,
@@ -159,7 +172,7 @@ if ! MEMORY_RECORD=$(jq -c -n \
         deploy_time: optional($deploy_time),
         git_commit: optional($git_commit),
         exit_code: $exit_code,
-        command: $command,
+        command: ($command | .[0:500]),
         project: $project,
         error_details: optional($error_details)
       },
@@ -172,6 +185,8 @@ fi
 AUTOMEM_QUEUE="$MEMORY_QUEUE" \
 AUTOMEM_RECORD="$MEMORY_RECORD" \
 python3 - <<'PY'
+import hashlib
+import json
 import os
 
 try:
@@ -203,9 +218,33 @@ def unlock_file(handle):
         except OSError:
             pass
 
+def content_hash(text):
+    return hashlib.md5(text.encode("utf-8")).hexdigest()
+
+def is_duplicate(queue_path, new_content, lookback=20):
+    """Skip if identical content already queued recently."""
+    new_hash = content_hash(new_content)
+    try:
+        with open(queue_path, "r", encoding="utf-8") as f:
+            for line in f.readlines()[-lookback:]:
+                try:
+                    if content_hash(json.loads(line.strip()).get("content", "")) == new_hash:
+                        return True
+                except (json.JSONDecodeError, KeyError):
+                    continue
+    except FileNotFoundError:
+        pass
+    return False
+
 queue_path = os.environ.get("AUTOMEM_QUEUE", "")
 record = os.environ.get("AUTOMEM_RECORD", "")
 if queue_path and record:
+    try:
+        new_content = json.loads(record).get("content", "")
+    except (json.JSONDecodeError, KeyError):
+        new_content = ""
+    if is_duplicate(queue_path, new_content):
+        raise SystemExit(0)
     os.makedirs(os.path.dirname(queue_path), exist_ok=True)
     with open(queue_path, "a", encoding="utf-8") as handle:
         lock_file(handle)

--- a/plugins/automem/scripts/capture-test-pattern.sh
+++ b/plugins/automem/scripts/capture-test-pattern.sh
@@ -15,11 +15,29 @@ log_message() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"
 }
 
-# Get test context from command output
-COMMAND="${CLAUDE_LAST_COMMAND:-${CLAUDE_CONTEXT:-${TOOL_NAME:-}}}"
-OUTPUT="${CLAUDE_COMMAND_OUTPUT:-${TOOL_RESULT:-}}"
-EXIT_CODE="${CLAUDE_EXIT_CODE:-0}"
-PROJECT_NAME=$(basename "$(pwd)")
+# Check required dependencies
+if ! command -v jq >/dev/null 2>&1; then
+    echo "Warning: jq not installed - capture disabled" >&2
+    exit 0
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "Warning: python3 not installed - capture disabled" >&2
+    exit 0
+fi
+
+# Read JSON input from stdin (Claude Code hook format)
+INPUT_JSON=$(cat)
+
+# Parse JSON fields, fall back to env vars for backward compat
+COMMAND=$(echo "$INPUT_JSON" | jq -r '.tool_input.command // empty' 2>/dev/null)
+COMMAND="${COMMAND:-${CLAUDE_LAST_COMMAND:-${CLAUDE_CONTEXT:-${TOOL_NAME:-}}}}"
+OUTPUT=$(echo "$INPUT_JSON" | jq -r '.tool_response // empty' 2>/dev/null)
+OUTPUT="${OUTPUT:-${CLAUDE_COMMAND_OUTPUT:-${TOOL_RESULT:-}}}"
+EXIT_CODE=$(echo "$INPUT_JSON" | jq -r '.tool_response | if type == "object" then (.exit_code // .exitCode // 0) else 0 end' 2>/dev/null)
+EXIT_CODE="${EXIT_CODE:-${CLAUDE_EXIT_CODE:-0}}"
+CWD=$(echo "$INPUT_JSON" | jq -r '.cwd // empty' 2>/dev/null)
+PROJECT_NAME=$(basename "${CWD:-$(pwd)}")
 
 # Skip non-test commands
 if [ -z "$COMMAND" ] || ! echo "$COMMAND" | grep -qiE "(^|\\s)(npm test|yarn test|pnpm test|vitest|jest|pytest|python .*test|go test|cargo test|phpunit)"; then
@@ -84,11 +102,6 @@ else
 fi
 
 # Queue memory for processing with safe JSON encoding and file locking
-if ! command -v jq >/dev/null 2>&1; then
-    log_message "jq not available; cannot encode test memory"
-    exit 1
-fi
-
 PROJECT_NAME="${PROJECT_NAME:-unknown}"
 TEST_FRAMEWORK="${TEST_FRAMEWORK:-unknown}"
 IMPORTANCE="${IMPORTANCE:-0.5}"
@@ -115,7 +128,7 @@ if ! MEMORY_RECORD=$(jq -c -n \
     --argjson exit_code "$EXIT_CODE" \
     --argjson error_details "$ERROR_DETAILS_JSON" \
     '{
-      content: $content,
+      content: ($content | .[0:1500]),
       tags: ["test", "framework:\($test_framework)", "project:\($project)"],
       importance: $importance,
       type: $type,
@@ -124,7 +137,7 @@ if ! MEMORY_RECORD=$(jq -c -n \
         tests_passed: $tests_passed,
         tests_failed: $tests_failed,
         exit_code: $exit_code,
-        command: $command,
+        command: ($command | .[0:500]),
         project: $project,
         error_details: $error_details
       },
@@ -137,6 +150,8 @@ fi
 AUTOMEM_QUEUE="$MEMORY_QUEUE" \
 AUTOMEM_RECORD="$MEMORY_RECORD" \
 python3 - <<'PY'
+import hashlib
+import json
 import os
 
 try:
@@ -168,9 +183,33 @@ def unlock_file(handle):
         except OSError:
             pass
 
+def content_hash(text):
+    return hashlib.md5(text.encode("utf-8")).hexdigest()
+
+def is_duplicate(queue_path, new_content, lookback=20):
+    """Skip if identical content already queued recently."""
+    new_hash = content_hash(new_content)
+    try:
+        with open(queue_path, "r", encoding="utf-8") as f:
+            for line in f.readlines()[-lookback:]:
+                try:
+                    if content_hash(json.loads(line.strip()).get("content", "")) == new_hash:
+                        return True
+                except (json.JSONDecodeError, KeyError):
+                    continue
+    except FileNotFoundError:
+        pass
+    return False
+
 queue_path = os.environ.get("AUTOMEM_QUEUE", "")
 record = os.environ.get("AUTOMEM_RECORD", "")
 if queue_path and record:
+    try:
+        new_content = json.loads(record).get("content", "")
+    except (json.JSONDecodeError, KeyError):
+        new_content = ""
+    if is_duplicate(queue_path, new_content):
+        raise SystemExit(0)
     os.makedirs(os.path.dirname(queue_path), exist_ok=True)
     with open(queue_path, "a", encoding="utf-8") as handle:
         lock_file(handle)

--- a/templates/claude-code/hooks/capture-build-result.sh
+++ b/templates/claude-code/hooks/capture-build-result.sh
@@ -15,11 +15,29 @@ log_message() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"
 }
 
-# Get build context
-COMMAND="${CLAUDE_LAST_COMMAND:-${CLAUDE_CONTEXT:-${TOOL_NAME:-}}}"
-OUTPUT="${CLAUDE_COMMAND_OUTPUT:-${TOOL_RESULT:-}}"
-EXIT_CODE="${CLAUDE_EXIT_CODE:-0}"
-PROJECT_NAME=$(basename "$(pwd)")
+# Check required dependencies
+if ! command -v jq >/dev/null 2>&1; then
+    echo "Warning: jq not installed - capture disabled" >&2
+    exit 0
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "Warning: python3 not installed - capture disabled" >&2
+    exit 0
+fi
+
+# Read JSON input from stdin (Claude Code hook format)
+INPUT_JSON=$(cat)
+
+# Parse JSON fields, fall back to env vars for backward compat
+COMMAND=$(echo "$INPUT_JSON" | jq -r '.tool_input.command // empty' 2>/dev/null)
+COMMAND="${COMMAND:-${CLAUDE_LAST_COMMAND:-${CLAUDE_CONTEXT:-${TOOL_NAME:-}}}}"
+OUTPUT=$(echo "$INPUT_JSON" | jq -r '.tool_response // empty' 2>/dev/null)
+OUTPUT="${OUTPUT:-${CLAUDE_COMMAND_OUTPUT:-${TOOL_RESULT:-}}}"
+EXIT_CODE=$(echo "$INPUT_JSON" | jq -r '.tool_response | if type == "object" then (.exit_code // .exitCode // 0) else 0 end' 2>/dev/null)
+EXIT_CODE="${EXIT_CODE:-${CLAUDE_EXIT_CODE:-0}}"
+CWD=$(echo "$INPUT_JSON" | jq -r '.cwd // empty' 2>/dev/null)
+PROJECT_NAME=$(basename "${CWD:-$(pwd)}")
 BUILD_TOOL="unknown"
 
 # Skip non-build commands
@@ -118,6 +136,7 @@ AUTOMEM_ERRORS="$ERRORS" \
 AUTOMEM_EXIT_CODE="$EXIT_CODE" \
 AUTOMEM_COMMAND="$COMMAND" \
 python3 - <<'PY'
+import hashlib
 import json
 import os
 from datetime import datetime, timezone
@@ -160,8 +179,32 @@ def to_int(value, default=0):
     except (TypeError, ValueError):
         return default
 
+def truncate(text, max_len):
+    """Truncate text to max_len to prevent oversized queue entries."""
+    if text and len(text) > max_len:
+        return text[:max_len] + "..."
+    return text
+
+def content_hash(text):
+    return hashlib.md5(text.encode("utf-8")).hexdigest()
+
+def is_duplicate(queue_path, new_content, lookback=20):
+    """Skip if identical content already queued recently."""
+    new_hash = content_hash(new_content)
+    try:
+        with open(queue_path, "r", encoding="utf-8") as f:
+            for line in f.readlines()[-lookback:]:
+                try:
+                    if content_hash(json.loads(line.strip()).get("content", "")) == new_hash:
+                        return True
+                except (json.JSONDecodeError, KeyError):
+                    continue
+    except FileNotFoundError:
+        pass
+    return False
+
 record = {
-    "content": os.environ.get("AUTOMEM_CONTENT", ""),
+    "content": truncate(os.environ.get("AUTOMEM_CONTENT", ""), 1500),
     "tags": ["build", os.environ.get("AUTOMEM_BUILD_TOOL", "unknown"), os.environ.get("AUTOMEM_PROJECT", "")],
     "importance": float(os.environ.get("AUTOMEM_IMPORTANCE", "0.5")),
     "type": os.environ.get("AUTOMEM_TYPE", "Context"),
@@ -172,7 +215,7 @@ record = {
         "warnings": to_int(os.environ.get("AUTOMEM_WARNINGS", "0")),
         "errors": to_int(os.environ.get("AUTOMEM_ERRORS", "0")),
         "exit_code": to_int(os.environ.get("AUTOMEM_EXIT_CODE", "0")),
-        "command": os.environ.get("AUTOMEM_COMMAND", ""),
+        "command": truncate(os.environ.get("AUTOMEM_COMMAND", ""), 500),
         "project": os.environ.get("AUTOMEM_PROJECT", ""),
     },
     "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
@@ -180,6 +223,8 @@ record = {
 
 queue_path = os.environ.get("AUTOMEM_QUEUE", "")
 if queue_path:
+    if is_duplicate(queue_path, record["content"]):
+        raise SystemExit(0)
     os.makedirs(os.path.dirname(queue_path), exist_ok=True)
     with open(queue_path, "a", encoding="utf-8") as handle:
         lock_file(handle)

--- a/templates/claude-code/hooks/capture-deployment.sh
+++ b/templates/claude-code/hooks/capture-deployment.sh
@@ -15,11 +15,29 @@ log_message() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"
 }
 
-# Get deployment context
-COMMAND="${CLAUDE_LAST_COMMAND:-${CLAUDE_CONTEXT:-${TOOL_NAME:-}}}"
-OUTPUT="${CLAUDE_COMMAND_OUTPUT:-${TOOL_RESULT:-}}"
-EXIT_CODE="${CLAUDE_EXIT_CODE:-0}"
-PROJECT_NAME=$(basename "$(pwd)")
+# Check required dependencies
+if ! command -v jq >/dev/null 2>&1; then
+    echo "Warning: jq not installed - capture disabled" >&2
+    exit 0
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "Warning: python3 not installed - capture disabled" >&2
+    exit 0
+fi
+
+# Read JSON input from stdin (Claude Code hook format)
+INPUT_JSON=$(cat)
+
+# Parse JSON fields, fall back to env vars for backward compat
+COMMAND=$(echo "$INPUT_JSON" | jq -r '.tool_input.command // empty' 2>/dev/null)
+COMMAND="${COMMAND:-${CLAUDE_LAST_COMMAND:-${CLAUDE_CONTEXT:-${TOOL_NAME:-}}}}"
+OUTPUT=$(echo "$INPUT_JSON" | jq -r '.tool_response // empty' 2>/dev/null)
+OUTPUT="${OUTPUT:-${CLAUDE_COMMAND_OUTPUT:-${TOOL_RESULT:-}}}"
+EXIT_CODE=$(echo "$INPUT_JSON" | jq -r '.tool_response | if type == "object" then (.exit_code // .exitCode // 0) else 0 end' 2>/dev/null)
+EXIT_CODE="${EXIT_CODE:-${CLAUDE_EXIT_CODE:-0}}"
+CWD=$(echo "$INPUT_JSON" | jq -r '.cwd // empty' 2>/dev/null)
+PROJECT_NAME=$(basename "${CWD:-$(pwd)}")
 
 # Skip non-deploy commands
 if [ -z "$COMMAND" ] || ! echo "$COMMAND" | grep -qiE "(^|\\s)(deploy|railway|vercel|netlify|heroku|kubectl|k8s|kubernetes|docker|gcloud|aws|cloudfront|firebase|gh pages)"; then
@@ -132,6 +150,7 @@ AUTOMEM_EXIT_CODE="$EXIT_CODE" \
 AUTOMEM_COMMAND="$COMMAND" \
 AUTOMEM_ERROR_DETAILS="$ERROR_DETAILS" \
 python3 - <<'PY'
+import hashlib
 import json
 import os
 from datetime import datetime, timezone
@@ -174,8 +193,32 @@ def to_int(value, default=0):
     except (TypeError, ValueError):
         return default
 
+def truncate(text, max_len):
+    """Truncate text to max_len to prevent oversized queue entries."""
+    if text and len(text) > max_len:
+        return text[:max_len] + "..."
+    return text
+
+def content_hash(text):
+    return hashlib.md5(text.encode("utf-8")).hexdigest()
+
+def is_duplicate(queue_path, new_content, lookback=20):
+    """Skip if identical content already queued recently."""
+    new_hash = content_hash(new_content)
+    try:
+        with open(queue_path, "r", encoding="utf-8") as f:
+            for line in f.readlines()[-lookback:]:
+                try:
+                    if content_hash(json.loads(line.strip()).get("content", "")) == new_hash:
+                        return True
+                except (json.JSONDecodeError, KeyError):
+                    continue
+    except FileNotFoundError:
+        pass
+    return False
+
 record = {
-    "content": os.environ.get("AUTOMEM_CONTENT", ""),
+    "content": truncate(os.environ.get("AUTOMEM_CONTENT", ""), 1500),
     "tags": [
         "deployment",
         os.environ.get("AUTOMEM_DEPLOY_PLATFORM", "unknown"),
@@ -193,7 +236,7 @@ record = {
         "deploy_time": optional_text(os.environ.get("AUTOMEM_DEPLOY_TIME", "")),
         "git_commit": optional_text(os.environ.get("AUTOMEM_GIT_COMMIT", "")),
         "exit_code": to_int(os.environ.get("AUTOMEM_EXIT_CODE", "0")),
-        "command": os.environ.get("AUTOMEM_COMMAND", ""),
+        "command": truncate(os.environ.get("AUTOMEM_COMMAND", ""), 500),
         "project": os.environ.get("AUTOMEM_PROJECT", ""),
         "error_details": os.environ.get("AUTOMEM_ERROR_DETAILS", ""),
     },
@@ -202,6 +245,8 @@ record = {
 
 queue_path = os.environ.get("AUTOMEM_QUEUE", "")
 if queue_path:
+    if is_duplicate(queue_path, record["content"]):
+        raise SystemExit(0)
     os.makedirs(os.path.dirname(queue_path), exist_ok=True)
     with open(queue_path, "a", encoding="utf-8") as handle:
         lock_file(handle)

--- a/templates/claude-code/hooks/capture-test-pattern.sh
+++ b/templates/claude-code/hooks/capture-test-pattern.sh
@@ -15,11 +15,29 @@ log_message() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"
 }
 
-# Get test context from command output
-COMMAND="${CLAUDE_LAST_COMMAND:-${CLAUDE_CONTEXT:-${TOOL_NAME:-}}}"
-OUTPUT="${CLAUDE_COMMAND_OUTPUT:-${TOOL_RESULT:-}}"
-EXIT_CODE="${CLAUDE_EXIT_CODE:-0}"
-PROJECT_NAME=$(basename "$(pwd)")
+# Check required dependencies
+if ! command -v jq >/dev/null 2>&1; then
+    echo "Warning: jq not installed - capture disabled" >&2
+    exit 0
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "Warning: python3 not installed - capture disabled" >&2
+    exit 0
+fi
+
+# Read JSON input from stdin (Claude Code hook format)
+INPUT_JSON=$(cat)
+
+# Parse JSON fields, fall back to env vars for backward compat
+COMMAND=$(echo "$INPUT_JSON" | jq -r '.tool_input.command // empty' 2>/dev/null)
+COMMAND="${COMMAND:-${CLAUDE_LAST_COMMAND:-${CLAUDE_CONTEXT:-${TOOL_NAME:-}}}}"
+OUTPUT=$(echo "$INPUT_JSON" | jq -r '.tool_response // empty' 2>/dev/null)
+OUTPUT="${OUTPUT:-${CLAUDE_COMMAND_OUTPUT:-${TOOL_RESULT:-}}}"
+EXIT_CODE=$(echo "$INPUT_JSON" | jq -r '.tool_response | if type == "object" then (.exit_code // .exitCode // 0) else 0 end' 2>/dev/null)
+EXIT_CODE="${EXIT_CODE:-${CLAUDE_EXIT_CODE:-0}}"
+CWD=$(echo "$INPUT_JSON" | jq -r '.cwd // empty' 2>/dev/null)
+PROJECT_NAME=$(basename "${CWD:-$(pwd)}")
 
 # Skip non-test commands
 if [ -z "$COMMAND" ] || ! echo "$COMMAND" | grep -qiE "(^|\\s)(npm test|yarn test|pnpm test|vitest|jest|pytest|python .*test|go test|cargo test|phpunit)"; then
@@ -96,6 +114,7 @@ AUTOMEM_EXIT_CODE="$EXIT_CODE" \
 AUTOMEM_COMMAND="$COMMAND" \
 AUTOMEM_ERROR_DETAILS="$ERROR_DETAILS" \
 python3 - <<'PY'
+import hashlib
 import json
 import os
 from datetime import datetime, timezone
@@ -135,8 +154,32 @@ def to_int(value, default=0):
     except (TypeError, ValueError):
         return default
 
+def truncate(text, max_len):
+    """Truncate text to max_len to prevent oversized queue entries."""
+    if text and len(text) > max_len:
+        return text[:max_len] + "..."
+    return text
+
+def content_hash(text):
+    return hashlib.md5(text.encode("utf-8")).hexdigest()
+
+def is_duplicate(queue_path, new_content, lookback=20):
+    """Skip if identical content already queued recently."""
+    new_hash = content_hash(new_content)
+    try:
+        with open(queue_path, "r", encoding="utf-8") as f:
+            for line in f.readlines()[-lookback:]:
+                try:
+                    if content_hash(json.loads(line.strip()).get("content", "")) == new_hash:
+                        return True
+                except (json.JSONDecodeError, KeyError):
+                    continue
+    except FileNotFoundError:
+        pass
+    return False
+
 record = {
-    "content": os.environ.get("AUTOMEM_CONTENT", ""),
+    "content": truncate(os.environ.get("AUTOMEM_CONTENT", ""), 1500),
     "tags": ["test", os.environ.get("AUTOMEM_TEST_FRAMEWORK", "unknown"), os.environ.get("AUTOMEM_PROJECT", "")],
     "importance": float(os.environ.get("AUTOMEM_IMPORTANCE", "0.5")),
     "type": os.environ.get("AUTOMEM_TYPE", "Context"),
@@ -145,7 +188,7 @@ record = {
         "tests_passed": to_int(os.environ.get("AUTOMEM_TESTS_PASSED", "0")),
         "tests_failed": to_int(os.environ.get("AUTOMEM_TESTS_FAILED", "0")),
         "exit_code": to_int(os.environ.get("AUTOMEM_EXIT_CODE", "0")),
-        "command": os.environ.get("AUTOMEM_COMMAND", ""),
+        "command": truncate(os.environ.get("AUTOMEM_COMMAND", ""), 500),
         "project": os.environ.get("AUTOMEM_PROJECT", ""),
         "error_details": os.environ.get("AUTOMEM_ERROR_DETAILS", ""),
     },
@@ -154,6 +197,8 @@ record = {
 
 queue_path = os.environ.get("AUTOMEM_QUEUE", "")
 if queue_path:
+    if is_duplicate(queue_path, record["content"]):
+        raise SystemExit(0)
     os.makedirs(os.path.dirname(queue_path), exist_ok=True)
     with open(queue_path, "a", encoding="utf-8") as handle:
         lock_file(handle)


### PR DESCRIPTION
Cherry-picks the three highest-value improvements from #59 (thanks @George-RD):

- **stdin JSON reading**: PostToolUse hooks now parse input from stdin with env var fallback
- **Truncation guards**: Content capped at 1500 chars, commands at 500 chars
- **Duplicate detection**: Content hash check prevents duplicate queue entries

Applied to all 3 hook scripts (templates + plugin mirrors).

Ref: #59