### PR TITLE
docs: link to automem-evals evaluation lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,7 @@ Same factors apply here - go with Postgres."
 - 🏗️ **[AutoMem Service](https://github.com/verygoodplugins/automem)** - Backend repository
 - 🚀 **[Service Installation](https://github.com/verygoodplugins/automem/blob/main/INSTALLATION.md)** - Local, Railway, Docker deployment
 - ⚙️ **[API Documentation](https://github.com/verygoodplugins/automem#api-reference)** - REST API reference
+- 🧪 **[Evaluation Lab](https://github.com/verygoodplugins/automem-evals)** - Exploratory recall-quality benchmarks and ruleset A/B testing
 
 ## The Science Behind AutoMem
 


### PR DESCRIPTION
## Summary

- Adds a one-line pointer under the **AutoMem Service (separate repo)** subsection of the Documentation block to the newly-public evaluation lab at [verygoodplugins/automem-evals](https://github.com/verygoodplugins/automem-evals).

## Context

`automem-evals` is the exploratory sibling to `automem` for recall-quality evaluation work:

- Ruleset A/B comparisons against a seeded corpus with known ground-truth hits
- BEAM benchmark suite driven through a REST shim (mem0-OSS translation layer)
- Scenario authoring, parameter-isolation sweeps (`iso_a`..`iso_j`), and client-side graph-expansion prototypes

It intentionally does **not** publish benchmark claims — those remain in `verygoodplugins/automem`. The repo's own `docs/REPO_BOUNDARY.md` documents the contract.

## Test plan

- [ ] Verify the rendered README link resolves to `github.com/verygoodplugins/automem-evals` (public, MIT)
- [ ] Confirm the bullet fits the existing style in the "AutoMem Service (separate repo)" subsection

🤖 Generated with [Claude Code](https://claude.com/claude-code)