### PR TITLE
fix: improve Claude Code Windows Python compatibility

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -453,6 +453,8 @@ npx @verygoodplugins/mcp-automem claude-code
 
 This merges permissions into `~/.claude/settings.json` so Claude can use memory tools without asking.
 
+> Windows compatibility note: the Claude Code hook payload remains Bash-based. On Windows, use a POSIX shell environment such as Git Bash, MSYS2, or WSL, and make sure `bash`, `jq`, and Python are available. This is not full native Windows hook support yet.
+
 > Note: the old Claude Code marketplace plugin is deprecated and kept only as a migration bridge. Use `npx @verygoodplugins/mcp-automem claude-code` for new installs. See [DEPRECATION.md](DEPRECATION.md).
 
 Or manually add to `~/.claude/settings.json`:

--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ npx @verygoodplugins/mcp-automem claude-code
 
 This is the supported Claude Code integration path.
 
+On Windows, this compatibility path currently assumes a POSIX shell environment such as Git Bash, MSYS2, or WSL. `bash`, `jq`, and Python must be available. This is not full native Windows hook support yet.
+
 #### Option B: Plugin (Deprecated)
 
 ```bash

--- a/plugins/automem/scripts/capture-build-result.sh
+++ b/plugins/automem/scripts/capture-build-result.sh
@@ -3,8 +3,23 @@
 # Capture Build Result Hook for AutoMem
 # Records build outcomes, errors, and optimization patterns
 
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RELATIVE_PYTHON_HELPER="$(cd "$HOOK_DIR/../scripts" 2>/dev/null && pwd)/python-command.sh"
+PYTHON_HELPER="$HOME/.claude/scripts/python-command.sh"
 LOG_FILE="$HOME/.claude/logs/build-results.log"
 MEMORY_QUEUE="$HOME/.claude/scripts/memory-queue.jsonl"
+
+if [ -f "$RELATIVE_PYTHON_HELPER" ]; then
+    PYTHON_HELPER="$RELATIVE_PYTHON_HELPER"
+fi
+
+if [ -f "$PYTHON_HELPER" ]; then
+    # shellcheck disable=SC1090
+    . "$PYTHON_HELPER"
+else
+    echo "Warning: python resolver not found - capture disabled" >&2
+    exit 0
+fi
 
 # Ensure directories exist
 mkdir -p "$(dirname "$LOG_FILE")"
@@ -21,8 +36,8 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 0
 fi
 
-if ! command -v python3 >/dev/null 2>&1; then
-    echo "Warning: python3 not installed - capture disabled" >&2
+if ! automem_resolve_python >/dev/null 2>&1; then
+    echo "Warning: Python not installed (tried python3, python, py -3) - capture disabled" >&2
     exit 0
 fi
 
@@ -138,7 +153,7 @@ AUTOMEM_WARNINGS="$WARNINGS" \
 AUTOMEM_ERRORS="$ERRORS" \
 AUTOMEM_EXIT_CODE="$EXIT_CODE" \
 AUTOMEM_COMMAND="$COMMAND" \
-python3 - <<'PY'
+automem_run_python - <<'PY'
 import hashlib
 import json
 import os

--- a/plugins/automem/scripts/capture-deployment.sh
+++ b/plugins/automem/scripts/capture-deployment.sh
@@ -3,8 +3,23 @@
 # Capture Deployment Hook for AutoMem
 # Records deployment activities, environments, and outcomes
 
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RELATIVE_PYTHON_HELPER="$(cd "$HOOK_DIR/../scripts" 2>/dev/null && pwd)/python-command.sh"
+PYTHON_HELPER="$HOME/.claude/scripts/python-command.sh"
 LOG_FILE="$HOME/.claude/logs/deployments.log"
 MEMORY_QUEUE="$HOME/.claude/scripts/memory-queue.jsonl"
+
+if [ -f "$RELATIVE_PYTHON_HELPER" ]; then
+    PYTHON_HELPER="$RELATIVE_PYTHON_HELPER"
+fi
+
+if [ -f "$PYTHON_HELPER" ]; then
+    # shellcheck disable=SC1090
+    . "$PYTHON_HELPER"
+else
+    echo "Warning: python resolver not found - capture disabled" >&2
+    exit 0
+fi
 
 # Ensure directories exist
 mkdir -p "$(dirname "$LOG_FILE")"
@@ -21,8 +36,8 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 0
 fi
 
-if ! command -v python3 >/dev/null 2>&1; then
-    echo "Warning: python3 not installed - capture disabled" >&2
+if ! automem_resolve_python >/dev/null 2>&1; then
+    echo "Warning: Python not installed (tried python3, python, py -3) - capture disabled" >&2
     exit 0
 fi
 
@@ -165,7 +180,7 @@ AUTOMEM_GIT_COMMIT="$GIT_COMMIT" \
 AUTOMEM_EXIT_CODE="$EXIT_CODE" \
 AUTOMEM_COMMAND="$COMMAND" \
 AUTOMEM_ERROR_DETAILS="$ERROR_DETAILS" \
-python3 - <<'PY'
+automem_run_python - <<'PY'
 import hashlib
 import json
 import os

--- a/plugins/automem/scripts/capture-test-pattern.sh
+++ b/plugins/automem/scripts/capture-test-pattern.sh
@@ -3,8 +3,23 @@
 # Capture Test Pattern Hook for AutoMem
 # Records test execution patterns, results, and learned testing approaches
 
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RELATIVE_PYTHON_HELPER="$(cd "$HOOK_DIR/../scripts" 2>/dev/null && pwd)/python-command.sh"
+PYTHON_HELPER="$HOME/.claude/scripts/python-command.sh"
 LOG_FILE="$HOME/.claude/logs/test-patterns.log"
 MEMORY_QUEUE="$HOME/.claude/scripts/memory-queue.jsonl"
+
+if [ -f "$RELATIVE_PYTHON_HELPER" ]; then
+    PYTHON_HELPER="$RELATIVE_PYTHON_HELPER"
+fi
+
+if [ -f "$PYTHON_HELPER" ]; then
+    # shellcheck disable=SC1090
+    . "$PYTHON_HELPER"
+else
+    echo "Warning: python resolver not found - capture disabled" >&2
+    exit 0
+fi
 
 # Ensure directories exist
 mkdir -p "$(dirname "$LOG_FILE")"
@@ -21,8 +36,8 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 0
 fi
 
-if ! command -v python3 >/dev/null 2>&1; then
-    echo "Warning: python3 not installed - capture disabled" >&2
+if ! automem_resolve_python >/dev/null 2>&1; then
+    echo "Warning: Python not installed (tried python3, python, py -3) - capture disabled" >&2
     exit 0
 fi
 
@@ -113,7 +128,7 @@ AUTOMEM_TESTS_FAILED="$TESTS_FAILED" \
 AUTOMEM_EXIT_CODE="$EXIT_CODE" \
 AUTOMEM_COMMAND="$COMMAND" \
 AUTOMEM_ERROR_DETAILS="$ERROR_DETAILS" \
-python3 - <<'PY'
+automem_run_python - <<'PY'
 import hashlib
 import json
 import os

--- a/plugins/automem/scripts/python-command.sh
+++ b/plugins/automem/scripts/python-command.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Shared Python interpreter resolution for Claude Code hooks.
+# Supports POSIX-shell environments on Windows (Git Bash/MSYS2/WSL) without
+# requiring the executable to be named exactly `python3`.
+
+AUTOMEM_PYTHON_CMD=()
+AUTOMEM_PYTHON_LABEL=""
+
+automem_resolve_python() {
+    if [ "${#AUTOMEM_PYTHON_CMD[@]}" -gt 0 ]; then
+        return 0
+    fi
+
+    if command -v python3 >/dev/null 2>&1; then
+        AUTOMEM_PYTHON_CMD=(python3)
+        AUTOMEM_PYTHON_LABEL="python3"
+        return 0
+    fi
+
+    if command -v python >/dev/null 2>&1; then
+        AUTOMEM_PYTHON_CMD=(python)
+        AUTOMEM_PYTHON_LABEL="python"
+        return 0
+    fi
+
+    if command -v py >/dev/null 2>&1; then
+        AUTOMEM_PYTHON_CMD=(py -3)
+        AUTOMEM_PYTHON_LABEL="py -3"
+        return 0
+    fi
+
+    return 1
+}
+
+automem_python_label() {
+    automem_resolve_python || return 1
+    printf '%s\n' "$AUTOMEM_PYTHON_LABEL"
+}
+
+automem_run_python() {
+    automem_resolve_python || return 1
+    "${AUTOMEM_PYTHON_CMD[@]}" "$@"
+}

--- a/plugins/automem/scripts/python-command.sh
+++ b/plugins/automem/scripts/python-command.sh
@@ -7,26 +7,30 @@
 AUTOMEM_PYTHON_CMD=()
 AUTOMEM_PYTHON_LABEL=""
 
+automem_is_python3() {
+    "$@" -c 'import sys; sys.exit(0 if sys.version_info[0] >= 3 else 1)' >/dev/null 2>&1
+}
+
 automem_resolve_python() {
     if [ "${#AUTOMEM_PYTHON_CMD[@]}" -gt 0 ]; then
         return 0
     fi
 
-    if command -v python3 >/dev/null 2>&1; then
+    if command -v python3 >/dev/null 2>&1 && automem_is_python3 python3; then
         AUTOMEM_PYTHON_CMD=(python3)
         AUTOMEM_PYTHON_LABEL="python3"
         return 0
     fi
 
-    if command -v python >/dev/null 2>&1; then
-        AUTOMEM_PYTHON_CMD=(python)
-        AUTOMEM_PYTHON_LABEL="python"
+    if command -v py >/dev/null 2>&1 && automem_is_python3 py -3; then
+        AUTOMEM_PYTHON_CMD=(py -3)
+        AUTOMEM_PYTHON_LABEL="py -3"
         return 0
     fi
 
-    if command -v py >/dev/null 2>&1; then
-        AUTOMEM_PYTHON_CMD=(py -3)
-        AUTOMEM_PYTHON_LABEL="py -3"
+    if command -v python >/dev/null 2>&1 && automem_is_python3 python; then
+        AUTOMEM_PYTHON_CMD=(python)
+        AUTOMEM_PYTHON_LABEL="python"
         return 0
     fi
 

--- a/plugins/automem/scripts/queue-cleanup.sh
+++ b/plugins/automem/scripts/queue-cleanup.sh
@@ -8,6 +8,8 @@ fi
 
 set -o pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON_HELPER="$SCRIPT_DIR/python-command.sh"
 QUEUE_FILE="$HOME/.claude/scripts/memory-queue.jsonl"
 LOG_FILE="$HOME/.claude/logs/queue-cleanup.log"
 
@@ -16,6 +18,14 @@ log_message() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"
 }
 
+if [ -f "$PYTHON_HELPER" ]; then
+    # shellcheck disable=SC1090
+    . "$PYTHON_HELPER"
+else
+    log_message "Python resolver not found; aborting queue cleanup"
+    exit 1
+fi
+
 if [ ! -s "$QUEUE_FILE" ]; then
     log_message "Queue file empty or doesn't exist, nothing to clean"
     exit 0
@@ -23,6 +33,11 @@ fi
 
 if ! command -v jq >/dev/null 2>&1; then
     log_message "jq not available; aborting queue cleanup"
+    exit 1
+fi
+
+if ! automem_resolve_python >/dev/null 2>&1; then
+    log_message "Python not available (tried python3, python, py -3); aborting queue cleanup"
     exit 1
 fi
 
@@ -39,7 +54,7 @@ if [ ${pipe_status[0]} -ne 0 ] || [ ${pipe_status[1]} -ne 0 ] || [ ! -s "$VALIDA
     exit 1
 fi
 
-QUEUE_FILE="$QUEUE_FILE" LOG_FILE="$LOG_FILE" python3 - <<'PY'
+QUEUE_FILE="$QUEUE_FILE" LOG_FILE="$LOG_FILE" automem_run_python - <<'PY'
 import json
 import os
 import sys

--- a/plugins/automem/scripts/session-memory.sh
+++ b/plugins/automem/scripts/session-memory.sh
@@ -7,11 +7,30 @@
 # Configuration
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RELATIVE_PROCESSOR="$(cd "$HOOK_DIR/../scripts" 2>/dev/null && pwd)/process-session-memory.py"
+RELATIVE_PYTHON_HELPER="$(cd "$HOOK_DIR/../scripts" 2>/dev/null && pwd)/python-command.sh"
 MEMORY_PROCESSOR="$HOME/.claude/scripts/process-session-memory.py"
+PYTHON_HELPER="$HOME/.claude/scripts/python-command.sh"
 LOG_FILE="$HOME/.claude/logs/session-memory.log"
 
 if [ -f "$RELATIVE_PROCESSOR" ]; then
     MEMORY_PROCESSOR="$RELATIVE_PROCESSOR"
+fi
+
+if [ -f "$RELATIVE_PYTHON_HELPER" ]; then
+    PYTHON_HELPER="$RELATIVE_PYTHON_HELPER"
+fi
+
+if [ -f "$PYTHON_HELPER" ]; then
+    # shellcheck disable=SC1090
+    . "$PYTHON_HELPER"
+else
+    echo "Warning: python resolver not found - session capture disabled" >&2
+    exit 0
+fi
+
+if ! automem_resolve_python >/dev/null 2>&1; then
+    echo "Warning: Python not installed (tried python3, python, py -3) - session capture disabled" >&2
+    exit 0
 fi
 
 # Ensure log directory exists
@@ -62,10 +81,8 @@ create_temp_file() {
 
     if command -v mktemp >/dev/null 2>&1; then
         temp_file=$(mktemp "${TMPDIR:-/tmp}/claude_session.XXXXXX") || return 1
-    elif command -v python3 >/dev/null 2>&1; then
-        temp_file=$(python3 -c 'import os, tempfile; fd, path = tempfile.mkstemp(prefix="claude_session.", dir=os.environ.get("TMPDIR", "/tmp")); os.close(fd); print(path)') || return 1
-    elif command -v python >/dev/null 2>&1; then
-        temp_file=$(python -c 'import os, tempfile; fd, path = tempfile.mkstemp(prefix="claude_session.", dir=os.environ.get("TMPDIR", "/tmp")); os.close(fd); print(path)') || return 1
+    elif automem_resolve_python >/dev/null 2>&1; then
+        temp_file=$(automem_run_python -c 'import os, tempfile; fd, path = tempfile.mkstemp(prefix="claude_session.", dir=os.environ.get("TMPDIR", "/tmp")); os.close(fd); print(path)') || return 1
     else
         return 1
     fi
@@ -97,7 +114,7 @@ AUTOMEM_USER="$USER" \
 AUTOMEM_HOSTNAME="$(hostname)" \
 AUTOMEM_PLATFORM="$(uname -s)" \
 AUTOMEM_TEMP_FILE="$TEMP_FILE" \
-python3 - <<'PY'
+automem_run_python - <<'PY'
 import json
 import os
 from datetime import datetime, timezone
@@ -136,7 +153,7 @@ if [ -f "$MEMORY_PROCESSOR" ]; then
     log_message "Processing session with Python processor"
     
     PROCESS_TIMEOUT=10
-    python3 "$MEMORY_PROCESSOR" "$TEMP_FILE" >> "$LOG_FILE" 2>&1 &
+    automem_run_python "$MEMORY_PROCESSOR" "$TEMP_FILE" >> "$LOG_FILE" 2>&1 &
     PROCESS_PID=$!
     RESULT=0
 

--- a/src/cli/claude-code.ts
+++ b/src/cli/claude-code.ts
@@ -21,6 +21,7 @@ const HOOK_SCRIPTS = [
   'session-memory.sh',
 ];
 const SUPPORT_SCRIPTS = [
+  'python-command.sh',
   'queue-cleanup.sh',
   'process-session-memory.py',
   'memory-filters.json',

--- a/templates/CLAUDE_CODE_INTEGRATION.md
+++ b/templates/CLAUDE_CODE_INTEGRATION.md
@@ -34,6 +34,8 @@ npx @verygoodplugins/mcp-automem claude-code
 
 This merges AutoMem permissions into `~/.claude/settings.json` and installs the canonical hook/support files under `~/.claude/`.
 
+Windows compatibility for this branch is limited to POSIX shell environments such as Git Bash, MSYS2, or WSL. `bash`, `jq`, and Python must be available. This is not full native Windows hook support.
+
 ### 2. Advanced Manual Fallback
 
 If you prefer to configure Claude Code by hand, use the manual steps below.

--- a/templates/claude-code/hooks/capture-build-result.sh
+++ b/templates/claude-code/hooks/capture-build-result.sh
@@ -3,8 +3,23 @@
 # Capture Build Result Hook for AutoMem
 # Records build outcomes, errors, and optimization patterns
 
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RELATIVE_PYTHON_HELPER="$(cd "$HOOK_DIR/../scripts" 2>/dev/null && pwd)/python-command.sh"
+PYTHON_HELPER="$HOME/.claude/scripts/python-command.sh"
 LOG_FILE="$HOME/.claude/logs/build-results.log"
 MEMORY_QUEUE="$HOME/.claude/scripts/memory-queue.jsonl"
+
+if [ -f "$RELATIVE_PYTHON_HELPER" ]; then
+    PYTHON_HELPER="$RELATIVE_PYTHON_HELPER"
+fi
+
+if [ -f "$PYTHON_HELPER" ]; then
+    # shellcheck disable=SC1090
+    . "$PYTHON_HELPER"
+else
+    echo "Warning: python resolver not found - capture disabled" >&2
+    exit 0
+fi
 
 # Ensure directories exist
 mkdir -p "$(dirname "$LOG_FILE")"
@@ -21,8 +36,8 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 0
 fi
 
-if ! command -v python3 >/dev/null 2>&1; then
-    echo "Warning: python3 not installed - capture disabled" >&2
+if ! automem_resolve_python >/dev/null 2>&1; then
+    echo "Warning: Python not installed (tried python3, python, py -3) - capture disabled" >&2
     exit 0
 fi
 
@@ -138,7 +153,7 @@ AUTOMEM_WARNINGS="$WARNINGS" \
 AUTOMEM_ERRORS="$ERRORS" \
 AUTOMEM_EXIT_CODE="$EXIT_CODE" \
 AUTOMEM_COMMAND="$COMMAND" \
-python3 - <<'PY'
+automem_run_python - <<'PY'
 import hashlib
 import json
 import os

--- a/templates/claude-code/hooks/capture-deployment.sh
+++ b/templates/claude-code/hooks/capture-deployment.sh
@@ -3,8 +3,23 @@
 # Capture Deployment Hook for AutoMem
 # Records deployment activities, environments, and outcomes
 
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RELATIVE_PYTHON_HELPER="$(cd "$HOOK_DIR/../scripts" 2>/dev/null && pwd)/python-command.sh"
+PYTHON_HELPER="$HOME/.claude/scripts/python-command.sh"
 LOG_FILE="$HOME/.claude/logs/deployments.log"
 MEMORY_QUEUE="$HOME/.claude/scripts/memory-queue.jsonl"
+
+if [ -f "$RELATIVE_PYTHON_HELPER" ]; then
+    PYTHON_HELPER="$RELATIVE_PYTHON_HELPER"
+fi
+
+if [ -f "$PYTHON_HELPER" ]; then
+    # shellcheck disable=SC1090
+    . "$PYTHON_HELPER"
+else
+    echo "Warning: python resolver not found - capture disabled" >&2
+    exit 0
+fi
 
 # Ensure directories exist
 mkdir -p "$(dirname "$LOG_FILE")"
@@ -21,8 +36,8 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 0
 fi
 
-if ! command -v python3 >/dev/null 2>&1; then
-    echo "Warning: python3 not installed - capture disabled" >&2
+if ! automem_resolve_python >/dev/null 2>&1; then
+    echo "Warning: Python not installed (tried python3, python, py -3) - capture disabled" >&2
     exit 0
 fi
 
@@ -165,7 +180,7 @@ AUTOMEM_GIT_COMMIT="$GIT_COMMIT" \
 AUTOMEM_EXIT_CODE="$EXIT_CODE" \
 AUTOMEM_COMMAND="$COMMAND" \
 AUTOMEM_ERROR_DETAILS="$ERROR_DETAILS" \
-python3 - <<'PY'
+automem_run_python - <<'PY'
 import hashlib
 import json
 import os

--- a/templates/claude-code/hooks/capture-test-pattern.sh
+++ b/templates/claude-code/hooks/capture-test-pattern.sh
@@ -3,8 +3,23 @@
 # Capture Test Pattern Hook for AutoMem
 # Records test execution patterns, results, and learned testing approaches
 
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RELATIVE_PYTHON_HELPER="$(cd "$HOOK_DIR/../scripts" 2>/dev/null && pwd)/python-command.sh"
+PYTHON_HELPER="$HOME/.claude/scripts/python-command.sh"
 LOG_FILE="$HOME/.claude/logs/test-patterns.log"
 MEMORY_QUEUE="$HOME/.claude/scripts/memory-queue.jsonl"
+
+if [ -f "$RELATIVE_PYTHON_HELPER" ]; then
+    PYTHON_HELPER="$RELATIVE_PYTHON_HELPER"
+fi
+
+if [ -f "$PYTHON_HELPER" ]; then
+    # shellcheck disable=SC1090
+    . "$PYTHON_HELPER"
+else
+    echo "Warning: python resolver not found - capture disabled" >&2
+    exit 0
+fi
 
 # Ensure directories exist
 mkdir -p "$(dirname "$LOG_FILE")"
@@ -21,8 +36,8 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 0
 fi
 
-if ! command -v python3 >/dev/null 2>&1; then
-    echo "Warning: python3 not installed - capture disabled" >&2
+if ! automem_resolve_python >/dev/null 2>&1; then
+    echo "Warning: Python not installed (tried python3, python, py -3) - capture disabled" >&2
     exit 0
 fi
 
@@ -113,7 +128,7 @@ AUTOMEM_TESTS_FAILED="$TESTS_FAILED" \
 AUTOMEM_EXIT_CODE="$EXIT_CODE" \
 AUTOMEM_COMMAND="$COMMAND" \
 AUTOMEM_ERROR_DETAILS="$ERROR_DETAILS" \
-python3 - <<'PY'
+automem_run_python - <<'PY'
 import hashlib
 import json
 import os

--- a/templates/claude-code/hooks/session-memory.sh
+++ b/templates/claude-code/hooks/session-memory.sh
@@ -7,11 +7,30 @@
 # Configuration
 HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RELATIVE_PROCESSOR="$(cd "$HOOK_DIR/../scripts" 2>/dev/null && pwd)/process-session-memory.py"
+RELATIVE_PYTHON_HELPER="$(cd "$HOOK_DIR/../scripts" 2>/dev/null && pwd)/python-command.sh"
 MEMORY_PROCESSOR="$HOME/.claude/scripts/process-session-memory.py"
+PYTHON_HELPER="$HOME/.claude/scripts/python-command.sh"
 LOG_FILE="$HOME/.claude/logs/session-memory.log"
 
 if [ -f "$RELATIVE_PROCESSOR" ]; then
     MEMORY_PROCESSOR="$RELATIVE_PROCESSOR"
+fi
+
+if [ -f "$RELATIVE_PYTHON_HELPER" ]; then
+    PYTHON_HELPER="$RELATIVE_PYTHON_HELPER"
+fi
+
+if [ -f "$PYTHON_HELPER" ]; then
+    # shellcheck disable=SC1090
+    . "$PYTHON_HELPER"
+else
+    echo "Warning: python resolver not found - session capture disabled" >&2
+    exit 0
+fi
+
+if ! automem_resolve_python >/dev/null 2>&1; then
+    echo "Warning: Python not installed (tried python3, python, py -3) - session capture disabled" >&2
+    exit 0
 fi
 
 # Ensure log directory exists
@@ -62,10 +81,8 @@ create_temp_file() {
 
     if command -v mktemp >/dev/null 2>&1; then
         temp_file=$(mktemp "${TMPDIR:-/tmp}/claude_session.XXXXXX") || return 1
-    elif command -v python3 >/dev/null 2>&1; then
-        temp_file=$(python3 -c 'import os, tempfile; fd, path = tempfile.mkstemp(prefix="claude_session.", dir=os.environ.get("TMPDIR", "/tmp")); os.close(fd); print(path)') || return 1
-    elif command -v python >/dev/null 2>&1; then
-        temp_file=$(python -c 'import os, tempfile; fd, path = tempfile.mkstemp(prefix="claude_session.", dir=os.environ.get("TMPDIR", "/tmp")); os.close(fd); print(path)') || return 1
+    elif automem_resolve_python >/dev/null 2>&1; then
+        temp_file=$(automem_run_python -c 'import os, tempfile; fd, path = tempfile.mkstemp(prefix="claude_session.", dir=os.environ.get("TMPDIR", "/tmp")); os.close(fd); print(path)') || return 1
     else
         return 1
     fi
@@ -97,7 +114,7 @@ AUTOMEM_USER="$USER" \
 AUTOMEM_HOSTNAME="$(hostname)" \
 AUTOMEM_PLATFORM="$(uname -s)" \
 AUTOMEM_TEMP_FILE="$TEMP_FILE" \
-python3 - <<'PY'
+automem_run_python - <<'PY'
 import json
 import os
 from datetime import datetime, timezone
@@ -136,7 +153,7 @@ if [ -f "$MEMORY_PROCESSOR" ]; then
     log_message "Processing session with Python processor"
     
     PROCESS_TIMEOUT=10
-    python3 "$MEMORY_PROCESSOR" "$TEMP_FILE" >> "$LOG_FILE" 2>&1 &
+    automem_run_python "$MEMORY_PROCESSOR" "$TEMP_FILE" >> "$LOG_FILE" 2>&1 &
     PROCESS_PID=$!
     RESULT=0
 

--- a/templates/claude-code/scripts/python-command.sh
+++ b/templates/claude-code/scripts/python-command.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Shared Python interpreter resolution for Claude Code hooks.
+# Supports POSIX-shell environments on Windows (Git Bash/MSYS2/WSL) without
+# requiring the executable to be named exactly `python3`.
+
+AUTOMEM_PYTHON_CMD=()
+AUTOMEM_PYTHON_LABEL=""
+
+automem_resolve_python() {
+    if [ "${#AUTOMEM_PYTHON_CMD[@]}" -gt 0 ]; then
+        return 0
+    fi
+
+    if command -v python3 >/dev/null 2>&1; then
+        AUTOMEM_PYTHON_CMD=(python3)
+        AUTOMEM_PYTHON_LABEL="python3"
+        return 0
+    fi
+
+    if command -v python >/dev/null 2>&1; then
+        AUTOMEM_PYTHON_CMD=(python)
+        AUTOMEM_PYTHON_LABEL="python"
+        return 0
+    fi
+
+    if command -v py >/dev/null 2>&1; then
+        AUTOMEM_PYTHON_CMD=(py -3)
+        AUTOMEM_PYTHON_LABEL="py -3"
+        return 0
+    fi
+
+    return 1
+}
+
+automem_python_label() {
+    automem_resolve_python || return 1
+    printf '%s\n' "$AUTOMEM_PYTHON_LABEL"
+}
+
+automem_run_python() {
+    automem_resolve_python || return 1
+    "${AUTOMEM_PYTHON_CMD[@]}" "$@"
+}

--- a/templates/claude-code/scripts/python-command.sh
+++ b/templates/claude-code/scripts/python-command.sh
@@ -7,26 +7,30 @@
 AUTOMEM_PYTHON_CMD=()
 AUTOMEM_PYTHON_LABEL=""
 
+automem_is_python3() {
+    "$@" -c 'import sys; sys.exit(0 if sys.version_info[0] >= 3 else 1)' >/dev/null 2>&1
+}
+
 automem_resolve_python() {
     if [ "${#AUTOMEM_PYTHON_CMD[@]}" -gt 0 ]; then
         return 0
     fi
 
-    if command -v python3 >/dev/null 2>&1; then
+    if command -v python3 >/dev/null 2>&1 && automem_is_python3 python3; then
         AUTOMEM_PYTHON_CMD=(python3)
         AUTOMEM_PYTHON_LABEL="python3"
         return 0
     fi
 
-    if command -v python >/dev/null 2>&1; then
-        AUTOMEM_PYTHON_CMD=(python)
-        AUTOMEM_PYTHON_LABEL="python"
+    if command -v py >/dev/null 2>&1 && automem_is_python3 py -3; then
+        AUTOMEM_PYTHON_CMD=(py -3)
+        AUTOMEM_PYTHON_LABEL="py -3"
         return 0
     fi
 
-    if command -v py >/dev/null 2>&1; then
-        AUTOMEM_PYTHON_CMD=(py -3)
-        AUTOMEM_PYTHON_LABEL="py -3"
+    if command -v python >/dev/null 2>&1 && automem_is_python3 python; then
+        AUTOMEM_PYTHON_CMD=(python)
+        AUTOMEM_PYTHON_LABEL="python"
         return 0
     fi
 

--- a/templates/claude-code/scripts/queue-cleanup.sh
+++ b/templates/claude-code/scripts/queue-cleanup.sh
@@ -8,6 +8,8 @@ fi
 
 set -o pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON_HELPER="$SCRIPT_DIR/python-command.sh"
 QUEUE_FILE="$HOME/.claude/scripts/memory-queue.jsonl"
 LOG_FILE="$HOME/.claude/logs/queue-cleanup.log"
 
@@ -16,6 +18,14 @@ log_message() {
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"
 }
 
+if [ -f "$PYTHON_HELPER" ]; then
+    # shellcheck disable=SC1090
+    . "$PYTHON_HELPER"
+else
+    log_message "Python resolver not found; aborting queue cleanup"
+    exit 1
+fi
+
 if [ ! -s "$QUEUE_FILE" ]; then
     log_message "Queue file empty or doesn't exist, nothing to clean"
     exit 0
@@ -23,6 +33,11 @@ fi
 
 if ! command -v jq >/dev/null 2>&1; then
     log_message "jq not available; aborting queue cleanup"
+    exit 1
+fi
+
+if ! automem_resolve_python >/dev/null 2>&1; then
+    log_message "Python not available (tried python3, python, py -3); aborting queue cleanup"
     exit 1
 fi
 
@@ -39,7 +54,7 @@ if [ ${pipe_status[0]} -ne 0 ] || [ ${pipe_status[1]} -ne 0 ] || [ ! -s "$VALIDA
     exit 1
 fi
 
-QUEUE_FILE="$QUEUE_FILE" LOG_FILE="$LOG_FILE" python3 - <<'PY'
+QUEUE_FILE="$QUEUE_FILE" LOG_FILE="$LOG_FILE" automem_run_python - <<'PY'
 import json
 import os
 import sys

--- a/templates/claude-code/settings.json
+++ b/templates/claude-code/settings.json
@@ -85,6 +85,8 @@
       "Bash(sed:*)",
       "Bash(node:*)",
       "Bash(python3:*)",
+      "Bash(python:*)",
+      "Bash(py:*)",
       "Bash(npx:*)",
       "mcp__memory__store_memory",
       "mcp__memory__recall_memory",

--- a/tests/cli/smoke.test.ts
+++ b/tests/cli/smoke.test.ts
@@ -122,6 +122,23 @@ describe('CLI Smoke Tests', () => {
     });
   });
 
+  describe('claude-code command', () => {
+    it('should run with --dry-run without creating files', () => {
+      const homeDir = path.join(tempDir, 'claude-home');
+      const claudeDir = path.join(tempDir, 'claude-config');
+      fs.mkdirSync(homeDir, { recursive: true });
+
+      const result = runCli(['claude-code', '--dry-run', '--dir', claudeDir], {
+        env: {
+          HOME: homeDir,
+        },
+      });
+
+      expect((result.stdout + result.stderr).length).toBeGreaterThan(0);
+      expect(fs.existsSync(claudeDir)).toBe(false);
+    });
+  });
+
   describe('setup command', () => {
     it('should show config with --yes flag (non-interactive)', () => {
       const result = runCli(['setup', '--yes', '--endpoint', 'http://test:8001']);
@@ -338,6 +355,7 @@ describe('Template Generation', () => {
       ['templates/claude-code/hooks/capture-test-pattern.sh', 'plugins/automem/scripts/capture-test-pattern.sh'],
       ['templates/claude-code/hooks/session-memory.sh', 'plugins/automem/scripts/session-memory.sh'],
       ['templates/claude-code/hooks/automem-session-start.sh', 'plugins/automem/scripts/session-start.sh'],
+      ['templates/claude-code/scripts/python-command.sh', 'plugins/automem/scripts/python-command.sh'],
       ['templates/claude-code/scripts/memory-filters.json', 'plugins/automem/scripts/memory-filters.json'],
       ['templates/claude-code/scripts/process-session-memory.py', 'plugins/automem/scripts/process-session-memory.py'],
       ['templates/claude-code/scripts/queue-cleanup.sh', 'plugins/automem/scripts/queue-cleanup.sh'],
@@ -494,16 +512,32 @@ describe('Template Generation', () => {
       path.resolve(__dirname, '../../templates/CLAUDE_CODE_INTEGRATION.md'),
       'utf8'
     );
+    const installationGuide = fs.readFileSync(
+      path.resolve(__dirname, '../../INSTALLATION.md'),
+      'utf8'
+    );
+    const claudeSettings = fs.readFileSync(
+      path.resolve(__dirname, '../../templates/claude-code/settings.json'),
+      'utf8'
+    );
 
     expect(readme).toContain('#### Option A: CLI Setup (Recommended)');
     expect(readme).toContain('#### Option B: Plugin (Deprecated)');
     expect(readme).toContain('DEPRECATION.md');
+    expect(readme).toContain('Git Bash, MSYS2, or WSL');
 
     expect(pluginReadme).toContain('Deprecated');
     expect(pluginReadme).toContain('npx @verygoodplugins/mcp-automem claude-code');
 
     expect(claudeCodeGuide).toContain('npx @verygoodplugins/mcp-automem claude-code');
     expect(claudeCodeGuide).toContain('deprecated');
+    expect(claudeCodeGuide).toContain('Git Bash, MSYS2, or WSL');
+
+    expect(installationGuide).toContain('Git Bash, MSYS2, or WSL');
+
+    expect(claudeSettings).toContain('Bash(python3:*)');
+    expect(claudeSettings).toContain('Bash(python:*)');
+    expect(claudeSettings).toContain('Bash(py:*)');
 
     expect(deprecations).toContain('Claude Code Plugin');
     expect(deprecations).toContain('npx @verygoodplugins/mcp-automem claude-code');

--- a/tests/hooks/python-command.test.ts
+++ b/tests/hooks/python-command.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 const HELPER_PATH = path.resolve(__dirname, '../../templates/claude-code/scripts/python-command.sh');
 
+// These tests require a Unix-like environment with bash (Linux/macOS/WSL/Git Bash).
 function resolveBash(): string {
   const result = spawnSync('which', ['bash'], { encoding: 'utf8' });
   return result.stdout.trim() || '/bin/bash';
@@ -19,17 +20,17 @@ function makeExecutable(dir: string, name: string, body: string) {
   fs.chmodSync(filePath, 0o755);
 }
 
-// Fake that passes automem_is_python3 (exits 0)
-function makePython3Stub(dir: string, name: string, printPrefix: string) {
-  makeExecutable(dir, name, `printf "${printPrefix}:%s\\n" "$*"`);
+// Fake that passes automem_is_python3 (exits 0 on any invocation).
+function makePython3Stub(dir: string, name: string) {
+  makeExecutable(dir, name, 'exit 0');
 }
 
-// Fake that fails automem_is_python3 (exits 1 for any -c invocation)
+// Fake that fails automem_is_python3 (exits 1 for any -c invocation, simulating Python 2).
 function makePython2Stub(dir: string, name: string) {
   makeExecutable(dir, name, 'case "$1" in -c) exit 1 ;; esac; exit 0');
 }
 
-// Fake that always exits 1 (unavailable / broken stub)
+// Fake that always exits 1, shadowing any same-named system binary via PATH prepend.
 function blockInterpreter(dir: string, name: string) {
   makeExecutable(dir, name, 'exit 1');
 }
@@ -42,6 +43,7 @@ function runHelper(pathDir: string, command: string) {
       encoding: 'utf8',
       env: {
         ...process.env,
+        // Prepend the temp dir so our stubs shadow any system interpreters with the same name.
         PATH: pathDir + path.delimiter + (process.env.PATH || ''),
       },
     }
@@ -65,8 +67,8 @@ describe('python-command.sh', () => {
 
   it('prefers python3 when available', () => {
     const dir = createBinDir();
-    makePython3Stub(dir, 'python3', 'python3');
-    makePython3Stub(dir, 'python', 'python');
+    makePython3Stub(dir, 'python3');
+    makePython3Stub(dir, 'python');
     blockInterpreter(dir, 'py');
 
     const label = runHelper(dir, 'automem_python_label');
@@ -78,7 +80,7 @@ describe('python-command.sh', () => {
     const dir = createBinDir();
     blockInterpreter(dir, 'python3');
     blockInterpreter(dir, 'py');
-    makePython3Stub(dir, 'python', 'python');
+    makePython3Stub(dir, 'python');
 
     const label = runHelper(dir, 'automem_python_label');
     expect(label.status).toBe(0);
@@ -88,7 +90,8 @@ describe('python-command.sh', () => {
   it('uses py -3 when only the Windows launcher is available', () => {
     const dir = createBinDir();
     blockInterpreter(dir, 'python3');
-    makePython3Stub(dir, 'py', 'py');
+    // py stub must echo its arguments so automem_run_python output can be verified.
+    makeExecutable(dir, 'py', 'printf "py:%s\\n" "$*"');
     blockInterpreter(dir, 'python');
 
     const label = runHelper(dir, 'automem_python_label');
@@ -103,7 +106,7 @@ describe('python-command.sh', () => {
   it('prefers py -3 over a python that is Python 2', () => {
     const dir = createBinDir();
     blockInterpreter(dir, 'python3');
-    makePython3Stub(dir, 'py', 'py');
+    makePython3Stub(dir, 'py');
     makePython2Stub(dir, 'python');
 
     const label = runHelper(dir, 'automem_python_label');

--- a/tests/hooks/python-command.test.ts
+++ b/tests/hooks/python-command.test.ts
@@ -5,12 +5,33 @@ import path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 const HELPER_PATH = path.resolve(__dirname, '../../templates/claude-code/scripts/python-command.sh');
-const BASH_PATH = '/bin/bash';
+
+function resolveBash(): string {
+  const result = spawnSync('which', ['bash'], { encoding: 'utf8' });
+  return result.stdout.trim() || '/bin/bash';
+}
+
+const BASH_PATH = resolveBash();
 
 function makeExecutable(dir: string, name: string, body: string) {
   const filePath = path.join(dir, name);
   fs.writeFileSync(filePath, `#!/bin/sh\n${body}\n`, 'utf8');
   fs.chmodSync(filePath, 0o755);
+}
+
+// Fake that passes automem_is_python3 (exits 0)
+function makePython3Stub(dir: string, name: string, printPrefix: string) {
+  makeExecutable(dir, name, `printf "${printPrefix}:%s\\n" "$*"`);
+}
+
+// Fake that fails automem_is_python3 (exits 1 for any -c invocation)
+function makePython2Stub(dir: string, name: string) {
+  makeExecutable(dir, name, 'case "$1" in -c) exit 1 ;; esac; exit 0');
+}
+
+// Fake that always exits 1 (unavailable / broken stub)
+function blockInterpreter(dir: string, name: string) {
+  makeExecutable(dir, name, 'exit 1');
 }
 
 function runHelper(pathDir: string, command: string) {
@@ -21,7 +42,7 @@ function runHelper(pathDir: string, command: string) {
       encoding: 'utf8',
       env: {
         ...process.env,
-        PATH: pathDir,
+        PATH: pathDir + path.delimiter + (process.env.PATH || ''),
       },
     }
   );
@@ -44,8 +65,9 @@ describe('python-command.sh', () => {
 
   it('prefers python3 when available', () => {
     const dir = createBinDir();
-    makeExecutable(dir, 'python3', 'printf "python3:%s\\n" "$*"');
-    makeExecutable(dir, 'python', 'printf "python:%s\\n" "$*"');
+    makePython3Stub(dir, 'python3', 'python3');
+    makePython3Stub(dir, 'python', 'python');
+    blockInterpreter(dir, 'py');
 
     const label = runHelper(dir, 'automem_python_label');
     expect(label.status).toBe(0);
@@ -54,7 +76,9 @@ describe('python-command.sh', () => {
 
   it('falls back to python when python3 is unavailable', () => {
     const dir = createBinDir();
-    makeExecutable(dir, 'python', 'printf "python:%s\\n" "$*"');
+    blockInterpreter(dir, 'python3');
+    blockInterpreter(dir, 'py');
+    makePython3Stub(dir, 'python', 'python');
 
     const label = runHelper(dir, 'automem_python_label');
     expect(label.status).toBe(0);
@@ -63,7 +87,9 @@ describe('python-command.sh', () => {
 
   it('uses py -3 when only the Windows launcher is available', () => {
     const dir = createBinDir();
-    makeExecutable(dir, 'py', 'printf "py:%s\\n" "$*"');
+    blockInterpreter(dir, 'python3');
+    makePython3Stub(dir, 'py', 'py');
+    blockInterpreter(dir, 'python');
 
     const label = runHelper(dir, 'automem_python_label');
     expect(label.status).toBe(0);
@@ -74,8 +100,33 @@ describe('python-command.sh', () => {
     expect(run.stdout.trim()).toBe('py:-3 --version');
   });
 
+  it('prefers py -3 over a python that is Python 2', () => {
+    const dir = createBinDir();
+    blockInterpreter(dir, 'python3');
+    makePython3Stub(dir, 'py', 'py');
+    makePython2Stub(dir, 'python');
+
+    const label = runHelper(dir, 'automem_python_label');
+    expect(label.status).toBe(0);
+    expect(label.stdout.trim()).toBe('py -3');
+  });
+
+  it('skips python when it fails the Python 3 version check', () => {
+    const dir = createBinDir();
+    blockInterpreter(dir, 'python3');
+    blockInterpreter(dir, 'py');
+    makePython2Stub(dir, 'python');
+
+    const label = runHelper(dir, 'automem_python_label');
+    expect(label.status).not.toBe(0);
+    expect(label.stdout.trim()).toBe('');
+  });
+
   it('fails cleanly when no supported interpreter is available', () => {
     const dir = createBinDir();
+    blockInterpreter(dir, 'python3');
+    blockInterpreter(dir, 'py');
+    blockInterpreter(dir, 'python');
 
     const label = runHelper(dir, 'automem_python_label');
     expect(label.status).not.toBe(0);

--- a/tests/hooks/python-command.test.ts
+++ b/tests/hooks/python-command.test.ts
@@ -1,0 +1,84 @@
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const HELPER_PATH = path.resolve(__dirname, '../../templates/claude-code/scripts/python-command.sh');
+const BASH_PATH = '/bin/bash';
+
+function makeExecutable(dir: string, name: string, body: string) {
+  const filePath = path.join(dir, name);
+  fs.writeFileSync(filePath, `#!/bin/sh\n${body}\n`, 'utf8');
+  fs.chmodSync(filePath, 0o755);
+}
+
+function runHelper(pathDir: string, command: string) {
+  return spawnSync(
+    BASH_PATH,
+    ['-c', `source "${HELPER_PATH}"; ${command}`],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: pathDir,
+      },
+    }
+  );
+}
+
+describe('python-command.sh', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    while (tempDirs.length) {
+      fs.rmSync(tempDirs.pop()!, { recursive: true, force: true });
+    }
+  });
+
+  function createBinDir() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'automem-python-helper-'));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  it('prefers python3 when available', () => {
+    const dir = createBinDir();
+    makeExecutable(dir, 'python3', 'printf "python3:%s\\n" "$*"');
+    makeExecutable(dir, 'python', 'printf "python:%s\\n" "$*"');
+
+    const label = runHelper(dir, 'automem_python_label');
+    expect(label.status).toBe(0);
+    expect(label.stdout.trim()).toBe('python3');
+  });
+
+  it('falls back to python when python3 is unavailable', () => {
+    const dir = createBinDir();
+    makeExecutable(dir, 'python', 'printf "python:%s\\n" "$*"');
+
+    const label = runHelper(dir, 'automem_python_label');
+    expect(label.status).toBe(0);
+    expect(label.stdout.trim()).toBe('python');
+  });
+
+  it('uses py -3 when only the Windows launcher is available', () => {
+    const dir = createBinDir();
+    makeExecutable(dir, 'py', 'printf "py:%s\\n" "$*"');
+
+    const label = runHelper(dir, 'automem_python_label');
+    expect(label.status).toBe(0);
+    expect(label.stdout.trim()).toBe('py -3');
+
+    const run = runHelper(dir, 'automem_run_python --version');
+    expect(run.status).toBe(0);
+    expect(run.stdout.trim()).toBe('py:-3 --version');
+  });
+
+  it('fails cleanly when no supported interpreter is available', () => {
+    const dir = createBinDir();
+
+    const label = runHelper(dir, 'automem_python_label');
+    expect(label.status).not.toBe(0);
+    expect(label.stdout.trim()).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- add shared Python interpreter resolution for Claude Code hooks
- fall back from `python3` to `python` or `py -3` in POSIX-shell Windows environments
- document the current Windows support boundary and keep plugin/runtime parity intact

## Testing
- npm run build
- npm test
