### PR TITLE
docs: add Google Antigravity setup

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -67,6 +67,7 @@ Now that your AutoMem service is running, install and configure the MCP client t
 - [Cursor IDE](#cursor-ide) - AI-powered code editor
 - [Claude Code](#claude-code) - Terminal coding assistant with automation hooks
 - [OpenAI Codex](#openai-codex) - CLI, IDE, and cloud agent
+- [Google Antigravity](#google-antigravity) - Desktop editor with MCP Store and raw config
 - [OpenClaw](#openclaw) - Personal AI assistant with multi-platform messaging (WhatsApp, Telegram, Slack, Discord, etc.)
 
 ---
@@ -751,6 +752,80 @@ Memories stored in Codex are available in:
 
 Use consistent project names and tags across platforms.
 Use consistent **bare** project slugs and category tags across platforms; avoid platform tags and date tags.
+
+---
+
+## Google Antigravity
+
+Google Antigravity supports MCP servers through its built-in MCP Store and a raw config file. AutoMem fits Antigravity's local stdio MCP flow directly, so the primary path is to add the `memory` server to Antigravity's custom MCP server config.
+
+### 1. Open Antigravity's MCP raw config
+
+Antigravity's own MCP docs currently describe this flow:
+
+1. Open the MCP Store via the `...` dropdown at the top of the editor's agent panel
+2. Click **Manage MCP Servers**
+3. Click **View raw config**
+4. Edit `mcp_config.json`
+
+**Config location:** `~/.gemini/antigravity/mcp_config.json`
+
+### 2. Add the AutoMem MCP server
+
+Merge the following into the `mcpServers` object in `~/.gemini/antigravity/mcp_config.json`.
+
+You can also copy it directly from [templates/antigravity/mcp_config.json](/Users/jgarturo/Projects/OpenAI/mcp-servers/mcp-automem/templates/antigravity/mcp_config.json).
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "npx",
+      "args": ["-y", "@verygoodplugins/mcp-automem"],
+      "env": {
+        "AUTOMEM_ENDPOINT": "https://your-automem-instance.railway.app",
+        "AUTOMEM_API_KEY": "your-api-key-if-required"
+      }
+    }
+  }
+}
+```
+
+**For local development:**
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "npx",
+      "args": ["-y", "@verygoodplugins/mcp-automem"],
+      "env": {
+        "AUTOMEM_ENDPOINT": "http://127.0.0.1:8001"
+      }
+    }
+  }
+}
+```
+
+### 3. Reload Antigravity
+
+Restart Antigravity, or reload the MCP configuration from the MCP Store, so the `memory` server is picked up.
+
+### 4. Verify installation
+
+Confirm the `memory` server appears in Antigravity's MCP server list, then ask Antigravity:
+
+```text
+Check the health of the AutoMem service
+```
+
+You should see connection status for FalkorDB and Qdrant.
+
+### Optional: use the remote MCP sidecar instead
+
+Antigravity's MCP config also supports remote Streamable HTTP servers via `serverUrl`, so you can use the optional AutoMem remote sidecar if you want an HTTPS MCP endpoint instead of a local `npx` process.
+
+Use the local stdio configuration above as the default path. Reach for remote MCP only if you specifically want the sidecar model described in [Remote MCP via HTTP (Sidecar)](#remote-mcp-via-http-sidecar).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npx @verygoodplugins/mcp-automem setup
 
 Your AI assistant now remembers everything. Forever. Across every conversation.
 
-Works with **Claude Desktop**, **Cursor IDE**, **Claude Code**, **GitHub Copilot (coding agent)**, **ChatGPT**, **ElevenLabs**, **OpenAI Codex** - any MCP-compatible AI platform.
+Works with **Claude Desktop**, **Cursor IDE**, **Claude Code**, **GitHub Copilot (coding agent)**, **ChatGPT**, **ElevenLabs**, **OpenAI Codex**, **Google Antigravity** - any MCP-compatible AI platform.
 
 ## The Problem We Solve
 
@@ -34,7 +34,7 @@ AutoMem MCP connects your AI to persistent memory powered by **[AutoMem](https:/
 ### 🧠 Persistent Memory Across Sessions
 
 - AI remembers decisions, patterns, and context **forever**
-- Works across **all MCP platforms** - Claude Desktop, Cursor, Claude Code
+- Works across **all MCP platforms** - Claude Desktop, Cursor, Claude Code, Codex, Antigravity
 - **Cross-device sync** - same memory on Mac, Windows, Linux
 
 ### 🏆 Graph-Vector Architecture
@@ -52,6 +52,7 @@ AutoMem MCP connects your AI to persistent memory powered by **[AutoMem](https:/
 | **Claude Code**    | ✅ Full | 30 seconds |
 | **GitHub Copilot** | ✅ Full | 2 minutes  |
 | **OpenAI Codex**   | ✅ Full | 30 seconds |
+| **Google Antigravity** | ✅ Full | 30 seconds |
 | **Any MCP client** | ✅ Full | 30 seconds |
 
 ## See It In Action
@@ -215,6 +216,15 @@ npx @verygoodplugins/mcp-automem config --format=json
 # Optional: add memory-first rules to this repo
 npx @verygoodplugins/mcp-automem codex
 ```
+
+**For Google Antigravity:**
+
+1. Open the MCP Store from the `...` menu at the top of the editor's agent panel
+2. Click `Manage MCP Servers` and then `View raw config`
+3. Paste the config from [templates/antigravity/mcp_config.json](/Users/jgarturo/Projects/OpenAI/mcp-servers/mcp-automem/templates/antigravity/mcp_config.json) into `~/.gemini/antigravity/mcp_config.json`
+4. Restart or reload Antigravity so the `memory` server is available
+
+👉 **[Google Antigravity Setup](INSTALLATION.md#google-antigravity)** for the full flow and verification steps
 
 👉 **[Full Installation Guide](INSTALLATION.md)** for detailed MCP client and platform-specific setup
 
@@ -416,6 +426,7 @@ Same factors apply here - go with Postgres."
 - 🤖 **[Claude Code Setup](templates/CLAUDE_CODE_INTEGRATION.md)** - Memory rules integration
 - ⚠️ **[Deprecations](DEPRECATION.md)** - Claude Code plugin migration and removal plan
 - 🚀 **[OpenAI Codex Setup](INSTALLATION.md#openai-codex)** - Codex CLI/IDE/Cloud integration
+- 🪐 **[Google Antigravity Setup](INSTALLATION.md#google-antigravity)** - Raw MCP config via Antigravity's MCP Store
 - 📖 **[MCP Tools Reference](INSTALLATION.md#mcp-tools)** - All memory operations
 
 ### AutoMem Service (separate repo)
@@ -453,6 +464,7 @@ This MCP package provides the bridge between your AI and that research-validated
 - [Claude Code Setup](templates/CLAUDE_CODE_INTEGRATION.md) - Memory rules integration
 - [Deprecations](DEPRECATION.md) - Claude Code plugin migration and removal plan
 - [OpenAI Codex](INSTALLATION.md#openai-codex) - Codex integration
+- [Google Antigravity](INSTALLATION.md#google-antigravity) - Antigravity MCP setup
 - [Changelog](CHANGELOG.md) - Release history
 
 ### AutoMem Service

--- a/templates/antigravity/mcp_config.json
+++ b/templates/antigravity/mcp_config.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "memory": {
+      "command": "npx",
+      "args": ["-y", "@verygoodplugins/mcp-automem"],
+      "env": {
+        "AUTOMEM_ENDPOINT": "https://your-automem-instance.railway.app",
+        "AUTOMEM_API_KEY": "your-api-key-if-required"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a publishable Antigravity MCP config template
- document Google Antigravity in the README support and setup flow
- add a full Installation Guide section for Antigravity raw config and verification

## Testing
- node -e "JSON.parse(require('fs').readFileSync('templates/antigravity/mcp_config.json','utf8')); console.log('templates/antigravity/mcp_config.json OK')"
- npm run build

Closes #87