### PR TITLE
feat(openclaw): plugin-first memory parity with shared policy

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -911,8 +911,8 @@ AutoMem now supports three OpenClaw integration modes, in this recommended order
 
 4. **Open OpenClaw**. The installer will restart the gateway, verify the plugin, and open or print the dashboard URL.
 
-`openclaw --mode plugin` installs a lean native plugin package staged inside `@verygoodplugins/mcp-automem`. That keeps `memory-core` as OpenClaw's active memory slot instead of replacing it.
-It also enables the `/plugins` chat command so users can verify and inspect the install from inside OpenClaw.
+The recommended setup command above installs OpenClaw in `plugin` mode using the packaged flow from `@verygoodplugins/mcp-automem` (under the hood: `npx @verygoodplugins/mcp-automem openclaw --mode plugin`). That stages a lean native plugin package and keeps `memory-core` as OpenClaw's active memory slot instead of replacing it.
+Plugin mode also enables the `/plugins` chat command so users can verify and inspect the install from inside OpenClaw.
 It also appends the AutoMem tool names to `tools.alsoAllow`, which keeps them callable even when OpenClaw is using a restrictive base profile such as `tools.profile = "coding"` without forcing a restrictive global allowlist.
 On fresh installs, it also probes AutoMem once: if the service is reachable and already contains memory, the installer sets `agents.defaults.skipBootstrap = true` so OpenClaw skips the name/timezone/vibe bootstrap flow. If AutoMem is empty or unavailable, the normal bootstrap remains in place.
 When AutoMem already knows the user, the installer also hydrates a compact startup profile from memory so the first browser chat can behave like a returning user agent conversation instead of a generic blank slate.

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -297,8 +297,8 @@ When creating substantial content, briefly note which memories informed the appr
 ![Claude Desktop with Custom Instructions](screenshots/claude-desktop-custom-instructions-3.jpg)
 _Add memory instructions to Custom Instructions_
 
-5. Click **Save**
-6. Restart Claude Desktop
+1. Click **Save**
+2. Restart Claude Desktop
 
 **How this works:**
 
@@ -653,6 +653,7 @@ Restart the Codex CLI or reload your IDE extension to load the MCP server.
 ### 5. Verify Installation
 
 Ask Codex:
+
 ```text
 Check the health of the AutoMem service
 ```
@@ -662,6 +663,7 @@ You should see connection status for FalkorDB and Qdrant.
 ### How to Use with Codex
 
 **In the CLI:**
+
 ```bash
 cd ~/Projects/my-app
 
@@ -898,10 +900,24 @@ AutoMem now supports three OpenClaw integration modes, in this recommended order
 3. **Run the recommended setup**:
 
    ```bash
-   npx @verygoodplugins/mcp-automem openclaw --mode plugin
+   curl -fsSL https://automem.ai/install.sh | bash
    ```
 
-4. **Restart OpenClaw gateway** and start a new session.
+   Local-build equivalent while developing this repo:
+
+   ```bash
+   ./install.sh
+   ```
+
+4. **Open OpenClaw**. The installer will restart the gateway, verify the plugin, and open or print the dashboard URL.
+
+`openclaw --mode plugin` installs a lean native plugin package staged inside `@verygoodplugins/mcp-automem`. That keeps `memory-core` as OpenClaw's active memory slot instead of replacing it.
+It also enables the `/plugins` chat command so users can verify and inspect the install from inside OpenClaw.
+It also appends the AutoMem tool names to `tools.alsoAllow`, which keeps them callable even when OpenClaw is using a restrictive base profile such as `tools.profile = "coding"` without forcing a restrictive global allowlist.
+On fresh installs, it also probes AutoMem once: if the service is reachable and already contains memory, the installer sets `agents.defaults.skipBootstrap = true` so OpenClaw skips the name/timezone/vibe bootstrap flow. If AutoMem is empty or unavailable, the normal bootstrap remains in place.
+When AutoMem already knows the user, the installer also hydrates a compact startup profile from memory so the first browser chat can behave like a returning user agent conversation instead of a generic blank slate.
+
+For a deterministic dogfood pass, see the scripted clean-install demo in [`templates/openclaw/OPENCLAW_SETUP.md`](./templates/openclaw/OPENCLAW_SETUP.md).
 
 ### Alternate modes
 
@@ -917,9 +933,15 @@ npx @verygoodplugins/mcp-automem openclaw --mode skill --workspace ~/clawd
 
 - **Multi-platform memory**: Your agent remembers decisions across WhatsApp, Telegram, Slack, Discord, and other OpenClaw channels
 - **Native plugin option**: New installs can use OpenClaw's plugin system instead of only curl-based skills
+- **Lower-friction onboarding**: Populated AutoMem installs can start with memory-aware context immediately instead of redoing first-run bootstrap questions
 - **Transparent MCP option**: `mcp` mode writes a normal `mcporter.json` and keeps secrets out of it
-- **Semantic-first recall**: OpenClaw now recalls preferences first and keeps task recall semantic instead of hard-gating every turn with installer default tags
+- **Shared memory-policy parity**: OpenClaw now follows the same validated AutoMem policy as Claude Desktop, Claude Code, and Cursor
+- **Targeted recall instead of every-turn recall**: preference recall on the first substantive turn (`limit 20`), semantic task recall on that turn (`limit 30`, `last 90 days`), then bugfix recall only for active debugging
+- **Semantic-first recall**: OpenClaw only uses installer `defaultTags` as an unambiguous project gate for first-turn task recall instead of hard-gating every turn
+- **Optional full replacement mode**: `--replace-memory` disables `memory-core`, disables the bundled `session-memory` hook, and turns off dreaming so AutoMem becomes the only memory system
 - **Complementary memory layers**: `memory-core` remains useful for local file memory; AutoMem is the semantic graph layer
+
+Use `https://automem.ai/install.sh` for the OpenClaw happy path, or `npx @verygoodplugins/mcp-automem openclaw --mode plugin` when you need the raw CLI. Do not point `openclaw plugins install` at the main `@verygoodplugins/mcp-automem` package directly.
 
 ### Full Setup Guide
 

--- a/install.sh
+++ b/install.sh
@@ -246,8 +246,8 @@ case "$selected_client" in
 esac
 
 echo "Restarting OpenClaw gateway..."
-if ! node -e 'const { spawnSync } = require("child_process"); const result = spawnSync("openclaw", ["gateway", "restart"], { stdio: "ignore", timeout: 20000 }); if (result.error && result.error.code !== "ETIMEDOUT") process.exit(1); process.exit(result.status ?? 1);' >/dev/null 2>&1; then
-  echo "OpenClaw gateway restart did not complete cleanly. Retry manually: openclaw gateway restart" >&2
+if ! node -e 'const { spawnSync } = require("child_process"); const result = spawnSync("openclaw", ["gateway", "restart"], { stdio: "ignore", timeout: 20000 }); if (result.error) { if (result.error.code === "ETIMEDOUT") { console.error("Warning: OpenClaw gateway restart timed out after 20s; continuing to health check."); process.exit(0); } process.exit(1); } if (typeof result.status === "number") process.exit(result.status); process.exit(1);'; then
+  echo "OpenClaw gateway restart failed. Retry manually: openclaw gateway restart" >&2
   exit 1
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+package_spec="${AUTOMEM_PACKAGE_SPEC:-@verygoodplugins/mcp-automem}"
+default_endpoint="${AUTOMEM_DEFAULT_ENDPOINT:-http://127.0.0.1:8001}"
+endpoint="${AUTOMEM_ENDPOINT:-}"
+api_key="${AUTOMEM_API_KEY:-}"
+scope="${AUTOMEM_OPENCLAW_SCOPE:-shared}"
+selected_client="${AUTOMEM_CLIENT:-openclaw}"
+replace_memory="${AUTOMEM_REPLACE_OPENCLAW_MEMORY:-0}"
+tty_fd="3"
+interactive="0"
+
+open_tty() {
+  if [[ "$interactive" == "1" ]]; then
+    return 0
+  fi
+
+  if [[ ! -t 1 ]]; then
+    return 1
+  fi
+
+  exec 3<>/dev/tty || return 1
+  interactive="1"
+  return 0
+}
+
+tty_print() {
+  local message="$1"
+  if [[ "$interactive" == "1" ]]; then
+    printf "%s" "$message" >&"$tty_fd"
+  else
+    printf "%s" "$message"
+  fi
+}
+
+read_line() {
+  local prompt="$1"
+  local default_value="${2:-}"
+  local value=""
+
+  if [[ "$interactive" != "1" ]]; then
+    printf '%s' "$default_value"
+    return 0
+  fi
+
+  if [[ -n "$default_value" ]]; then
+    tty_print "$prompt [$default_value] "
+  else
+    tty_print "$prompt "
+  fi
+
+  IFS= read -r value <&"$tty_fd" || true
+  if [[ -z "$value" ]]; then
+    value="$default_value"
+  fi
+  printf '%s' "$value"
+}
+
+read_secret() {
+  local prompt="$1"
+  local value=""
+
+  if [[ "$interactive" != "1" ]]; then
+    printf '%s' "$api_key"
+    return 0
+  fi
+
+  tty_print "$prompt "
+  stty -echo <&"$tty_fd"
+  IFS= read -r value <&"$tty_fd" || true
+  stty echo <&"$tty_fd"
+  tty_print $'\n'
+  printf '%s' "$value"
+}
+
+confirm_prompt() {
+  local prompt="$1"
+  local default_answer="${2:-n}"
+  local answer=""
+
+  if [[ "$interactive" != "1" ]]; then
+    [[ "$default_answer" =~ ^[yY]$ ]]
+    return
+  fi
+
+  tty_print "$prompt "
+  IFS= read -r answer <&"$tty_fd" || true
+  if [[ -z "$answer" ]]; then
+    answer="$default_answer"
+  fi
+  case "$answer" in
+    [yY]|[yY][eE][sS]) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+probe_endpoint() {
+  local url="$1"
+  local health_url="${url%/}/health"
+  curl -fsSL --max-time 4 "$health_url" >/dev/null 2>&1
+}
+
+prompt_for_openclaw_inputs() {
+  if [[ -z "$endpoint" ]]; then
+    if ! open_tty; then
+      endpoint="$default_endpoint"
+      return 0
+    fi
+
+    if ! confirm_prompt "Do you want to install AutoMem to OpenClaw? (y|N)"; then
+      tty_print "Install cancelled.\n"
+      exit 0
+    fi
+
+    while [[ -z "$endpoint" ]]; do
+      endpoint="$(read_line "What is your AutoMem URL?" "$default_endpoint")"
+      endpoint="${endpoint//[$'\r\n']}"
+      if [[ -z "$endpoint" ]]; then
+        tty_print "A URL is required.\n"
+        continue
+      fi
+
+      if probe_endpoint "$endpoint"; then
+        tty_print "  ✓ AutoMem reachable at $endpoint\n"
+      else
+        tty_print "  ✗ Could not reach $endpoint/health. Check the URL, or confirm to proceed anyway.\n"
+        if ! confirm_prompt "Use this URL anyway? (y|N)" "n"; then
+          endpoint=""
+        fi
+      fi
+    done
+  fi
+
+  if [[ "$interactive" != "1" ]]; then
+    return 0
+  fi
+
+  if [[ -z "$api_key" ]]; then
+    api_key="$(read_secret "AutoMem API key (optional — press Enter to skip for local installs):")"
+    api_key="${api_key//[$'\r\n']}"
+  fi
+
+  if [[ "${AUTOMEM_REPLACE_OPENCLAW_MEMORY:-}" == "" ]]; then
+    tty_print "\nOpenClaw ships with a built-in 'memory-core' plugin. AutoMem is a graph-vector\n"
+    tty_print "memory service that persists across sessions. Most users should replace memory-core.\n"
+    if confirm_prompt "Replace OpenClaw's built-in memory with AutoMem? (Y|n)" "y"; then
+      replace_memory="1"
+    else
+      replace_memory="0"
+    fi
+  fi
+}
+
+wait_for_gateway_health() {
+  local attempt=0
+  local max_attempts=15
+  while (( attempt < max_attempts )); do
+    if openclaw health >/dev/null 2>&1; then
+      return 0
+    fi
+    attempt=$((attempt + 1))
+    sleep 2
+  done
+  return 1
+}
+
+print_install_summary() {
+  local key_note="not set"
+  if [[ -n "$api_key" ]]; then
+    key_note="set (length $(printf '%s' "$api_key" | wc -c | tr -d ' '))"
+  fi
+  local replace_note="no"
+  if [[ "$replace_memory" == "1" ]]; then
+    replace_note="yes"
+  fi
+  echo ""
+  echo "────────────────────────────────────────────────────────────"
+  echo "  AutoMem is installed in OpenClaw"
+  echo "────────────────────────────────────────────────────────────"
+  echo "  Endpoint          : $endpoint"
+  echo "  API key           : $key_note"
+  echo "  Replaced memory-core: $replace_note"
+  echo "  OpenClaw config   : ~/.openclaw/openclaw.json (backup saved as *.bak)"
+  echo "  Plugin installed  : ~/.openclaw/extensions/automem/"
+  echo ""
+  echo "  What to do next:"
+  echo "    1. Open OpenClaw Chat and start a conversation."
+  echo "    2. Your AI will recall preferences automatically on the first turn."
+  echo "    3. Say things like \"let's ship it\" or \"actually, I prefer X\" to"
+  echo "       trigger durable memory stores."
+  echo ""
+  echo "  Docs: https://github.com/verygoodplugins/mcp-automem/blob/main/templates/openclaw/OPENCLAW_SETUP.md"
+  echo "────────────────────────────────────────────────────────────"
+}
+
+build_runner() {
+  if [[ -f "$script_dir/dist/index.js" ]]; then
+    runner=(node "$script_dir/dist/index.js")
+  else
+    runner=(npx -y "$package_spec")
+  fi
+}
+
+run_openclaw_install() {
+  local args=(openclaw --mode plugin --scope "$scope" --endpoint "$endpoint")
+  if [[ -n "$api_key" ]]; then
+    args+=(--api-key "$api_key")
+  fi
+  if [[ -n "${AUTOMEM_OPENCLAW_WORKSPACE:-}" ]]; then
+    args+=(--workspace "$AUTOMEM_OPENCLAW_WORKSPACE")
+  fi
+  if [[ -n "${AUTOMEM_OPENCLAW_PLUGIN_SOURCE:-}" ]]; then
+    args+=(--plugin-source "$AUTOMEM_OPENCLAW_PLUGIN_SOURCE")
+  fi
+  if [[ "$replace_memory" == "1" ]]; then
+    args+=(--replace-memory)
+  fi
+
+  echo "Installing AutoMem into OpenClaw..."
+  "${runner[@]}" "${args[@]}"
+}
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "Node.js is required to install AutoMem for OpenClaw." >&2
+  exit 1
+fi
+
+if ! command -v openclaw >/dev/null 2>&1; then
+  echo "OpenClaw not found. Installing it first..." >&2
+  curl -fsSL https://openclaw.ai/install.sh | bash
+fi
+
+build_runner
+
+case "$selected_client" in
+  openclaw)
+    prompt_for_openclaw_inputs
+    run_openclaw_install
+    ;;
+  *)
+    echo "Unsupported AutoMem client: $selected_client" >&2
+    exit 1
+    ;;
+esac
+
+echo "Restarting OpenClaw gateway..."
+if ! node -e 'const { spawnSync } = require("child_process"); const result = spawnSync("openclaw", ["gateway", "restart"], { stdio: "ignore", timeout: 20000 }); if (result.error && result.error.code !== "ETIMEDOUT") process.exit(1); process.exit(result.status ?? 1);' >/dev/null 2>&1; then
+  echo "OpenClaw gateway restart did not complete cleanly. Retry manually: openclaw gateway restart" >&2
+  exit 1
+fi
+
+echo "Waiting for gateway to come back..."
+if ! wait_for_gateway_health; then
+  echo "Gateway did not report healthy within 30s. Check status: openclaw health" >&2
+  exit 1
+fi
+
+echo "Verifying plugin install..."
+if ! openclaw plugins inspect automem --json >/dev/null; then
+  echo "Plugin not registered. Check: openclaw plugins list" >&2
+  exit 1
+fi
+
+print_install_summary
+
+if [[ "${AUTOMEM_NO_OPEN:-0}" == "1" ]]; then
+  openclaw dashboard --no-open >/dev/null 2>&1 || true
+  exit 0
+fi
+
+if [[ -t 1 ]]; then
+  openclaw dashboard >/dev/null 2>&1 || openclaw dashboard --no-open >/dev/null 2>&1 || true
+else
+  openclaw dashboard --no-open >/dev/null 2>&1 || true
+fi

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,12 +2,9 @@
   "id": "automem",
   "name": "AutoMem",
   "description": "Persistent graph-vector memory backed by an AutoMem service.",
-  "kind": "memory",
-  "skills": ["./skills"],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
-    "required": ["endpoint"],
     "properties": {
       "endpoint": {
         "type": "string",
@@ -23,8 +20,31 @@
       "autoRecallLimit": {
         "type": "integer",
         "minimum": 1,
-        "maximum": 10,
-        "default": 3
+        "maximum": 50
+      },
+      "preferenceRecallLimit": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 50,
+        "default": 20
+      },
+      "contextRecallLimit": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 50,
+        "default": 30
+      },
+      "debugRecallLimit": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 50,
+        "default": 20
+      },
+      "contextRecallWindowDays": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 365,
+        "default": 90
       },
       "exposure": {
         "type": "string",
@@ -36,6 +56,9 @@
         "items": {
           "type": "string"
         }
+      },
+      "startupProfile": {
+        "type": "string"
       }
     }
   },
@@ -55,7 +78,20 @@
       "help": "Recall relevant memories before a new agent turn."
     },
     "autoRecallLimit": {
-      "label": "Auto Recall Limit"
+      "label": "Legacy Auto Recall Limit",
+      "help": "Compatibility fallback for older installs. Prefer the per-phase recall settings below."
+    },
+    "preferenceRecallLimit": {
+      "label": "Preference Recall Limit"
+    },
+    "contextRecallLimit": {
+      "label": "Context Recall Limit"
+    },
+    "debugRecallLimit": {
+      "label": "Debug Recall Limit"
+    },
+    "contextRecallWindowDays": {
+      "label": "Context Recall Window (days)"
     },
     "exposure": {
       "label": "Exposure",
@@ -63,7 +99,11 @@
     },
     "defaultTags": {
       "label": "Default Tags",
-      "help": "Project tags to apply when the request does not supply tags."
+      "help": "Used as the project gate for first-turn context recall when unambiguous, and merged into stored memories."
+    },
+    "startupProfile": {
+      "label": "Startup Profile",
+      "help": "Cached profile and personality cues hydrated from AutoMem for fast first-turn startup."
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,15 +11,10 @@
   "bin": {
     "mcp-automem": "dist/index.js"
   },
-  "openclaw": {
-    "extensions": [
-      "./dist/openclaw-plugin.js"
-    ]
-  },
   "scripts": {
     "prebuild": "node scripts/sync-template-versions.mjs",
-    "build": "tsc && npm run postbuild",
-    "postbuild": "chmod +x dist/index.js",
+    "build": "tsc",
+    "postbuild": "node scripts/build-openclaw-plugin-package.mjs && chmod +x dist/index.js",
     "sync-versions": "node scripts/sync-template-versions.mjs",
     "dev": "tsx watch src/index.ts",
     "lint": "eslint .",
@@ -83,7 +78,7 @@
     ".claude-plugin",
     "assets",
     "manifest.json",
-    "openclaw.plugin.json",
+    "install.sh",
     "env.example",
     "README.md",
     "CHANGELOG.md",

--- a/plugins/automem/scripts/session-start.sh
+++ b/plugins/automem/scripts/session-start.sh
@@ -9,9 +9,9 @@ PROJECT=$(basename "$PWD")
 
 cat << EOF
 <automem_session_context>
-MEMORY RECALL — run these phases in order before your first substantive response.
+MEMORY RECALL - run these phases in order before your first substantive response.
 
-Phase 1 — Preferences (tag-only, no time filter, no query):
+Phase 1 - Preferences (tag-only, no time filter, no query):
   mcp__memory__recall_memory({
     tags: ["preference"],
     limit: 20,
@@ -19,16 +19,16 @@ Phase 1 — Preferences (tag-only, no time filter, no query):
     format: "detailed"
   })
 
-Phase 2 — Task context (ONE semantic query from the user's actual nouns; project-slug gate; 90-day window):
+Phase 2 - Task context (ONE semantic query from the user's actual nouns; project-slug gate when unambiguous; 90-day window):
   mcp__memory__recall_memory({
     query: "<proper nouns, product names, tools, specific topics from the user's message>",
-    tags: ["$PROJECT"],
+    tags: ["$PROJECT"],    // drop if slug collides with a common word
     time_query: "last 90 days",
     limit: 30,
     format: "detailed"
   })
 
-Phase 3 — ON-DEMAND (only if the user's message is a debugging/error-symptom question; skip otherwise):
+Phase 3 - ON-DEMAND debugging (only if the user's message is a debugging/error-symptom question; skip otherwise):
   mcp__memory__recall_memory({
     query: "<error symptom>",
     tags: ["bugfix", "solution"],
@@ -38,10 +38,11 @@ Phase 3 — ON-DEMAND (only if the user's message is a debugging/error-symptom q
 Project slug: $PROJECT
 
 Notes:
-- Tags are a HARD GATE — they filter before scoring. For discovery/debugging across the full corpus, drop \`tags\` and rely on semantic \`query\` alone.
-- Do NOT use namespace-prefixed tags (\`project/*\`, \`lang/*\`, etc.) — the corpus uses bare tags.
+- Tags are a HARD GATE - they filter before scoring. For discovery/debugging across the full corpus, drop \`tags\` and rely on semantic \`query\` alone.
+- Do NOT use namespace-prefixed tags (\`project/*\`, \`lang/*\`, etc.) - the corpus uses bare tags.
 - Phase 2 uses ONE targeted query, not \`queries[]\` + \`auto_decompose\`. Sub-queries converge and dedup drops results; a single query built from the real nouns in the user's message wins empirically. Only switch to \`queries[]\` for genuinely multi-topic questions.
-- If the project slug collides with a common topic word (e.g., \`video\`, \`test\`), drop the Phase 2 tag gate and rely on semantic \`query\` alone.
-- If recall fails or returns nothing, continue without memory — do not mention the failure to the user.
+- If the project slug collides with a common topic word (for example \`video\` or \`test\`), drop the Phase 2 tag gate and rely on semantic \`query\` alone.
+- Do not re-recall every turn. After turn 1, recall again only for topic shifts, new proper nouns, or active debugging.
+- If recall fails or returns nothing, continue without memory - do not mention the failure to the user.
 </automem_session_context>
 EOF

--- a/scripts/build-openclaw-plugin-package.mjs
+++ b/scripts/build-openclaw-plugin-package.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const DIST_ROOT = join(REPO_ROOT, 'dist');
+const OUTPUT_ROOT = join(DIST_ROOT, 'openclaw-plugin-package');
+const OUTPUT_DIST = join(OUTPUT_ROOT, 'dist');
+
+const pkg = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8'));
+const pluginManifest = JSON.parse(readFileSync(join(REPO_ROOT, 'openclaw.plugin.json'), 'utf8'));
+const runtimeFiles = [
+  'openclaw-plugin.js',
+  'openclaw-startup-profile.js',
+  'automem-client.js',
+  'types.js',
+  'memory-policy/shared.js',
+];
+
+for (const filename of runtimeFiles) {
+  const sourcePath = join(DIST_ROOT, filename);
+  if (!existsSync(sourcePath)) {
+    throw new Error(`Missing OpenClaw plugin runtime file: ${sourcePath}`);
+  }
+}
+
+rmSync(OUTPUT_ROOT, { recursive: true, force: true });
+mkdirSync(OUTPUT_DIST, { recursive: true });
+
+writeFileSync(
+  join(OUTPUT_ROOT, 'package.json'),
+  `${JSON.stringify(
+    {
+      name: pluginManifest.id,
+      version: pkg.version,
+      type: 'module',
+      private: true,
+      openclaw: {
+        extensions: ['./dist/openclaw-plugin.js'],
+      },
+    },
+    null,
+    2
+  )}\n`
+);
+
+writeFileSync(join(OUTPUT_ROOT, 'openclaw.plugin.json'), `${JSON.stringify(pluginManifest, null, 2)}\n`);
+
+for (const filename of runtimeFiles) {
+  const targetPath = join(OUTPUT_DIST, filename);
+  mkdirSync(dirname(targetPath), { recursive: true });
+  cpSync(join(DIST_ROOT, filename), targetPath);
+}
+
+console.log(`✓ staged lean OpenClaw plugin package in ${join('dist', 'openclaw-plugin-package')}`);

--- a/src/automem-client.test.ts
+++ b/src/automem-client.test.ts
@@ -1,18 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AutoMemClient } from './automem-client.js';
 
-// Mock node-fetch
-vi.mock('node-fetch', () => ({
-  default: vi.fn(),
-}));
-
-import fetch from 'node-fetch';
-const mockFetch = vi.mocked(fetch);
+const mockFetch = vi.fn();
 
 describe('AutoMemClient', () => {
   let client: AutoMemClient;
 
   beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
     client = new AutoMemClient({
       endpoint: 'http://localhost:8001',
       apiKey: 'test-key',
@@ -21,6 +16,7 @@ describe('AutoMemClient', () => {
   });
 
   afterEach(() => {
+    vi.unstubAllGlobals();
     vi.resetAllMocks();
   });
 

--- a/src/automem-client.ts
+++ b/src/automem-client.ts
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import type {
   AutoMemConfig,
   MemoryRecord,
@@ -25,7 +24,7 @@ export class AutoMemClient {
     retryCount = 0
   ): Promise<any> {
     const url = `${this.config.endpoint.replace(/\/$/, '')}/${path.replace(/^\//, '')}`;
-    
+
     const headers: Record<string, string> = {
       'Content-Type': 'application/json',
     };
@@ -34,10 +33,13 @@ export class AutoMemClient {
       headers.Authorization = `Bearer ${this.config.apiKey}`;
     }
 
-    const options: any = {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 25_000);
+
+    const options: RequestInit = {
       method,
       headers,
-      timeout: 25000, // 25s timeout - Claude Desktop has ~30s MCP timeout
+      signal: controller.signal,
     };
 
     if (body && method !== 'GET') {
@@ -52,6 +54,7 @@ export class AutoMemClient {
     try {
       response = await fetch(url, options);
     } catch (error) {
+      clearTimeout(timeoutId);
       if (error instanceof Error && retryCount < maxRetries) {
         const delay = baseDelay * Math.pow(2, retryCount);
         console.error(`[AutoMem] Network error, retrying after ${delay}ms (attempt ${retryCount + 1}/${maxRetries})...`);
@@ -62,6 +65,7 @@ export class AutoMemClient {
       console.error(`AutoMem API error (${method} ${url}):`, error);
       throw error;
     }
+    clearTimeout(timeoutId);
 
     let data: any;
     try {

--- a/src/cli/openclaw.test.ts
+++ b/src/cli/openclaw.test.ts
@@ -1,12 +1,28 @@
 import { describe, expect, it } from 'vitest';
 import {
+  allowAutoMemTools,
+  allowPluginWhenAllowlistExists,
   buildDefaultTags,
   buildMcporterConfig,
   buildPluginConfigEntry,
   buildSkillConfigEntry,
+  disableBuiltInMemorySlot,
+  disableMemoryCoreDreaming,
+  disableSessionMemoryHook,
+  enablePluginsCommand,
+  enableSkipBootstrap,
+  hasExplicitSkipBootstrap,
+  hasOnboardingArtifacts,
+  hydrateStartupProfile,
+  isFreshOnboardingTarget,
   parseArgs,
+  probeBootstrapBypass,
   redactConfigForOutput,
+  replaceOpenClawMemorySystem,
 } from './openclaw.js';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 
 describe('openclaw cli helpers', () => {
   it('parses the new openclaw flags with plugin defaults', () => {
@@ -25,12 +41,14 @@ describe('openclaw cli helpers', () => {
         '../local-plugin',
         '--name',
         'Project X',
+        '--replace-memory',
       ])
     ).toMatchObject({
       mode: 'mcp',
       scope: 'shared',
       pluginSource: '../local-plugin',
       projectName: 'Project X',
+      replaceMemory: true,
     });
   });
 
@@ -68,6 +86,7 @@ describe('openclaw cli helpers', () => {
         endpoint: 'http://localhost:8001',
         apiKey: 'top-secret',
         defaultTags: ['project-x'],
+        startupProfile: '- [Preference] Call me Jack.',
       })
     ).toEqual({
       enabled: true,
@@ -75,8 +94,42 @@ describe('openclaw cli helpers', () => {
         endpoint: 'http://localhost:8001',
         apiKey: 'top-secret',
         autoRecall: true,
-        autoRecallLimit: 3,
         exposure: 'dm-only',
+        defaultTags: ['project-x'],
+        startupProfile: '- [Preference] Call me Jack.',
+      },
+    });
+  });
+
+  it('preserves existing plugin recall settings while updating endpoint and tags', () => {
+    expect(
+      buildPluginConfigEntry({
+        existing: {
+          config: {
+            endpoint: 'http://old-endpoint',
+            autoRecall: false,
+            autoRecallLimit: 8,
+            preferenceRecallLimit: 20,
+            contextRecallLimit: 30,
+            debugRecallLimit: 20,
+            contextRecallWindowDays: 90,
+            exposure: 'all',
+          },
+        },
+        endpoint: 'http://localhost:8001',
+        defaultTags: ['project-x'],
+      })
+    ).toEqual({
+      enabled: true,
+      config: {
+        endpoint: 'http://localhost:8001',
+        autoRecall: false,
+        autoRecallLimit: 8,
+        preferenceRecallLimit: 20,
+        contextRecallLimit: 30,
+        debugRecallLimit: 20,
+        contextRecallWindowDays: 90,
+        exposure: 'all',
         defaultTags: ['project-x'],
       },
     });
@@ -133,5 +186,342 @@ describe('openclaw cli helpers', () => {
         },
       },
     });
+  });
+
+  it('enables the /plugins chat command', () => {
+    const config = {};
+    enablePluginsCommand(config as never);
+    expect(config).toEqual({
+      commands: {
+        plugins: true,
+      },
+    });
+  });
+
+  it('can disable OpenClaw built-in memory components for AutoMem-only mode', () => {
+    const config = {};
+    replaceOpenClawMemorySystem(config as never, { mode: 'plugin', scope: 'shared' });
+    expect(config).toEqual({
+      plugins: {
+        slots: {
+          memory: 'none',
+        },
+        entries: {
+          'memory-core': {
+            config: {
+              dreaming: {
+                enabled: false,
+              },
+            },
+          },
+        },
+      },
+      hooks: {
+        internal: {
+          entries: {
+            'session-memory': {
+              enabled: false,
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('updates individual memory-core compatibility helpers without clobbering siblings', () => {
+    const config = {
+      plugins: {
+        slots: {
+          contextEngine: 'legacy',
+        },
+        entries: {
+          'memory-core': {
+            enabled: true,
+            config: {
+              dreaming: {
+                enabled: true,
+                frequency: '0 3 * * *',
+              },
+            },
+          },
+        },
+      },
+      hooks: {
+        internal: {
+          entries: {
+            'command-logger': {
+              enabled: true,
+            },
+          },
+        },
+      },
+    };
+
+    disableBuiltInMemorySlot(config as never);
+    disableSessionMemoryHook(config as never);
+    disableMemoryCoreDreaming(config as never);
+
+    expect(config).toEqual({
+      plugins: {
+        slots: {
+          contextEngine: 'legacy',
+          memory: 'none',
+        },
+        entries: {
+          'memory-core': {
+            enabled: true,
+            config: {
+              dreaming: {
+                enabled: false,
+                frequency: '0 3 * * *',
+              },
+            },
+          },
+        },
+      },
+      hooks: {
+        internal: {
+          entries: {
+            'command-logger': {
+              enabled: true,
+            },
+            'session-memory': {
+              enabled: false,
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('adds automem to plugins.allow when an allowlist already exists', () => {
+    const config = {
+      plugins: {
+        allow: ['anthropic', 'brave'],
+      },
+    };
+
+    allowPluginWhenAllowlistExists(config as never, 'automem');
+
+    expect(config).toEqual({
+      plugins: {
+        allow: ['anthropic', 'brave', 'automem'],
+      },
+    });
+  });
+
+  it('does not create a new plugins.allow gate when one was not already configured', () => {
+    const config = {
+      plugins: {
+        entries: {
+          anthropic: { enabled: true },
+        },
+      },
+    };
+
+    allowPluginWhenAllowlistExists(config as never, 'automem');
+
+    expect(config).toEqual({
+      plugins: {
+        entries: {
+          anthropic: { enabled: true },
+        },
+      },
+    });
+  });
+
+  it('adds AutoMem tool names to tools.alsoAllow for additive plugin installs', () => {
+    const config = {};
+
+    allowAutoMemTools(config as never);
+
+    expect(config).toEqual({
+      tools: {
+        alsoAllow: [
+          'automem_store_memory',
+          'automem_recall_memory',
+          'automem_update_memory',
+          'automem_delete_memory',
+          'automem_associate_memories',
+          'automem_check_health',
+        ],
+      },
+    });
+  });
+
+  it('preserves an existing restrictive tools.allow policy while deduping AutoMem tool names', () => {
+    const config = {
+      tools: {
+        profile: 'coding',
+        allow: ['bash', 'automem_recall_memory'],
+      },
+    };
+
+    allowAutoMemTools(config as never);
+
+    expect(config).toEqual({
+      tools: {
+        profile: 'coding',
+        allow: [
+          'bash',
+          'automem_recall_memory',
+          'automem_store_memory',
+          'automem_update_memory',
+          'automem_delete_memory',
+          'automem_associate_memories',
+          'automem_check_health',
+        ],
+      },
+    });
+  });
+
+  it('migrates legacy AutoMem-only tools.allow entries into tools.alsoAllow', () => {
+    const config = {
+      tools: {
+        profile: 'coding',
+        allow: ['automem_recall_memory', 'automem_store_memory'],
+      },
+    };
+
+    allowAutoMemTools(config as never);
+
+    expect(config).toEqual({
+      tools: {
+        profile: 'coding',
+        alsoAllow: [
+          'automem_store_memory',
+          'automem_recall_memory',
+          'automem_update_memory',
+          'automem_delete_memory',
+          'automem_associate_memories',
+          'automem_check_health',
+        ],
+      },
+    });
+  });
+
+  it('detects fresh onboarding targets from empty workspaces', () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'automem-openclaw-'));
+    expect(hasOnboardingArtifacts(workspace)).toBe(false);
+    expect(isFreshOnboardingTarget({}, workspace)).toBe(true);
+    fs.rmSync(workspace, { recursive: true, force: true });
+  });
+
+  it('does not treat a workspace with onboarding files as fresh', () => {
+    const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'automem-openclaw-'));
+    fs.writeFileSync(path.join(workspace, 'USER.md'), 'Jack');
+    expect(hasOnboardingArtifacts(workspace)).toBe(true);
+    expect(isFreshOnboardingTarget({}, workspace)).toBe(false);
+    fs.rmSync(workspace, { recursive: true, force: true });
+  });
+
+  it('preserves explicit skipBootstrap config', () => {
+    const config = {
+      agents: {
+        defaults: {
+          skipBootstrap: false,
+        },
+      },
+    };
+
+    expect(hasExplicitSkipBootstrap(config as never)).toBe(true);
+    expect(isFreshOnboardingTarget(config as never, null)).toBe(false);
+  });
+
+  it('enables skipBootstrap on config when requested', () => {
+    const config = {};
+    enableSkipBootstrap(config as never);
+    expect(config).toEqual({
+      agents: {
+        defaults: {
+          skipBootstrap: true,
+        },
+      },
+    });
+  });
+
+  it('skips bootstrap when AutoMem is healthy and non-empty', async () => {
+    const probe = await probeBootstrapBypass({
+      checkHealth: async () => ({
+        status: 'healthy',
+        backend: 'automem',
+        statistics: {},
+      }),
+      recallMemory: async () => ({
+        results: [{ id: 'mem-1', memory: { content: 'Known profile' } }],
+        count: 1,
+      }),
+    });
+
+    expect(probe).toMatchObject({
+      shouldSkipBootstrap: true,
+      healthStatus: 'healthy',
+      memoryCount: 1,
+    });
+  });
+
+  it('leaves bootstrap enabled when AutoMem is healthy but empty', async () => {
+    const probe = await probeBootstrapBypass({
+      checkHealth: async () => ({
+        status: 'healthy',
+        backend: 'automem',
+        statistics: {},
+      }),
+      recallMemory: async () => ({
+        results: [],
+        count: 0,
+      }),
+    });
+
+    expect(probe).toMatchObject({
+      shouldSkipBootstrap: false,
+      healthStatus: 'healthy',
+      memoryCount: 0,
+    });
+  });
+
+  it('leaves bootstrap enabled when AutoMem health fails', async () => {
+    const probe = await probeBootstrapBypass({
+      checkHealth: async () => ({
+        status: 'error',
+        backend: 'automem',
+        statistics: {},
+        error: 'down',
+      }),
+      recallMemory: async () => ({
+        results: [{ id: 'mem-1', memory: { content: 'should not be read' } }],
+        count: 1,
+      }),
+    });
+
+    expect(probe).toMatchObject({
+      shouldSkipBootstrap: false,
+      healthStatus: 'error',
+    });
+  });
+
+  it('hydrates a startup profile from recalled identity cues', async () => {
+    const profile = await hydrateStartupProfile({
+      checkHealth: async () => ({
+        status: 'healthy',
+        backend: 'automem',
+        statistics: {},
+      }),
+      recallMemory: async () => ({
+        results: [
+          {
+            id: 'profile-1',
+            memory: {
+              content: 'Call me Jack. Timezone Berlin. Keep it sharp and direct.',
+              tags: ['profile', 'identity'],
+              type: 'Preference',
+            },
+          },
+        ],
+        count: 1,
+      }),
+    });
+
+    expect(profile).toContain('Call me Jack');
   });
 });

--- a/src/cli/openclaw.ts
+++ b/src/cli/openclaw.ts
@@ -3,7 +3,10 @@ import os from 'os';
 import path from 'path';
 import { execFileSync, execSync } from 'child_process';
 import { fileURLToPath } from 'url';
+import { AutoMemClient } from '../automem-client.js';
 import { readAutoMemApiKeyFromEnv } from '../env.js';
+import { buildDefaultProjectTags } from '../memory-policy/shared.js';
+import { buildStartupProfileFromResults } from '../openclaw-startup-profile.js';
 import { DEFAULT_AUTOMEM_ENDPOINT } from './templates.js';
 
 export type OpenClawSetupMode = 'plugin' | 'mcp' | 'skill';
@@ -21,20 +24,48 @@ interface OpenClawSetupOptions {
   scope: OpenClawSetupScope;
   pluginSource?: string;
   timeoutMs?: number;
+  replaceMemory?: boolean;
 }
 
 type JsonPrimitive = string | number | boolean | null;
 type JsonArray = JsonValue[];
 type JsonObject = { [key: string]: JsonValue | undefined };
 type JsonValue = JsonPrimitive | JsonObject | JsonArray;
+type BootstrapProbeClient = Pick<AutoMemClient, 'checkHealth' | 'recallMemory'>;
+
+type BootstrapBypassProbeResult = {
+  shouldSkipBootstrap: boolean;
+  reason: string;
+  healthStatus: 'healthy' | 'error';
+  memoryCount?: number;
+};
 
 const TEMPLATE_ROOT = path.resolve(
   fileURLToPath(new URL('../../templates/openclaw', import.meta.url))
 );
 const PACKAGE_ROOT = path.resolve(fileURLToPath(new URL('../../package.json', import.meta.url)));
+const BUNDLED_PLUGIN_ROOT = path.resolve(
+  fileURLToPath(new URL('../../dist/openclaw-plugin-package', import.meta.url))
+);
 const DEFAULT_PLUGIN_SOURCE = '@verygoodplugins/mcp-automem';
 const OPENCLAW_PLUGIN_ID = 'automem';
+const OPENCLAW_TOOL_NAMES = [
+  'automem_store_memory',
+  'automem_recall_memory',
+  'automem_update_memory',
+  'automem_delete_memory',
+  'automem_associate_memories',
+  'automem_check_health',
+] as const;
 const SENSITIVE_KEY_PATTERN = /(api[-_]?key|token|secret|authorization)/i;
+const OPENCLAW_ONBOARDING_ARTIFACTS = [
+  'AGENTS.md',
+  'SOUL.md',
+  'TOOLS.md',
+  'BOOTSTRAP.md',
+  'IDENTITY.md',
+  'USER.md',
+];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value));
@@ -221,7 +252,9 @@ function looksLikePath(input: string): boolean {
 }
 
 function resolvePluginSource(input?: string): string {
-  const candidate = input?.trim() || readCurrentPackageName() || DEFAULT_PLUGIN_SOURCE;
+  const candidate =
+    input?.trim() ||
+    (fs.existsSync(BUNDLED_PLUGIN_ROOT) ? BUNDLED_PLUGIN_ROOT : readCurrentPackageName() || DEFAULT_PLUGIN_SOURCE);
   return looksLikePath(candidate) ? resolveTildePath(candidate) : candidate;
 }
 
@@ -245,26 +278,8 @@ function archivePath(targetPath: string): string {
   return candidate;
 }
 
-function sanitizeTag(input: string): string {
-  return input
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .slice(0, 64);
-}
-
-function isAmbiguousProjectSlug(slug: string): boolean {
-  return ['api', 'app', 'test', 'video'].includes(slug);
-}
-
 export function buildDefaultTags(projectName?: string): string[] {
-  const normalizedProjectName = String(projectName || '').replace(/^@.*?\//, '');
-  const sanitized = sanitizeTag(normalizedProjectName);
-  if (!sanitized || isAmbiguousProjectSlug(sanitized)) {
-    return [];
-  }
-  return [sanitized];
+  return buildDefaultProjectTags(projectName);
 }
 
 export function redactSensitiveValue(value: unknown): unknown {
@@ -463,6 +478,7 @@ export function buildPluginConfigEntry(params: {
   endpoint: string;
   apiKey?: string;
   defaultTags: string[];
+  startupProfile?: string;
 }): Record<string, unknown> {
   const existing = isRecord(params.existing) ? params.existing : {};
   const existingConfig = isRecord(existing.config) ? existing.config : {};
@@ -480,15 +496,31 @@ export function buildPluginConfigEntry(params: {
       ...(params.apiKey || existingApiKey ? { apiKey: params.apiKey || existingApiKey } : {}),
       autoRecall:
         typeof existingConfig.autoRecall === 'boolean' ? existingConfig.autoRecall : true,
-      autoRecallLimit:
-        typeof existingConfig.autoRecallLimit === 'number' && Number.isFinite(existingConfig.autoRecallLimit)
-          ? existingConfig.autoRecallLimit
-          : 3,
+      ...(typeof existingConfig.autoRecallLimit === 'number' && Number.isFinite(existingConfig.autoRecallLimit)
+        ? { autoRecallLimit: existingConfig.autoRecallLimit }
+        : {}),
+      ...(typeof existingConfig.preferenceRecallLimit === 'number' &&
+      Number.isFinite(existingConfig.preferenceRecallLimit)
+        ? { preferenceRecallLimit: existingConfig.preferenceRecallLimit }
+        : {}),
+      ...(typeof existingConfig.contextRecallLimit === 'number' &&
+      Number.isFinite(existingConfig.contextRecallLimit)
+        ? { contextRecallLimit: existingConfig.contextRecallLimit }
+        : {}),
+      ...(typeof existingConfig.debugRecallLimit === 'number' &&
+      Number.isFinite(existingConfig.debugRecallLimit)
+        ? { debugRecallLimit: existingConfig.debugRecallLimit }
+        : {}),
+      ...(typeof existingConfig.contextRecallWindowDays === 'number' &&
+      Number.isFinite(existingConfig.contextRecallWindowDays)
+        ? { contextRecallWindowDays: existingConfig.contextRecallWindowDays }
+        : {}),
       exposure:
         typeof existingConfig.exposure === 'string' && existingConfig.exposure.trim()
           ? existingConfig.exposure
           : 'dm-only',
       ...(params.defaultTags.length > 0 ? { defaultTags: params.defaultTags } : {}),
+      ...(params.startupProfile ? { startupProfile: params.startupProfile } : {}),
     },
   };
 }
@@ -540,20 +572,176 @@ export function buildMcporterConfig(params: {
   };
 }
 
-function normalizeSkillEntryForPlugin(existing?: Record<string, unknown>): Record<string, unknown> {
-  const next = isRecord(existing) ? { ...existing } : {};
-  delete next.apiKey;
-  delete next.env;
-  return {
-    ...next,
-    enabled: true,
-  };
-}
-
 function disablePluginEntry(existing?: Record<string, unknown>): Record<string, unknown> {
   const next = isRecord(existing) ? { ...existing } : {};
   next.enabled = false;
   return next;
+}
+
+function disableSkillEntry(existing?: Record<string, unknown>): Record<string, unknown> {
+  const next = isRecord(existing) ? { ...existing } : {};
+  next.enabled = false;
+  return next;
+}
+
+export function enablePluginsCommand(config: JsonObject): void {
+  const commands = isRecord(config.commands) ? { ...config.commands } : {};
+  commands.plugins = true;
+  config.commands = commands as JsonValue;
+}
+
+export function allowPluginWhenAllowlistExists(config: JsonObject, pluginId: string): void {
+  const plugins = isRecord(config.plugins) ? { ...config.plugins } : {};
+  const allow = Array.isArray(plugins.allow)
+    ? plugins.allow.filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
+    : [];
+
+  if (allow.length === 0 || allow.includes(pluginId)) {
+    if (plugins.allow) {
+      config.plugins = plugins as JsonValue;
+    }
+    return;
+  }
+
+  plugins.allow = [...allow, pluginId];
+  config.plugins = plugins as JsonValue;
+}
+
+export function allowAutoMemTools(config: JsonObject): void {
+  const tools = isRecord(config.tools) ? { ...config.tools } : {};
+  const allow = Array.isArray(tools.allow)
+    ? tools.allow.filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
+    : [];
+  const alsoAllow = Array.isArray(tools.alsoAllow)
+    ? tools.alsoAllow.filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0)
+    : [];
+  const normalizedAutoMemTools = new Set(OPENCLAW_TOOL_NAMES);
+  const legacyAutoMemOnlyAllow =
+    allow.length > 0 && allow.every((entry) => normalizedAutoMemTools.has(entry as (typeof OPENCLAW_TOOL_NAMES)[number]));
+
+  if (allow.length > 0 && !legacyAutoMemOnlyAllow) {
+    const nextAllow = [...allow];
+    for (const toolName of OPENCLAW_TOOL_NAMES) {
+      if (!nextAllow.includes(toolName)) {
+        nextAllow.push(toolName);
+      }
+    }
+    tools.allow = nextAllow;
+    config.tools = tools as JsonValue;
+    return;
+  }
+
+  const nextAlsoAllow = [...alsoAllow];
+  for (const toolName of OPENCLAW_TOOL_NAMES) {
+    if (!nextAlsoAllow.includes(toolName)) {
+      nextAlsoAllow.push(toolName);
+    }
+  }
+
+  tools.alsoAllow = nextAlsoAllow;
+  if (legacyAutoMemOnlyAllow || allow.length === 0) {
+    delete tools.allow;
+  }
+  config.tools = tools as JsonValue;
+}
+
+function readAgentDefaults(config: JsonObject): JsonObject {
+  const agents = isRecord(config.agents) ? { ...config.agents } : {};
+  const defaults = isRecord(agents.defaults) ? { ...agents.defaults } : {};
+  agents.defaults = defaults as JsonValue;
+  config.agents = agents as JsonValue;
+  return defaults as JsonObject;
+}
+
+export function hasExplicitSkipBootstrap(config: JsonObject): boolean {
+  const agents = isRecord(config.agents) ? config.agents : undefined;
+  const defaults = isRecord(agents?.defaults) ? agents.defaults : undefined;
+  return typeof defaults?.skipBootstrap === 'boolean';
+}
+
+export function enableSkipBootstrap(config: JsonObject): void {
+  const defaults = readAgentDefaults(config);
+  defaults.skipBootstrap = true;
+}
+
+export function hasOnboardingArtifacts(workspaceDir: string | null): boolean {
+  if (!workspaceDir || !fs.existsSync(workspaceDir)) {
+    return false;
+  }
+
+  return OPENCLAW_ONBOARDING_ARTIFACTS.some((name) =>
+    fs.existsSync(path.join(workspaceDir, name))
+  );
+}
+
+export function isFreshOnboardingTarget(config: JsonObject, workspaceDir: string | null): boolean {
+  if (hasExplicitSkipBootstrap(config)) {
+    return false;
+  }
+
+  return !hasOnboardingArtifacts(workspaceDir);
+}
+
+export async function probeBootstrapBypass(
+  client: BootstrapProbeClient
+): Promise<BootstrapBypassProbeResult> {
+  const health = await client.checkHealth();
+  if (health.status !== 'healthy') {
+    return {
+      shouldSkipBootstrap: false,
+      reason: 'AutoMem is unavailable or unhealthy; leaving bootstrap enabled.',
+      healthStatus: 'error',
+    };
+  }
+
+  try {
+    const recall = await client.recallMemory({
+      limit: 1,
+      sort: 'time_desc',
+      format: 'detailed',
+    });
+
+    const memoryCount = recall.count ?? recall.results?.length ?? 0;
+    if (memoryCount > 0) {
+      return {
+        shouldSkipBootstrap: true,
+        reason: 'AutoMem already has memory for this user; skipping bootstrap.',
+        healthStatus: 'healthy',
+        memoryCount,
+      };
+    }
+
+    return {
+      shouldSkipBootstrap: false,
+      reason: 'AutoMem is reachable but empty; leaving bootstrap enabled.',
+      healthStatus: 'healthy',
+      memoryCount,
+    };
+  } catch (error) {
+    return {
+      shouldSkipBootstrap: false,
+      reason: `AutoMem recall probe failed; leaving bootstrap enabled. ${String(error)}`,
+      healthStatus: 'healthy',
+      memoryCount: 0,
+    };
+  }
+}
+
+export async function hydrateStartupProfile(
+  client: BootstrapProbeClient
+): Promise<string | undefined> {
+  try {
+    const recall = await client.recallMemory({
+      query: 'user name timezone preferred name work style personality tone ongoing context',
+      limit: 5,
+      sort: 'time_desc',
+      format: 'detailed',
+    });
+
+    return buildStartupProfileFromResults(recall.results || [], { maxEntries: 4 });
+  } catch {
+    return undefined;
+  }
 }
 
 function installSkillTemplate(params: {
@@ -620,13 +808,13 @@ function archiveLegacySkillOverrides(workspaceDir: string | null, options: OpenC
 
 function installOpenClawPlugin(pluginSource: string, options: OpenClawSetupOptions) {
   if (options.dryRun) {
-    log(`[DRY RUN] Would run: openclaw plugins install ${pluginSource}`, options.quiet);
+    log(`[DRY RUN] Would run: openclaw plugins install ${pluginSource} --force`, options.quiet);
     return;
   }
 
   const timeout = options.timeoutMs ?? 120_000;
   try {
-    execFileSync('openclaw', ['plugins', 'install', pluginSource], {
+    execFileSync('openclaw', ['plugins', 'install', pluginSource, '--force'], {
       stdio: options.quiet ? 'ignore' : 'inherit',
       env: process.env,
       timeout,
@@ -643,6 +831,52 @@ function installOpenClawPlugin(pluginSource: string, options: OpenClawSetupOptio
   }
 }
 
+export function disableBuiltInMemorySlot(config: JsonObject) {
+  const plugins = isRecord(config.plugins) ? { ...config.plugins } : {};
+  const slots = isRecord(plugins.slots) ? { ...plugins.slots } : {};
+  slots.memory = 'none';
+  plugins.slots = slots as JsonValue;
+  config.plugins = plugins as JsonValue;
+}
+
+export function disableSessionMemoryHook(config: JsonObject) {
+  const hooks = isRecord(config.hooks) ? { ...config.hooks } : {};
+  const internal = isRecord(hooks.internal) ? { ...hooks.internal } : {};
+  const entries = isRecord(internal.entries) ? { ...internal.entries } : {};
+  const sessionMemory = isRecord(entries['session-memory'])
+    ? { ...entries['session-memory'] }
+    : {};
+  sessionMemory.enabled = false;
+  entries['session-memory'] = sessionMemory as JsonValue;
+  internal.entries = entries as JsonValue;
+  hooks.internal = internal as JsonValue;
+  config.hooks = hooks as JsonValue;
+}
+
+export function disableMemoryCoreDreaming(config: JsonObject) {
+  const plugins = isRecord(config.plugins) ? { ...config.plugins } : {};
+  const entries = isRecord(plugins.entries) ? { ...plugins.entries } : {};
+  const memoryCoreEntry = isRecord(entries['memory-core']) ? { ...entries['memory-core'] } : {};
+  const memoryCoreConfig = isRecord(memoryCoreEntry.config) ? { ...memoryCoreEntry.config } : {};
+  const dreaming = isRecord(memoryCoreConfig.dreaming) ? { ...memoryCoreConfig.dreaming } : {};
+  dreaming.enabled = false;
+  memoryCoreConfig.dreaming = dreaming as JsonValue;
+  memoryCoreEntry.config = memoryCoreConfig as JsonValue;
+  entries['memory-core'] = memoryCoreEntry as JsonValue;
+  plugins.entries = entries as JsonValue;
+  config.plugins = plugins as JsonValue;
+}
+
+export function replaceOpenClawMemorySystem(config: JsonObject, options: OpenClawSetupOptions) {
+  disableBuiltInMemorySlot(config);
+  disableSessionMemoryHook(config);
+  disableMemoryCoreDreaming(config);
+  log(
+    'Configured OpenClaw to replace the built-in memory layer: plugins.slots.memory="none", session-memory hook disabled, dreaming disabled.',
+    options.quiet
+  );
+}
+
 function resolveMcporterConfigPath(scope: OpenClawSetupScope, workspaceDir: string | null): string {
   if (scope === 'shared') {
     return path.join(os.homedir(), '.mcporter', 'mcporter.json');
@@ -657,7 +891,7 @@ function updateOpenClawConfig(config: JsonObject, configPath: string, options: O
   writeJsonFileWithBackup(configPath, config, options);
 }
 
-function applyPluginMode(params: {
+async function applyPluginMode(params: {
   config: JsonObject;
   configPath: string;
   workspaceDir: string | null;
@@ -668,29 +902,69 @@ function applyPluginMode(params: {
 }) {
   installOpenClawPlugin(resolvePluginSource(params.options.pluginSource), params.options);
   archiveLegacySkillOverrides(params.workspaceDir, params.options);
+  const client = new AutoMemClient({
+    endpoint: params.endpoint,
+    ...(params.apiKey ? { apiKey: params.apiKey } : {}),
+  });
+  let startupProfile: string | undefined;
 
   const plugins = isRecord(params.config.plugins) ? { ...params.config.plugins } : {};
   const pluginEntries = isRecord(plugins.entries) ? { ...plugins.entries } : {};
   const existingPluginEntry = isRecord(pluginEntries[OPENCLAW_PLUGIN_ID])
     ? (pluginEntries[OPENCLAW_PLUGIN_ID] as Record<string, unknown>)
     : undefined;
+
+  if (hasExplicitSkipBootstrap(params.config)) {
+    log('Preserving existing agents.defaults.skipBootstrap setting.', params.options.quiet);
+  } else if (isFreshOnboardingTarget(params.config, params.workspaceDir)) {
+    const probe = await probeBootstrapBypass(client);
+
+    if (probe.shouldSkipBootstrap) {
+      enableSkipBootstrap(params.config);
+      startupProfile = await hydrateStartupProfile(client);
+      if (startupProfile) {
+        log('Hydrated startup profile from AutoMem for the first OpenClaw turn.', params.options.quiet);
+      }
+      log(
+        `${probe.reason}${probe.memoryCount ? ` (${probe.memoryCount} memory found in probe)` : ''}`,
+        params.options.quiet
+      );
+    } else {
+      log(probe.reason, params.options.quiet);
+    }
+  } else {
+    log(
+      'Existing OpenClaw onboarding files were found; leaving bootstrap settings unchanged.',
+      params.options.quiet
+    );
+  }
+
   pluginEntries[OPENCLAW_PLUGIN_ID] = buildPluginConfigEntry({
     existing: existingPluginEntry,
     endpoint: params.endpoint,
     apiKey: params.apiKey,
     defaultTags: params.defaultTags,
+    startupProfile,
   }) as JsonValue;
   plugins.entries = pluginEntries as JsonValue;
   params.config.plugins = plugins as JsonValue;
+  allowPluginWhenAllowlistExists(params.config, OPENCLAW_PLUGIN_ID);
+  allowAutoMemTools(params.config);
+  enablePluginsCommand(params.config);
+  if (params.options.replaceMemory) {
+    replaceOpenClawMemorySystem(params.config, params.options);
+  }
 
   const skills = isRecord(params.config.skills) ? { ...params.config.skills } : {};
   const skillEntries = isRecord(skills.entries) ? { ...skills.entries } : {};
   const existingSkillEntry = isRecord(skillEntries[OPENCLAW_PLUGIN_ID])
     ? (skillEntries[OPENCLAW_PLUGIN_ID] as Record<string, unknown>)
     : undefined;
-  skillEntries[OPENCLAW_PLUGIN_ID] = normalizeSkillEntryForPlugin(existingSkillEntry) as JsonValue;
-  skills.entries = skillEntries as JsonValue;
-  params.config.skills = skills as JsonValue;
+  if (existingSkillEntry) {
+    skillEntries[OPENCLAW_PLUGIN_ID] = disableSkillEntry(existingSkillEntry) as JsonValue;
+    skills.entries = skillEntries as JsonValue;
+    params.config.skills = skills as JsonValue;
+  }
 
   if (params.options.dryRun) {
     renderConfigEntryForOutput(
@@ -784,7 +1058,7 @@ function applyMcpMode(params: {
 function resolveModeSummary(mode: OpenClawSetupMode): string {
   switch (mode) {
     case 'plugin':
-      return 'native OpenClaw plugin with typed tools and auto-recall hook';
+      return 'lean native OpenClaw plugin with typed tools and auto-recall hook';
     case 'mcp':
       return 'workspace skill plus mcporter stdio server';
     case 'skill':
@@ -818,7 +1092,17 @@ export async function applyOpenClawSetup(cliOptions: OpenClawSetupOptions): Prom
 
   log(`Setting up OpenClaw AutoMem for ${projectName}`, cliOptions.quiet);
   log(`Mode: ${cliOptions.mode} (${resolveModeSummary(cliOptions.mode)})`, cliOptions.quiet);
-  log(`Workspace: ${workspaceDir || '(not required for this run)'}`, cliOptions.quiet);
+  const workspaceSource = cliOptions.workspace
+    ? '(from --workspace)'
+    : process.env.OPENCLAW_WORKSPACE || process.env.CLAWDBOT_WORKSPACE
+      ? '(from env)'
+      : workspaceDir
+        ? '(auto-detected, override with --workspace <path>)'
+        : '';
+  log(
+    `Workspace: ${workspaceDir || '(not required for this run)'}${workspaceSource ? ' ' + workspaceSource : ''}`,
+    cliOptions.quiet
+  );
   if (cliOptions.mode !== 'plugin') {
     log(`Scope: ${cliOptions.scope}`, cliOptions.quiet);
   }
@@ -827,9 +1111,12 @@ export async function applyOpenClawSetup(cliOptions: OpenClawSetupOptions): Prom
     `Default store tags: ${defaultTags.length > 0 ? defaultTags.join(', ') : '(none - semantic recall only)'}`,
     cliOptions.quiet
   );
+  if (cliOptions.replaceMemory) {
+    log('Memory mode: replace built-in OpenClaw memory with AutoMem', cliOptions.quiet);
+  }
 
   if (cliOptions.mode === 'plugin') {
-    applyPluginMode({
+    await applyPluginMode({
       config,
       configPath,
       workspaceDir,
@@ -938,6 +1225,9 @@ export function parseArgs(args: string[]): OpenClawSetupOptions {
           fail('Error: --plugin-source requires an npm spec or path');
         }
         options.pluginSource = args[++i];
+        break;
+      case '--replace-memory':
+        options.replaceMemory = true;
         break;
       case '--dry-run':
         options.dryRun = true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,6 +194,9 @@ CODEX SETUP:
 OPENCLAW SETUP:
   npx @verygoodplugins/mcp-automem openclaw [options]
 
+  Recommended happy path:
+    curl -fsSL https://automem.ai/install.sh | bash
+
   Options:
     --mode <plugin|mcp|skill>   Integration mode (default: plugin)
     --scope <workspace|shared>  Install scope for mcp/skill modes (default: workspace)
@@ -202,6 +205,7 @@ OPENCLAW SETUP:
     --api-key <key>             AutoMem API key (optional)
     --plugin-source <spec>      npm spec or path for plugin installs
     --name <name>               Project name used to seed default memory tags
+    --replace-memory            Disable OpenClaw's built-in memory layer and use AutoMem as the only memory system
     --dry-run                   Show what would be changed
     --quiet                     Suppress output
 

--- a/src/memory-policy.test.ts
+++ b/src/memory-policy.test.ts
@@ -1,0 +1,175 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+import {
+  AUTOMEM_POLICY_ASSOCIATION_MAPPINGS,
+  AUTOMEM_POLICY_DEFAULTS,
+  renderClaudeCodeSessionStartPrompt,
+  renderOpenClawPolicyContext,
+  renderRelationTypesInline,
+} from './memory-policy/shared.js';
+
+const REPO_ROOT = path.resolve(fileURLToPath(new URL('..', import.meta.url)));
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), 'utf8');
+}
+
+function normalize(value: string): string {
+  return value
+    .replace(/[–—]/g, '-')
+    .replace(/[“”]/g, '"')
+    .replace(/[‘’]/g, "'")
+    .replace(/\\`/g, '`')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function extractHeredocBody(fileContents: string): string {
+  const match = fileContents.match(/cat << EOF\n([\s\S]*?)\nEOF/);
+  if (!match) {
+    throw new Error('Could not find heredoc body.');
+  }
+  return match[1];
+}
+
+function expectSharedPolicySurface(source: string) {
+  const normalized = normalize(source);
+  expect(normalized).toContain(`limit: ${AUTOMEM_POLICY_DEFAULTS.preferenceRecallLimit}`);
+  expect(normalized).toContain(`limit: ${AUTOMEM_POLICY_DEFAULTS.contextRecallLimit}`);
+  expect(normalized).toContain(`time_query: "last ${AUTOMEM_POLICY_DEFAULTS.contextRecallWindowDays} days"`);
+  expect(normalized).toContain(`tags: ["bugfix", "solution"]`);
+  expect(normalized).toContain(`limit: ${AUTOMEM_POLICY_DEFAULTS.debugRecallLimit}`);
+  expect(normalized).toContain('topic genuinely shifts');
+  expect(normalized).toContain('proper noun');
+  expect(normalized).toContain('debug');
+  expect(normalized).toContain('INVALIDATED_BY');
+  expect(normalized).toContain('PREFERS_OVER');
+  expect(normalized).toContain('EXEMPLIFIES');
+  expect(normalized).toContain('update_memory');
+  expect(normalized).toMatch(/correct/i);
+  expect(normalized).toMatch(/decision stabil/i);
+  expect(normalized).toMatch(/pattern/i);
+
+  for (const mapping of AUTOMEM_POLICY_ASSOCIATION_MAPPINGS) {
+    const [_, __, relation] = mapping.split(' -> ');
+    expect(normalized).toContain(relation);
+  }
+
+  for (const relationType of renderRelationTypesInline().split(', ')) {
+    expect(normalized).toContain(relationType);
+  }
+}
+
+describe('shared AutoMem memory policy', () => {
+  it('renders the Claude Code session-start prompt from shared defaults', () => {
+    expect(renderClaudeCodeSessionStartPrompt('$PROJECT')).toMatchInlineSnapshot(`
+      "<automem_session_context>
+      MEMORY RECALL - run these phases in order before your first substantive response.
+      
+      Phase 1 - Preferences (tag-only, no time filter, no query):
+        mcp__memory__recall_memory({
+          tags: ["preference"],
+          limit: 20,
+          sort: "updated_desc",
+          format: "detailed"
+        })
+      
+      Phase 2 - Task context (ONE semantic query from the user's actual nouns; project-slug gate when unambiguous; 90-day window):
+        mcp__memory__recall_memory({
+          query: "<proper nouns, product names, tools, specific topics from the user's message>",
+          tags: ["$PROJECT"],    // drop if slug collides with a common word
+          time_query: "last 90 days",
+          limit: 30,
+          format: "detailed"
+        })
+      
+      Phase 3 - ON-DEMAND debugging (only if the user's message is a debugging/error-symptom question; skip otherwise):
+        mcp__memory__recall_memory({
+          query: "<error symptom>",
+          tags: ["bugfix", "solution"],
+          limit: 20
+        })
+      
+      Project slug: $PROJECT
+      
+      Notes:
+      - Tags are a HARD GATE - they filter before scoring. For discovery/debugging across the full corpus, drop \`tags\` and rely on semantic \`query\` alone.
+      - Do NOT use namespace-prefixed tags (\`project/*\`, \`lang/*\`, etc.) - the corpus uses bare tags.
+      - Phase 2 uses ONE targeted query, not \`queries[]\` + \`auto_decompose\`. Sub-queries converge and dedup drops results; a single query built from the real nouns in the user's message wins empirically. Only switch to \`queries[]\` for genuinely multi-topic questions.
+      - If the project slug collides with a common topic word (for example \`video\` or \`test\`), drop the Phase 2 tag gate and rely on semantic \`query\` alone.
+      - Do not re-recall every turn. After turn 1, recall again only for topic shifts, new proper nouns, or active debugging.
+      - If recall fails or returns nothing, continue without memory - do not mention the failure to the user.
+      </automem_session_context>"
+    `);
+  });
+
+  it('renders the OpenClaw policy block from shared defaults', () => {
+    expect(
+      renderOpenClawPolicyContext({
+        defaultTags: ['mcp-automem'],
+      })
+    ).toMatchInlineSnapshot(`
+      "<automem-policy>
+      Use AutoMem with the validated shared policy.
+
+      Recall rules:
+      - First substantive turn: run automem_recall_memory for preferences with tags ["preference"], limit 20, sort "updated_desc", format "detailed". Then run ONE semantic task-context recall using the user's real nouns, time_query "last 90 days", limit 30, format "detailed", and only use the project gate when it is unambiguous.
+      - Active debugging only: run automem_recall_memory with the error symptom, tags ["bugfix", "solution"], and limit 20.
+      - After turn 1, recall again only for topic shifts, new proper nouns, or active debugging. Do not re-recall on routine follow-ups.
+      - If the user explicitly asks what you know about a person, project, or topic, run automem_recall_memory before answering from memory. Do not promise a "live recall" without doing it.
+
+      Tag discipline for tool calls (tags are a hard gate, not a hint):
+      - Valid tag sets for automem_recall_memory: ["preference"], ["bugfix", "solution"], or the project slug (e.g. ["mcp-automem"]). Otherwise drop tags and rely on the query.
+      - Never invent topic-word tags from the prompt (e.g. ["voiceink", "autohub"]). Put those nouns in query, not tags.
+      - Bare strings only. No namespace prefixes (project/*, lang/*), no platform tags (cursor, claude-code), no date-stamped tags.
+
+      Mid-conversation stores fire the atomic ritual on exactly these three triggers. Listen for the trigger phrases; do not queue stores for session-end.
+
+      1. User correction or override.
+         Listen for: "actually", "no, I prefer", "not X, Y", "that's wrong", "stop doing X", "never do X", "I told you before", "we decided X already".
+         -> automem_store_memory as Preference, importance 0.9, confidence 0.95, include "correction" in tags. Then automem_associate_memories INVALIDATED_BY the old memory (strength 0.9). Fire this turn, not later.
+
+      2. Stabilized decision (survived at least one round of discussion).
+         Listen for: "let's go with X", "yeah that's the plan", "ship it", "do it that way", "final answer", "okay let's do that".
+         -> automem_store_memory as Decision, importance 0.85-0.9. Then automem_associate_memories PREFERS_OVER any alternatives that came up.
+
+      3. Articulated pattern (user names it, you do not infer it).
+         Listen for: "I always do X", "every time", "this is how I usually", "my thing is".
+         -> automem_store_memory as Pattern, importance 0.8. Then automem_associate_memories EXEMPLIFIES concrete examples.
+
+      Storage ritual (every store runs all four steps):
+        (1) Pre-recall automem_recall_memory with a tight query, limit 5, to find the related memory.
+        (2) automem_store_memory with type, importance, confidence, bare tags.
+        (3) Verify with automem_recall_memory on a distinctive phrase from the content. Retry the store once if verify misses (known server quirk).
+        (4) automem_associate_memories to the step-1 hit. Skip only if nothing plausible came back.
+
+      Prefer automem_update_memory over a duplicate store when a fact changes in place.
+      Valid relation types for automem_associate_memories: RELATES_TO, LEADS_TO, OCCURRED_BEFORE, PREFERS_OVER, EXEMPLIFIES, CONTRADICTS, REINFORCES, INVALIDATED_BY, EVOLVED_INTO, DERIVED_FROM, PART_OF.
+      Never store: session summaries, agent task-result dumps, attentiveness notes, speculative context, or confirmations ("great, that worked"). Memory is for future-you, not performance.
+
+      Project gate for first-turn task-context recall: mcp-automem
+      </automem-policy>"
+    `);
+  });
+
+  it('keeps the Claude Code session-start hook aligned with the shared renderer', () => {
+    const hookContents = readRepoFile('templates/claude-code/hooks/automem-session-start.sh');
+    expect(normalize(extractHeredocBody(hookContents))).toBe(
+      normalize(renderClaudeCodeSessionStartPrompt('$PROJECT'))
+    );
+  });
+
+  it('keeps the Cursor template aligned with the shared defaults', () => {
+    expectSharedPolicySurface(readRepoFile('templates/cursor/automem.mdc.template'));
+  });
+
+  it('keeps the Claude Desktop instructions aligned with the shared defaults', () => {
+    expectSharedPolicySurface(readRepoFile('templates/CLAUDE_DESKTOP_INSTRUCTIONS.md'));
+  });
+
+  it('keeps the Codex memory rules aligned with the shared defaults', () => {
+    expectSharedPolicySurface(readRepoFile('templates/codex/memory-rules.md'));
+  });
+});

--- a/src/memory-policy/shared.ts
+++ b/src/memory-policy/shared.ts
@@ -25,7 +25,7 @@ const CASUAL_OPENING_PATTERN =
 const DEBUG_PROMPT_PATTERN =
   /(error|exception|traceback|stack trace|stacktrace|failing|fails|failed|failure|bug|regression|crash|broken|debug|investigat|not work|doesn't work|does not work|cannot|can't|fix)/i;
 const EXPLICIT_RECALL_PROMPT_PATTERN =
-  /(what do (you|we) (have|know) about|tell me about|who is|who's|do you remember|remember|recall|search memory|check memory|look in memory|have we spoken about|what do you have on)/i;
+  /(what do (you|we) (have|know) about|what do you remember about|tell me about|who is|who's|do you remember|remember when|recall|search memory|check memory|look in memory|have we spoken about|what do you have on)/i;
 
 type ToolNames = {
   recall: string;
@@ -128,9 +128,17 @@ export function renderClaudeCodeSessionStartPrompt(projectExpression: string): s
   ].join('\n');
 }
 
+export type OpenClawPolicyLimits = {
+  preferenceRecallLimit?: number;
+  contextRecallLimit?: number;
+  debugRecallLimit?: number;
+  contextRecallWindowDays?: number;
+};
+
 export function renderOpenClawPolicyContext(params: {
   defaultTags: string[];
   tools?: Partial<ToolNames>;
+  limits?: OpenClawPolicyLimits;
 }): string {
   const tools: ToolNames = {
     recall: params.tools?.recall || 'automem_recall_memory',
@@ -138,6 +146,13 @@ export function renderOpenClawPolicyContext(params: {
     update: params.tools?.update || 'automem_update_memory',
     associate: params.tools?.associate || 'automem_associate_memories',
   };
+  const preferenceLimit =
+    params.limits?.preferenceRecallLimit ?? AUTOMEM_POLICY_DEFAULTS.preferenceRecallLimit;
+  const contextLimit =
+    params.limits?.contextRecallLimit ?? AUTOMEM_POLICY_DEFAULTS.contextRecallLimit;
+  const debugLimit = params.limits?.debugRecallLimit ?? AUTOMEM_POLICY_DEFAULTS.debugRecallLimit;
+  const windowDays =
+    params.limits?.contextRecallWindowDays ?? AUTOMEM_POLICY_DEFAULTS.contextRecallWindowDays;
   const projectGate = resolveProjectGateTags(params.defaultTags);
   const projectGateLine = projectGate
     ? `Project gate for first-turn task-context recall: ${projectGate.join(', ')}`
@@ -149,8 +164,8 @@ export function renderOpenClawPolicyContext(params: {
     'Use AutoMem with the validated shared policy.',
     '',
     'Recall rules:',
-    `- First substantive turn: run ${tools.recall} for preferences with tags ["preference"], limit ${AUTOMEM_POLICY_DEFAULTS.preferenceRecallLimit}, sort "updated_desc", format "detailed". Then run ONE semantic task-context recall using the user's real nouns, time_query "last ${AUTOMEM_POLICY_DEFAULTS.contextRecallWindowDays} days", limit ${AUTOMEM_POLICY_DEFAULTS.contextRecallLimit}, format "detailed", and only use the project gate when it is unambiguous.`,
-    `- Active debugging only: run ${tools.recall} with the error symptom, tags ["bugfix", "solution"], and limit ${AUTOMEM_POLICY_DEFAULTS.debugRecallLimit}.`,
+    `- First substantive turn: run ${tools.recall} for preferences with tags ["preference"], limit ${preferenceLimit}, sort "updated_desc", format "detailed". Then run ONE semantic task-context recall using the user's real nouns, time_query "last ${windowDays} days", limit ${contextLimit}, format "detailed", and only use the project gate when it is unambiguous.`,
+    `- Active debugging only: run ${tools.recall} with the error symptom, tags ["bugfix", "solution"], and limit ${debugLimit}.`,
     '- After turn 1, recall again only for topic shifts, new proper nouns, or active debugging. Do not re-recall on routine follow-ups.',
     `- If the user explicitly asks what you know about a person, project, or topic, run ${tools.recall} before answering from memory. Do not promise a "live recall" without doing it.`,
     '',

--- a/src/memory-policy/shared.ts
+++ b/src/memory-policy/shared.ts
@@ -149,7 +149,7 @@ export function renderOpenClawPolicyContext(params: {
     'Use AutoMem with the validated shared policy.',
     '',
     'Recall rules:',
-    `- First substantive turn: run ${tools.recall} for preferences with tags ["preference"], limit ${AUTOMEM_POLICY_DEFAULTS.preferenceRecallLimit}, sort "updated_desc", format "detailed". Then run ONE semantic task-context recall using the user\'s real nouns, time_query "last ${AUTOMEM_POLICY_DEFAULTS.contextRecallWindowDays} days", limit ${AUTOMEM_POLICY_DEFAULTS.contextRecallLimit}, format "detailed", and only use the project gate when it is unambiguous.`,
+    `- First substantive turn: run ${tools.recall} for preferences with tags ["preference"], limit ${AUTOMEM_POLICY_DEFAULTS.preferenceRecallLimit}, sort "updated_desc", format "detailed". Then run ONE semantic task-context recall using the user's real nouns, time_query "last ${AUTOMEM_POLICY_DEFAULTS.contextRecallWindowDays} days", limit ${AUTOMEM_POLICY_DEFAULTS.contextRecallLimit}, format "detailed", and only use the project gate when it is unambiguous.`,
     `- Active debugging only: run ${tools.recall} with the error symptom, tags ["bugfix", "solution"], and limit ${AUTOMEM_POLICY_DEFAULTS.debugRecallLimit}.`,
     '- After turn 1, recall again only for topic shifts, new proper nouns, or active debugging. Do not re-recall on routine follow-ups.',
     `- If the user explicitly asks what you know about a person, project, or topic, run ${tools.recall} before answering from memory. Do not promise a "live recall" without doing it.`,

--- a/src/memory-policy/shared.ts
+++ b/src/memory-policy/shared.ts
@@ -1,0 +1,193 @@
+import { AUTHORABLE_RELATION_TYPES } from '../types.js';
+
+export const AUTOMEM_POLICY_DEFAULTS = {
+  preferenceRecallLimit: 20,
+  contextRecallLimit: 30,
+  debugRecallLimit: 20,
+  contextRecallWindowDays: 90,
+} as const;
+
+export const AUTOMEM_POLICY_TRIGGER_HEADINGS = [
+  '1. User correction or override.',
+  '2. Decision stabilizes after at least one round of discussion.',
+  '3. Pattern articulated - not inferred.',
+] as const;
+
+export const AUTOMEM_POLICY_ASSOCIATION_MAPPINGS = [
+  'User correction -> Preference -> INVALIDATED_BY',
+  'Architectural decision -> Decision -> PREFERS_OVER',
+  'Pattern discovered -> Pattern -> EXEMPLIFIES',
+] as const;
+
+const AMBIGUOUS_PROJECT_TAGS = new Set(['api', 'app', 'test', 'video']);
+const CASUAL_OPENING_PATTERN =
+  /^(hi|hello|hey|yo|sup|thanks|thank you|ok|okay|cool|nice|great|ping|test|who are you)\b/i;
+const DEBUG_PROMPT_PATTERN =
+  /(error|exception|traceback|stack trace|stacktrace|failing|fails|failed|failure|bug|regression|crash|broken|debug|investigat|not work|doesn't work|does not work|cannot|can't|fix)/i;
+const EXPLICIT_RECALL_PROMPT_PATTERN =
+  /(what do (you|we) (have|know) about|tell me about|who is|who's|do you remember|remember|recall|search memory|check memory|look in memory|have we spoken about|what do you have on)/i;
+
+type ToolNames = {
+  recall: string;
+  store: string;
+  update: string;
+  associate: string;
+};
+
+function normalizeProjectTag(tag: string): string {
+  return tag
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64);
+}
+
+export function isAmbiguousProjectTag(tag: string): boolean {
+  return AMBIGUOUS_PROJECT_TAGS.has(normalizeProjectTag(tag));
+}
+
+export function buildDefaultProjectTags(projectName?: string): string[] {
+  const normalizedProjectName = String(projectName || '').replace(/^@.*?\//, '');
+  const sanitized = normalizeProjectTag(normalizedProjectName);
+  if (!sanitized || isAmbiguousProjectTag(sanitized)) {
+    return [];
+  }
+  return [sanitized];
+}
+
+export function resolveProjectGateTags(defaultTags: string[]): string[] | undefined {
+  const normalized = defaultTags
+    .map((tag) => normalizeProjectTag(tag))
+    .filter((tag) => tag && !isAmbiguousProjectTag(tag));
+  const deduped = [...new Set(normalized)];
+  return deduped.length > 0 ? deduped : undefined;
+}
+
+export function isSubstantivePrompt(prompt: string): boolean {
+  const normalized = String(prompt || '').replace(/\s+/g, ' ').trim();
+  if (!normalized) {
+    return false;
+  }
+
+  const wordCount = normalized.split(' ').filter(Boolean).length;
+  if (CASUAL_OPENING_PATTERN.test(normalized) && wordCount <= 4) {
+    return false;
+  }
+
+  return wordCount >= 3 || DEBUG_PROMPT_PATTERN.test(normalized) || /[?]/.test(normalized);
+}
+
+export function looksLikeDebugPrompt(prompt: string): boolean {
+  return DEBUG_PROMPT_PATTERN.test(String(prompt || ''));
+}
+
+export function looksLikeExplicitRecallPrompt(prompt: string): boolean {
+  return EXPLICIT_RECALL_PROMPT_PATTERN.test(String(prompt || ''));
+}
+
+export function renderClaudeCodeSessionStartPrompt(projectExpression: string): string {
+  return [
+    '<automem_session_context>',
+    'MEMORY RECALL - run these phases in order before your first substantive response.',
+    '',
+    'Phase 1 - Preferences (tag-only, no time filter, no query):',
+    '  mcp__memory__recall_memory({',
+    '    tags: ["preference"],',
+    `    limit: ${AUTOMEM_POLICY_DEFAULTS.preferenceRecallLimit},`,
+    '    sort: "updated_desc",',
+    '    format: "detailed"',
+    '  })',
+    '',
+    'Phase 2 - Task context (ONE semantic query from the user\'s actual nouns; project-slug gate when unambiguous; 90-day window):',
+    '  mcp__memory__recall_memory({',
+    '    query: "<proper nouns, product names, tools, specific topics from the user\'s message>",',
+    `    tags: ["${projectExpression}"],    // drop if slug collides with a common word`,
+    `    time_query: "last ${AUTOMEM_POLICY_DEFAULTS.contextRecallWindowDays} days",`,
+    `    limit: ${AUTOMEM_POLICY_DEFAULTS.contextRecallLimit},`,
+    '    format: "detailed"',
+    '  })',
+    '',
+    'Phase 3 - ON-DEMAND debugging (only if the user\'s message is a debugging/error-symptom question; skip otherwise):',
+    '  mcp__memory__recall_memory({',
+    '    query: "<error symptom>",',
+    '    tags: ["bugfix", "solution"],',
+    `    limit: ${AUTOMEM_POLICY_DEFAULTS.debugRecallLimit}`,
+    '  })',
+    '',
+    `Project slug: ${projectExpression}`,
+    '',
+    'Notes:',
+    '- Tags are a HARD GATE - they filter before scoring. For discovery/debugging across the full corpus, drop `tags` and rely on semantic `query` alone.',
+    '- Do NOT use namespace-prefixed tags (`project/*`, `lang/*`, etc.) - the corpus uses bare tags.',
+    '- Phase 2 uses ONE targeted query, not `queries[]` + `auto_decompose`. Sub-queries converge and dedup drops results; a single query built from the real nouns in the user\'s message wins empirically. Only switch to `queries[]` for genuinely multi-topic questions.',
+    '- If the project slug collides with a common topic word (for example `video` or `test`), drop the Phase 2 tag gate and rely on semantic `query` alone.',
+    '- Do not re-recall every turn. After turn 1, recall again only for topic shifts, new proper nouns, or active debugging.',
+    '- If recall fails or returns nothing, continue without memory - do not mention the failure to the user.',
+    '</automem_session_context>',
+  ].join('\n');
+}
+
+export function renderOpenClawPolicyContext(params: {
+  defaultTags: string[];
+  tools?: Partial<ToolNames>;
+}): string {
+  const tools: ToolNames = {
+    recall: params.tools?.recall || 'automem_recall_memory',
+    store: params.tools?.store || 'automem_store_memory',
+    update: params.tools?.update || 'automem_update_memory',
+    associate: params.tools?.associate || 'automem_associate_memories',
+  };
+  const projectGate = resolveProjectGateTags(params.defaultTags);
+  const projectGateLine = projectGate
+    ? `Project gate for first-turn task-context recall: ${projectGate.join(', ')}`
+    : 'Project gate for first-turn task-context recall: none - use semantic query only.';
+  const projectSlugHint = projectGate ? `"${projectGate[0]}"` : '"your-project-slug"';
+
+  return [
+    '<automem-policy>',
+    'Use AutoMem with the validated shared policy.',
+    '',
+    'Recall rules:',
+    `- First substantive turn: run ${tools.recall} for preferences with tags ["preference"], limit ${AUTOMEM_POLICY_DEFAULTS.preferenceRecallLimit}, sort "updated_desc", format "detailed". Then run ONE semantic task-context recall using the user\'s real nouns, time_query "last ${AUTOMEM_POLICY_DEFAULTS.contextRecallWindowDays} days", limit ${AUTOMEM_POLICY_DEFAULTS.contextRecallLimit}, format "detailed", and only use the project gate when it is unambiguous.`,
+    `- Active debugging only: run ${tools.recall} with the error symptom, tags ["bugfix", "solution"], and limit ${AUTOMEM_POLICY_DEFAULTS.debugRecallLimit}.`,
+    '- After turn 1, recall again only for topic shifts, new proper nouns, or active debugging. Do not re-recall on routine follow-ups.',
+    `- If the user explicitly asks what you know about a person, project, or topic, run ${tools.recall} before answering from memory. Do not promise a "live recall" without doing it.`,
+    '',
+    'Tag discipline for tool calls (tags are a hard gate, not a hint):',
+    `- Valid tag sets for ${tools.recall}: ["preference"], ["bugfix", "solution"], or the project slug (e.g. [${projectSlugHint}]). Otherwise drop tags and rely on the query.`,
+    '- Never invent topic-word tags from the prompt (e.g. ["voiceink", "autohub"]). Put those nouns in query, not tags.',
+    '- Bare strings only. No namespace prefixes (project/*, lang/*), no platform tags (cursor, claude-code), no date-stamped tags.',
+    '',
+    'Mid-conversation stores fire the atomic ritual on exactly these three triggers. Listen for the trigger phrases; do not queue stores for session-end.',
+    '',
+    '1. User correction or override.',
+    '   Listen for: "actually", "no, I prefer", "not X, Y", "that\'s wrong", "stop doing X", "never do X", "I told you before", "we decided X already".',
+    `   -> ${tools.store} as Preference, importance 0.9, confidence 0.95, include "correction" in tags. Then ${tools.associate} INVALIDATED_BY the old memory (strength 0.9). Fire this turn, not later.`,
+    '',
+    '2. Stabilized decision (survived at least one round of discussion).',
+    '   Listen for: "let\'s go with X", "yeah that\'s the plan", "ship it", "do it that way", "final answer", "okay let\'s do that".',
+    `   -> ${tools.store} as Decision, importance 0.85-0.9. Then ${tools.associate} PREFERS_OVER any alternatives that came up.`,
+    '',
+    '3. Articulated pattern (user names it, you do not infer it).',
+    '   Listen for: "I always do X", "every time", "this is how I usually", "my thing is".',
+    `   -> ${tools.store} as Pattern, importance 0.8. Then ${tools.associate} EXEMPLIFIES concrete examples.`,
+    '',
+    'Storage ritual (every store runs all four steps):',
+    `  (1) Pre-recall ${tools.recall} with a tight query, limit 5, to find the related memory.`,
+    `  (2) ${tools.store} with type, importance, confidence, bare tags.`,
+    `  (3) Verify with ${tools.recall} on a distinctive phrase from the content. Retry the store once if verify misses (known server quirk).`,
+    `  (4) ${tools.associate} to the step-1 hit. Skip only if nothing plausible came back.`,
+    '',
+    `Prefer ${tools.update} over a duplicate store when a fact changes in place.`,
+    `Valid relation types for ${tools.associate}: ${AUTHORABLE_RELATION_TYPES.join(', ')}.`,
+    'Never store: session summaries, agent task-result dumps, attentiveness notes, speculative context, or confirmations ("great, that worked"). Memory is for future-you, not performance.',
+    '',
+    projectGateLine,
+    '</automem-policy>',
+  ].join('\n');
+}
+
+export function renderRelationTypesInline(): string {
+  return AUTHORABLE_RELATION_TYPES.join(', ');
+}

--- a/src/openclaw-plugin.test.ts
+++ b/src/openclaw-plugin.test.ts
@@ -1,0 +1,516 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import openClawPlugin, {
+  isLikelyStartupTurn,
+  resetOpenClawSessionStateForTests,
+} from './openclaw-plugin.js';
+import {
+  buildOpenClawStartupContext,
+  looksLikeOpenClawProfileCue,
+} from './openclaw-startup-profile.js';
+
+const mockFetch = vi.fn();
+
+function jsonResponse(payload: unknown) {
+  return {
+    ok: true,
+    json: async () => payload,
+  } as Response;
+}
+
+function registerBeforePromptHandler(params?: {
+  config?: unknown;
+  pluginConfig?: Record<string, unknown>;
+}) {
+  const handlers: Array<
+    (event: { prompt: string; messages: unknown[] }, ctx: { sessionKey?: string }) => Promise<{ prependSystemContext?: string } | void>
+  > = [];
+
+  openClawPlugin.register({
+    config: params?.config,
+    pluginConfig: {
+      endpoint: 'http://localhost:8001',
+      autoRecall: true,
+      exposure: 'dm-only',
+      ...(params?.pluginConfig || {}),
+    },
+    logger: { warn: vi.fn() },
+    registerTool: vi.fn(),
+    on: (_hookName, handler) => {
+      handlers.push(handler);
+    },
+  });
+
+  expect(handlers).toHaveLength(1);
+  return handlers[0];
+}
+
+function getRequestUrl(callIndex: number): URL {
+  return new URL(String(mockFetch.mock.calls[callIndex]?.[0]));
+}
+
+describe('openclaw AutoMem plugin', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+    vi.clearAllMocks();
+    resetOpenClawSessionStateForTests();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetAllMocks();
+  });
+
+  it('recognizes likely startup turns', () => {
+    expect(isLikelyStartupTurn([])).toBe(true);
+    expect(isLikelyStartupTurn([{}])).toBe(true);
+    expect(isLikelyStartupTurn([{}, {}])).toBe(false);
+  });
+
+  it('detects profile-like memories', () => {
+    expect(
+      looksLikeOpenClawProfileCue({
+        memory: {
+          content: 'Call me Jack. Timezone Berlin.',
+          tags: ['identity'],
+        },
+      })
+    ).toBe(true);
+
+    expect(
+      looksLikeOpenClawProfileCue({
+        memory: {
+          content: 'Shipped the TypeScript refactor.',
+          tags: ['release'],
+        },
+      })
+    ).toBe(false);
+  });
+
+  it('builds generic startup guidance when no profile cue is present', () => {
+    const context = buildOpenClawStartupContext({
+      startupResults: [
+        {
+          memory: {
+            content: 'Recent work on plugin install flow.',
+            tags: ['openclaw'],
+          },
+        },
+      ],
+    });
+
+    expect(context).toContain('Do not run a bootstrap questionnaire');
+    expect(context).toContain('Use a generic greeting');
+  });
+
+  it('performs startup recall on first turn when bootstrap is skipped', async () => {
+    const handler = registerBeforePromptHandler({
+      config: {
+        agents: {
+          defaults: {
+            skipBootstrap: true,
+          },
+        },
+      },
+      pluginConfig: {
+        defaultTags: ['mcp-automem'],
+        startupProfile: '- [Preference] Call me Jack. Keep it sharp and direct. [tags: profile]',
+      },
+    });
+
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        results: [
+          {
+            id: 'mem-profile',
+            memory: {
+              content: 'Call me Jack. Timezone Berlin. Keep it sharp and direct.',
+              tags: ['profile', 'identity'],
+              type: 'Preference',
+            },
+          },
+        ],
+        count: 1,
+      })
+    );
+
+    const result = await handler(
+      {
+        prompt: 'hi',
+        messages: [{ role: 'user', content: 'hi' }],
+      },
+      {}
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(getRequestUrl(0).searchParams.get('limit')).toBe('20');
+    expect(result?.prependSystemContext).toContain('<automem-policy>');
+    expect(result?.prependSystemContext).toContain('<automem-startup>');
+    expect(result?.prependSystemContext).toContain('Cached startup profile');
+    expect(result?.prependSystemContext).toContain('Call me Jack');
+    expect(result?.prependSystemContext).not.toContain('<relevant-memories>');
+  });
+
+  it('recalls preferences and first-turn context using the project gate when unambiguous', async () => {
+    const handler = registerBeforePromptHandler({
+      pluginConfig: {
+        defaultTags: ['mcp-automem'],
+      },
+    });
+
+    mockFetch
+      .mockResolvedValueOnce(
+        jsonResponse({
+          results: [
+            {
+              id: 'pref-1',
+              memory: {
+                content: 'User prefers concise replies.',
+                tags: ['preference'],
+                type: 'Preference',
+              },
+            },
+          ],
+          count: 1,
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          results: [
+            {
+              id: 'ctx-1',
+              memory: {
+                content: 'Railway deploy work for mcp-automem.',
+                tags: ['mcp-automem'],
+                type: 'Context',
+              },
+            },
+          ],
+          count: 1,
+        })
+      );
+
+    const result = await handler(
+      {
+        prompt: 'Finish the Railway deploy flow for mcp-automem',
+        messages: [{ role: 'user', content: 'Finish the Railway deploy flow for mcp-automem' }],
+      },
+      {}
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    const preferenceUrl = getRequestUrl(0);
+    expect(preferenceUrl.searchParams.getAll('tags')).toEqual(['preference']);
+    expect(preferenceUrl.searchParams.get('limit')).toBe('20');
+    expect(preferenceUrl.searchParams.get('sort')).toBe('updated_desc');
+    expect(preferenceUrl.searchParams.get('format')).toBe('detailed');
+
+    const contextUrl = getRequestUrl(1);
+    expect(contextUrl.searchParams.get('query')).toBe('Finish the Railway deploy flow for mcp-automem');
+    expect(contextUrl.searchParams.getAll('tags')).toEqual(['mcp-automem']);
+    expect(contextUrl.searchParams.get('time_query')).toBe('last 90 days');
+    expect(contextUrl.searchParams.get('limit')).toBe('30');
+    expect(contextUrl.searchParams.get('format')).toBe('detailed');
+
+    expect(result?.prependSystemContext).toContain('<automem-policy>');
+    expect(result?.prependSystemContext).toContain('<relevant-memories>');
+    expect(result?.prependSystemContext).toContain('INVALIDATED_BY');
+    expect(result?.prependSystemContext).toContain('PREFERS_OVER');
+    expect(result?.prependSystemContext).toContain('EXEMPLIFIES');
+    expect(result?.prependSystemContext).toContain('automem_update_memory');
+  });
+
+  it('falls back to semantic-only context recall when default tags are ambiguous', async () => {
+    const handler = registerBeforePromptHandler({
+      pluginConfig: {
+        defaultTags: ['video'],
+      },
+    });
+
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ results: [], count: 0 }))
+      .mockResolvedValueOnce(jsonResponse({ results: [], count: 0 }));
+
+    await handler(
+      {
+        prompt: 'Plan the video onboarding launch',
+        messages: [{ role: 'user', content: 'Plan the video onboarding launch' }],
+      },
+      {}
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(getRequestUrl(1).searchParams.getAll('tags')).toEqual([]);
+  });
+
+  it('does not auto-recall on ordinary follow-up turns', async () => {
+    const handler = registerBeforePromptHandler({
+      pluginConfig: {
+        defaultTags: ['mcp-automem'],
+      },
+    });
+
+    const result = await handler(
+      {
+        prompt: 'Ship the next docs update',
+        messages: [{ role: 'user' }, { role: 'assistant' }],
+      },
+      {}
+    );
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result?.prependSystemContext).toContain('<automem-policy>');
+    expect(result?.prependSystemContext).not.toContain('<relevant-memories>');
+  });
+
+  it('returns policy via prependSystemContext when exposure is off', async () => {
+    const handler = registerBeforePromptHandler({
+      pluginConfig: {
+        defaultTags: ['mcp-automem'],
+        exposure: 'off',
+      },
+    });
+
+    const result = (await handler(
+      {
+        prompt: 'Hey, starting fresh in mcp-automem',
+        messages: [{ role: 'user', content: 'Hey, starting fresh in mcp-automem' }],
+      },
+      {}
+    )) as Record<string, unknown> | undefined;
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result?.prependSystemContext).toContain('<automem-policy>');
+    expect(result).not.toHaveProperty('prependContext');
+  });
+
+  it('returns policy via prependSystemContext on channel/group sessionKeys (dm-only exposure)', async () => {
+    const handler = registerBeforePromptHandler({
+      pluginConfig: {
+        defaultTags: ['mcp-automem'],
+      },
+    });
+
+    const result = (await handler(
+      {
+        prompt: 'team update on mcp-automem',
+        messages: [{ role: 'user', content: 'team update on mcp-automem' }],
+      },
+      { sessionKey: 'slack:group:eng-automation:channel:general' }
+    )) as Record<string, unknown> | undefined;
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result?.prependSystemContext).toContain('<automem-policy>');
+    expect(result).not.toHaveProperty('prependContext');
+  });
+
+  it('returns policy via prependSystemContext on hook: sessions (dm-only exposure)', async () => {
+    const handler = registerBeforePromptHandler({
+      pluginConfig: {
+        defaultTags: ['mcp-automem'],
+      },
+    });
+
+    const result = (await handler(
+      {
+        prompt: 'post-commit capture',
+        messages: [{ role: 'user', content: 'post-commit capture' }],
+      },
+      { sessionKey: 'hook:post-commit' }
+    )) as Record<string, unknown> | undefined;
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result?.prependSystemContext).toContain('<automem-policy>');
+    expect(result).not.toHaveProperty('prependContext');
+  });
+
+  it('runs semantic recall on explicit mid-conversation memory probes', async () => {
+    const handler = registerBeforePromptHandler({
+      pluginConfig: {
+        defaultTags: ['mcp-automem'],
+      },
+    });
+
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        results: [
+          {
+            id: 'person-1',
+            memory: {
+              content: 'Sonya helped with the Hermes rollout.',
+              tags: ['people'],
+              type: 'Context',
+            },
+          },
+        ],
+        count: 1,
+      })
+    );
+
+    const result = await handler(
+      {
+        prompt: 'What do you have on Sonya?',
+        messages: [{ role: 'user' }, { role: 'assistant' }],
+      },
+      { sessionKey: 'dm:test' }
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const recallUrl = getRequestUrl(0);
+    expect(recallUrl.searchParams.get('query')).toBe('What do you have on Sonya?');
+    expect(recallUrl.searchParams.getAll('tags')).toEqual([]);
+    expect(recallUrl.searchParams.get('time_query')).toBe('last 90 days');
+    expect(result?.prependSystemContext).toContain('<relevant-memories>');
+  });
+
+  it('runs semantic recall on later turns when a new named entity appears', async () => {
+    const handler = registerBeforePromptHandler({
+      pluginConfig: {
+        defaultTags: ['mcp-automem'],
+      },
+    });
+
+    const initialResult = await handler(
+      {
+        prompt: 'continue the installer work',
+        messages: [{ role: 'user' }, { role: 'assistant' }],
+      },
+      { sessionKey: 'dm:test' }
+    );
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(initialResult?.prependSystemContext).not.toContain('<relevant-memories>');
+
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        results: [
+          {
+            id: 'entity-1',
+            memory: {
+              content: 'Hermes is the next client integration target.',
+              tags: ['planning'],
+              type: 'Decision',
+            },
+          },
+        ],
+        count: 1,
+      })
+    );
+
+    const nextResult = await handler(
+      {
+        prompt: 'What do you think about doing this with Hermes next?',
+        messages: [{ role: 'user' }, { role: 'assistant' }],
+      },
+      { sessionKey: 'dm:test' }
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const recallUrl = getRequestUrl(0);
+    expect(recallUrl.searchParams.get('query')).toBe('What do you think about doing this with Hermes next?');
+    expect(recallUrl.searchParams.getAll('tags')).toEqual([]);
+    expect(nextResult?.prependSystemContext).toContain('<relevant-memories>');
+  });
+
+  it('runs debug recall on later error-investigation turns', async () => {
+    const handler = registerBeforePromptHandler({
+      pluginConfig: {
+        defaultTags: ['mcp-automem'],
+      },
+    });
+
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        results: [
+          {
+            id: 'bug-1',
+            memory: {
+              content: 'Fixed the Railway deploy traceback by resetting the plugin source.',
+              tags: ['bugfix', 'solution'],
+              type: 'Insight',
+            },
+          },
+        ],
+        count: 1,
+      })
+    );
+
+    const result = await handler(
+      {
+        prompt: 'I am debugging a traceback in the Railway deploy flow',
+        messages: [{ role: 'user' }, { role: 'assistant' }],
+      },
+      {}
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const debugUrl = getRequestUrl(0);
+    expect(debugUrl.searchParams.getAll('tags')).toEqual(['bugfix', 'solution']);
+    expect(debugUrl.searchParams.get('limit')).toBe('20');
+    expect(result?.prependSystemContext).toContain('<relevant-memories>');
+  });
+
+  it('uses legacy autoRecallLimit as the fallback for all recall phases', async () => {
+    const handler = registerBeforePromptHandler({
+      pluginConfig: {
+        autoRecallLimit: 8,
+        defaultTags: ['mcp-automem'],
+      },
+    });
+
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse({ results: [], count: 0 }))
+      .mockResolvedValueOnce(jsonResponse({ results: [], count: 0 }));
+
+    await handler(
+      {
+        prompt: 'Review the mcp-automem release process',
+        messages: [{ role: 'user', content: 'Review the mcp-automem release process' }],
+      },
+      {}
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(getRequestUrl(0).searchParams.get('limit')).toBe('8');
+    expect(getRequestUrl(1).searchParams.get('limit')).toBe('8');
+  });
+
+  it('falls back to a generic greeting when startup recall has no profile cues', async () => {
+    const handler = registerBeforePromptHandler({
+      config: {
+        agents: {
+          defaults: {
+            skipBootstrap: true,
+          },
+        },
+      },
+    });
+
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        results: [
+          {
+            id: 'mem-work',
+            memory: {
+              content: 'Recent work on onboarding docs.',
+              tags: ['openclaw'],
+              type: 'Context',
+            },
+          },
+        ],
+        count: 1,
+      })
+    );
+
+    const result = await handler(
+      {
+        prompt: 'hi',
+        messages: [{ role: 'user', content: 'hi' }],
+      },
+      {}
+    );
+
+    expect(result?.prependSystemContext).toContain('Use a generic greeting');
+    expect(result?.prependSystemContext).not.toContain('AutoJack');
+  });
+});

--- a/src/openclaw-plugin.ts
+++ b/src/openclaw-plugin.ts
@@ -39,6 +39,8 @@ type SessionState = {
   seenEntities: Set<string>;
 };
 
+const MAX_SESSION_STATES = 500;
+const MAX_SEEN_ENTITIES_PER_SESSION = 200;
 const sessionStates = new Map<string, SessionState>();
 const COMMON_ENTITY_STOPWORDS = new Set([
   'a',
@@ -199,11 +201,31 @@ function normalizeSessionKey(sessionKey?: string): string {
 function getSessionState(sessionKey?: string): SessionState {
   const key = normalizeSessionKey(sessionKey);
   let state = sessionStates.get(key);
-  if (!state) {
-    state = { seenEntities: new Set<string>() };
+  if (state) {
+    sessionStates.delete(key);
     sessionStates.set(key, state);
+    return state;
+  }
+  state = { seenEntities: new Set<string>() };
+  sessionStates.set(key, state);
+  while (sessionStates.size > MAX_SESSION_STATES) {
+    const oldest = sessionStates.keys().next().value;
+    if (typeof oldest !== 'string') break;
+    sessionStates.delete(oldest);
   }
   return state;
+}
+
+function addSeenEntity(state: SessionState, entity: string): void {
+  if (state.seenEntities.has(entity)) {
+    state.seenEntities.delete(entity);
+  }
+  state.seenEntities.add(entity);
+  while (state.seenEntities.size > MAX_SEEN_ENTITIES_PER_SESSION) {
+    const oldest = state.seenEntities.values().next().value;
+    if (typeof oldest !== 'string') break;
+    state.seenEntities.delete(oldest);
+  }
 }
 
 export function resetOpenClawSessionStateForTests(): void {
@@ -254,7 +276,7 @@ function hasNewPromptEntities(prompt: string, sessionKey?: string): boolean {
 function rememberPromptEntities(prompt: string, sessionKey?: string): void {
   const state = getSessionState(sessionKey);
   for (const entity of extractPromptEntities(prompt)) {
-    state.seenEntities.add(entity.toLowerCase());
+    addSeenEntity(state, entity.toLowerCase());
   }
 }
 
@@ -563,7 +585,15 @@ const openClawPlugin = {
       api.on('before_prompt_build', async (event, ctx) => {
         const prompt = String(event.prompt || '').trim();
         const sections: string[] = [
-          renderOpenClawPolicyContext({ defaultTags: config.defaultTags }),
+          renderOpenClawPolicyContext({
+            defaultTags: config.defaultTags,
+            limits: {
+              preferenceRecallLimit: config.preferenceRecallLimit,
+              contextRecallLimit: config.contextRecallLimit,
+              debugRecallLimit: config.debugRecallLimit,
+              contextRecallWindowDays: config.contextRecallWindowDays,
+            },
+          }),
         ];
         const bootstrapSkipped = configSkipsBootstrap(api.config);
         const startupTurn = bootstrapSkipped && isLikelyStartupTurn(event.messages);

--- a/src/openclaw-plugin.ts
+++ b/src/openclaw-plugin.ts
@@ -1,4 +1,18 @@
 import { AutoMemClient } from './automem-client.js';
+import {
+  type OpenClawRecallLikeResult,
+  buildOpenClawStartupContext,
+  dedupeOpenClawRecallResults,
+  formatOpenClawRecallContext,
+} from './openclaw-startup-profile.js';
+import {
+  AUTOMEM_POLICY_DEFAULTS,
+  isSubstantivePrompt,
+  looksLikeDebugPrompt,
+  looksLikeExplicitRecallPrompt,
+  renderOpenClawPolicyContext,
+  resolveProjectGateTags,
+} from './memory-policy/shared.js';
 import type {
   AssociateMemoryArgs,
   DeleteMemoryArgs,
@@ -9,13 +23,42 @@ import type {
 import { AUTHORABLE_RELATION_TYPES } from './types.js';
 
 type PluginConfig = {
-  endpoint: string;
+  endpoint?: string;
   apiKey?: string;
   autoRecall: boolean;
-  autoRecallLimit: number;
+  preferenceRecallLimit: number;
+  contextRecallLimit: number;
+  debugRecallLimit: number;
+  contextRecallWindowDays: number;
   exposure: 'dm-only' | 'all' | 'off';
   defaultTags: string[];
+  startupProfile?: string;
 };
+
+type SessionState = {
+  seenEntities: Set<string>;
+};
+
+const sessionStates = new Map<string, SessionState>();
+const COMMON_ENTITY_STOPWORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'automem',
+  'do',
+  'how',
+  'i',
+  'it',
+  'jack',
+  'tell',
+  'the',
+  'they',
+  'we',
+  'what',
+  'who',
+  'why',
+  'you',
+]);
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value));
@@ -26,12 +69,14 @@ function normalizeStringArray(value: unknown): string[] {
     return [];
   }
 
-  return value
-    .map((entry) => (typeof entry === 'string' ? entry.trim() : ''))
-    .filter(Boolean);
+  return value.map((entry) => (typeof entry === 'string' ? entry.trim() : '')).filter(Boolean);
 }
 
-function mergeTags(defaultTags: string[], provided: string[] | undefined, injectIfMissingOnly = false): string[] | undefined {
+function mergeTags(
+  defaultTags: string[],
+  provided: string[] | undefined,
+  injectIfMissingOnly = false
+): string[] | undefined {
   const nextProvided = Array.isArray(provided) ? provided.filter(Boolean) : [];
   if (injectIfMissingOnly && nextProvided.length > 0) {
     return nextProvided;
@@ -48,22 +93,43 @@ function explicitTags(provided: string[] | undefined): string[] | undefined {
   return deduped.length > 0 ? deduped : undefined;
 }
 
+function parseOptionalInteger(value: unknown, max: number): number | undefined {
+  const parsed =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string'
+        ? Number.parseInt(value, 10)
+        : Number.NaN;
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return undefined;
+  }
+  return Math.min(parsed, max);
+}
+
 function parsePluginConfig(value: unknown): PluginConfig {
   const raw = isRecord(value) ? value : {};
-  const endpoint = typeof raw.endpoint === 'string' ? raw.endpoint.trim() : '';
-  if (!endpoint) {
-    throw new Error('AutoMem OpenClaw plugin requires config.endpoint');
-  }
+  const endpoint =
+    typeof raw.endpoint === 'string' && raw.endpoint.trim() ? raw.endpoint.trim() : undefined;
 
-  const apiKey = typeof raw.apiKey === 'string' && raw.apiKey.trim() ? raw.apiKey.trim() : undefined;
+  const apiKey =
+    typeof raw.apiKey === 'string' && raw.apiKey.trim() ? raw.apiKey.trim() : undefined;
   const autoRecall = typeof raw.autoRecall === 'boolean' ? raw.autoRecall : true;
-  const rawLimit =
-    typeof raw.autoRecallLimit === 'number'
-      ? raw.autoRecallLimit
-      : typeof raw.autoRecallLimit === 'string'
-        ? Number.parseInt(raw.autoRecallLimit, 10)
-        : Number.NaN;
-  const autoRecallLimit = Number.isFinite(rawLimit) && rawLimit >= 1 ? Math.min(rawLimit, 10) : 3;
+  const legacyAutoRecallLimit = parseOptionalInteger(raw.autoRecallLimit, 50);
+  const preferenceRecallLimit =
+    parseOptionalInteger(raw.preferenceRecallLimit, 50) ??
+    legacyAutoRecallLimit ??
+    AUTOMEM_POLICY_DEFAULTS.preferenceRecallLimit;
+  const contextRecallLimit =
+    parseOptionalInteger(raw.contextRecallLimit, 50) ??
+    legacyAutoRecallLimit ??
+    AUTOMEM_POLICY_DEFAULTS.contextRecallLimit;
+  const debugRecallLimit =
+    parseOptionalInteger(raw.debugRecallLimit, 50) ??
+    legacyAutoRecallLimit ??
+    AUTOMEM_POLICY_DEFAULTS.debugRecallLimit;
+  const contextRecallWindowDays =
+    parseOptionalInteger(raw.contextRecallWindowDays, 365) ??
+    AUTOMEM_POLICY_DEFAULTS.contextRecallWindowDays;
   const exposure =
     raw.exposure === 'all' || raw.exposure === 'off' || raw.exposure === 'dm-only'
       ? raw.exposure
@@ -73,9 +139,16 @@ function parsePluginConfig(value: unknown): PluginConfig {
     endpoint,
     apiKey,
     autoRecall,
-    autoRecallLimit,
+    preferenceRecallLimit,
+    contextRecallLimit,
+    debugRecallLimit,
+    contextRecallWindowDays,
     exposure,
     defaultTags: normalizeStringArray(raw.defaultTags),
+    startupProfile:
+      typeof raw.startupProfile === 'string' && raw.startupProfile.trim()
+        ? raw.startupProfile.trim()
+        : undefined,
   };
 }
 
@@ -88,7 +161,9 @@ function shouldAutoRecall(exposure: PluginConfig['exposure'], sessionKey?: strin
     return true;
   }
 
-  const normalized = String(sessionKey || '').trim().toLowerCase();
+  const normalized = String(sessionKey || '')
+    .trim()
+    .toLowerCase();
   if (!normalized || normalized === 'main') {
     return true;
   }
@@ -102,14 +177,101 @@ function shouldAutoRecall(exposure: PluginConfig['exposure'], sessionKey?: strin
   );
 }
 
-function formatRecallContext(result: { memory?: { content?: string; tags?: string[]; type?: string } }): string {
-  const content = String(result.memory?.content || '').replace(/\s+/g, ' ').trim();
-  const compact = content.length > 220 ? `${content.slice(0, 217)}...` : content;
-  const tags = Array.isArray(result.memory?.tags) && result.memory.tags.length > 0
-    ? ` [tags: ${result.memory.tags.slice(0, 4).join(', ')}]`
-    : '';
-  const type = result.memory?.type ? `[${result.memory.type}] ` : '';
-  return `- ${type}${compact}${tags}`;
+function configSkipsBootstrap(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const agents = isRecord(value.agents) ? value.agents : undefined;
+  const defaults = isRecord(agents?.defaults) ? agents.defaults : undefined;
+  return defaults?.skipBootstrap === true;
+}
+
+export function isLikelyStartupTurn(messages: unknown): boolean {
+  return Array.isArray(messages) && messages.length <= 1;
+}
+
+function normalizeSessionKey(sessionKey?: string): string {
+  const normalized = String(sessionKey || '').trim();
+  return normalized || '__default__';
+}
+
+function getSessionState(sessionKey?: string): SessionState {
+  const key = normalizeSessionKey(sessionKey);
+  let state = sessionStates.get(key);
+  if (!state) {
+    state = { seenEntities: new Set<string>() };
+    sessionStates.set(key, state);
+  }
+  return state;
+}
+
+export function resetOpenClawSessionStateForTests(): void {
+  sessionStates.clear();
+}
+
+function extractPromptEntities(prompt: string): string[] {
+  const source = String(prompt || '');
+  const matches = new Set<string>();
+
+  for (const match of source.matchAll(/"([^"\n]{2,80})"/g)) {
+    const candidate = match[1]?.trim();
+    if (candidate) {
+      matches.add(candidate);
+    }
+  }
+
+  for (const match of source.matchAll(/\b[A-Z][a-z][A-Za-z0-9_-]{1,}\b/g)) {
+    const candidate = match[0]?.trim();
+    if (match.index === 0) {
+      continue;
+    }
+    if (candidate && !COMMON_ENTITY_STOPWORDS.has(candidate.toLowerCase())) {
+      matches.add(candidate);
+    }
+  }
+
+  for (const match of source.matchAll(/\b[a-z0-9]+(?:[-_/][a-z0-9]+)+\b/gi)) {
+    const candidate = match[0]?.trim();
+    if (
+      candidate &&
+      candidate.length >= 4 &&
+      !COMMON_ENTITY_STOPWORDS.has(candidate.toLowerCase())
+    ) {
+      matches.add(candidate);
+    }
+  }
+
+  return [...matches];
+}
+
+function hasNewPromptEntities(prompt: string, sessionKey?: string): boolean {
+  const state = getSessionState(sessionKey);
+  const entities = extractPromptEntities(prompt);
+  return entities.some((entity) => !state.seenEntities.has(entity.toLowerCase()));
+}
+
+function rememberPromptEntities(prompt: string, sessionKey?: string): void {
+  const state = getSessionState(sessionKey);
+  for (const entity of extractPromptEntities(prompt)) {
+    state.seenEntities.add(entity.toLowerCase());
+  }
+}
+
+function buildRelevantMemoriesSection(
+  results: OpenClawRecallLikeResult[],
+  maxEntries: number
+): string | undefined {
+  const uniqueResults = dedupeOpenClawRecallResults(results);
+  if (uniqueResults.length === 0) {
+    return undefined;
+  }
+
+  const memoryContext = uniqueResults
+    .slice(0, maxEntries)
+    .map((entry) => formatOpenClawRecallContext(entry))
+    .join('\n');
+  return `<relevant-memories>\nThe following AutoMem memories may be relevant to this turn:\n${memoryContext}\n</relevant-memories>`;
 }
 
 function jsonResult(payload: unknown) {
@@ -223,20 +385,23 @@ const openClawPlugin = {
   id: 'automem',
   name: 'AutoMem',
   description: 'Persistent AutoMem-backed graph memory for OpenClaw.',
-  kind: 'memory',
   configSchema: {
     parse: parsePluginConfig,
     jsonSchema: {
       type: 'object',
       additionalProperties: false,
-      required: ['endpoint'],
       properties: {
         endpoint: { type: 'string', minLength: 1 },
         apiKey: { type: 'string' },
         autoRecall: { type: 'boolean', default: true },
-        autoRecallLimit: { type: 'integer', minimum: 1, maximum: 10, default: 3 },
+        autoRecallLimit: { type: 'integer', minimum: 1, maximum: 50 },
+        preferenceRecallLimit: { type: 'integer', minimum: 1, maximum: 50, default: 20 },
+        contextRecallLimit: { type: 'integer', minimum: 1, maximum: 50, default: 30 },
+        debugRecallLimit: { type: 'integer', minimum: 1, maximum: 50, default: 20 },
+        contextRecallWindowDays: { type: 'integer', minimum: 1, maximum: 365, default: 90 },
         exposure: { type: 'string', enum: ['dm-only', 'all', 'off'], default: 'dm-only' },
         defaultTags: { type: 'array', items: { type: 'string' } },
+        startupProfile: { type: 'string' },
       },
     },
     uiHints: {
@@ -255,7 +420,20 @@ const openClawPlugin = {
         help: 'Recall memory before an agent turn starts.',
       },
       autoRecallLimit: {
-        label: 'Auto Recall Limit',
+        label: 'Legacy Auto Recall Limit',
+        help: 'Compatibility fallback for older installs. Prefer the per-phase recall settings below.',
+      },
+      preferenceRecallLimit: {
+        label: 'Preference Recall Limit',
+      },
+      contextRecallLimit: {
+        label: 'Context Recall Limit',
+      },
+      debugRecallLimit: {
+        label: 'Debug Recall Limit',
+      },
+      contextRecallWindowDays: {
+        label: 'Context Recall Window (days)',
       },
       exposure: {
         label: 'Exposure',
@@ -263,11 +441,16 @@ const openClawPlugin = {
       },
       defaultTags: {
         label: 'Default Tags',
-        help: 'Applied to stored memories. Recall stays semantic unless tags are explicitly provided.',
+        help: 'Used as the project gate for first-turn context recall when unambiguous, and merged into stored memories.',
+      },
+      startupProfile: {
+        label: 'Startup Profile',
+        help: 'Cached profile and personality cues hydrated from AutoMem for fast first-turn startup.',
       },
     },
   },
   register(api: {
+    config?: unknown;
     pluginConfig?: unknown;
     logger: { warn: (message: string) => void };
     registerTool: (tool: {
@@ -278,14 +461,21 @@ const openClawPlugin = {
       execute: (_toolCallId: string, params: unknown) => Promise<unknown>;
     }) => void;
     on: (
-      hookName: 'before_agent_start',
+      hookName: 'before_prompt_build',
       handler: (
-        event: { prompt: string },
+        event: { prompt: string; messages: unknown[] },
         ctx: { sessionKey?: string }
-      ) => Promise<{ prependContext?: string } | void>
+      ) => Promise<{ prependSystemContext?: string } | void>
     ) => void;
   }) {
     const config = parsePluginConfig(api.pluginConfig);
+    if (!config.endpoint) {
+      api.logger.warn(
+        'automem: plugin loaded without config.endpoint; configure plugins.entries.automem.config.endpoint to enable tools.'
+      );
+      return;
+    }
+
     const client = new AutoMemClient({
       endpoint: config.endpoint,
       ...(config.apiKey ? { apiKey: config.apiKey } : {}),
@@ -370,52 +560,115 @@ const openClawPlugin = {
     });
 
     if (config.autoRecall) {
-      api.on('before_agent_start', async (event, ctx) => {
+      api.on('before_prompt_build', async (event, ctx) => {
         const prompt = String(event.prompt || '').trim();
-        if (!prompt || !shouldAutoRecall(config.exposure, ctx.sessionKey)) {
-          return;
+        const sections: string[] = [
+          renderOpenClawPolicyContext({ defaultTags: config.defaultTags }),
+        ];
+        const bootstrapSkipped = configSkipsBootstrap(api.config);
+        const startupTurn = bootstrapSkipped && isLikelyStartupTurn(event.messages);
+        const firstSubstantiveTurn =
+          isLikelyStartupTurn(event.messages) && isSubstantivePrompt(prompt);
+        const debugTurn = looksLikeDebugPrompt(prompt);
+        const explicitRecallTurn = looksLikeExplicitRecallPrompt(prompt);
+        const topicShiftRecallTurn =
+          !firstSubstantiveTurn &&
+          !startupTurn &&
+          !debugTurn &&
+          hasNewPromptEntities(prompt, ctx.sessionKey);
+
+        if (startupTurn) {
+          try {
+            const startupResult = await client.recallMemory({
+              query: 'user name timezone preferred name work style ongoing context',
+              limit: Math.max(config.preferenceRecallLimit, 4),
+              sort: 'time_desc',
+              format: 'detailed',
+            });
+            sections.push(
+              buildOpenClawStartupContext({
+                startupProfile: config.startupProfile,
+                startupResults: startupResult.results || [],
+              })
+            );
+          } catch (error) {
+            api.logger.warn(`automem: startup recall failed: ${String(error)}`);
+            sections.push(
+              buildOpenClawStartupContext({
+                startupProfile: config.startupProfile,
+                startupResults: [],
+              })
+            );
+          }
         }
 
-        try {
-          const preferenceResult = await client.recallMemory({
+        if (!prompt || !shouldAutoRecall(config.exposure, ctx.sessionKey)) {
+          return {
+            prependSystemContext: sections.join('\n\n'),
+          };
+        }
+
+        const recalledResults: OpenClawRecallLikeResult[] = [];
+        const projectGateTags = resolveProjectGateTags(config.defaultTags);
+        const maxContextEntries = Math.max(
+          config.preferenceRecallLimit,
+          config.contextRecallLimit,
+          config.debugRecallLimit
+        );
+
+        const runRecall = async (label: string, args: RecallMemoryArgs) => {
+          try {
+            const result = await client.recallMemory(args);
+            recalledResults.push(...(result.results || []));
+          } catch (error) {
+            api.logger.warn(`automem: ${label} recall failed: ${String(error)}`);
+          }
+        };
+
+        if (firstSubstantiveTurn) {
+          await runRecall('preference', {
             tags: ['preference'],
-            limit: Math.max(config.autoRecallLimit, 5),
+            limit: config.preferenceRecallLimit,
             sort: 'updated_desc',
             format: 'detailed',
           });
-
-          const contextResult = await client.recallMemory({
+          await runRecall('context', {
             query: prompt,
-            limit: Math.max(config.autoRecallLimit * 2, 6),
+            ...(projectGateTags ? { tags: projectGateTags } : {}),
+            time_query: `last ${config.contextRecallWindowDays} days`,
+            limit: config.contextRecallLimit,
             format: 'detailed',
           });
-
-          const mergedResults = [...(preferenceResult.results || []), ...(contextResult.results || [])];
-          const seen = new Set<string>();
-          const uniqueResults = mergedResults.filter((entry) => {
-            const key = entry.id || entry.memory?.memory_id || entry.memory?.id || JSON.stringify(entry.memory || {});
-            if (!key || seen.has(key)) {
-              return false;
-            }
-            seen.add(key);
-            return true;
-          });
-
-          if (uniqueResults.length === 0) {
-            return;
-          }
-
-          const memoryContext = uniqueResults
-            .slice(0, Math.max(config.autoRecallLimit * 2, 6))
-            .map((entry) => formatRecallContext(entry))
-            .join('\n');
-
-          return {
-            prependContext: `<relevant-memories>\nThe following AutoMem memories may be relevant to this turn:\n${memoryContext}\n</relevant-memories>`,
-          };
-        } catch (error) {
-          api.logger.warn(`automem: auto-recall failed: ${String(error)}`);
         }
+
+        if (explicitRecallTurn || topicShiftRecallTurn) {
+          await runRecall(explicitRecallTurn ? 'explicit-memory-probe' : 'topic-shift', {
+            query: prompt,
+            time_query: `last ${config.contextRecallWindowDays} days`,
+            limit: config.contextRecallLimit,
+            format: 'detailed',
+          });
+        }
+
+        if (debugTurn) {
+          await runRecall('debug', {
+            query: prompt,
+            tags: ['bugfix', 'solution'],
+            limit: config.debugRecallLimit,
+            format: 'detailed',
+          });
+        }
+
+        const memorySection = buildRelevantMemoriesSection(recalledResults, maxContextEntries);
+        if (memorySection) {
+          sections.push(memorySection);
+        }
+
+        rememberPromptEntities(prompt, ctx.sessionKey);
+
+        return {
+          prependSystemContext: sections.join('\n\n'),
+        };
       });
     }
   },

--- a/src/openclaw-startup-profile.ts
+++ b/src/openclaw-startup-profile.ts
@@ -1,0 +1,84 @@
+export type OpenClawRecallLikeResult = {
+  id?: string;
+  memory?: {
+    memory_id?: string;
+    id?: string;
+    content?: string;
+    tags?: string[];
+    type?: string;
+  };
+};
+
+function compactText(value: string, maxLength: number): string {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  return normalized.length > maxLength ? `${normalized.slice(0, maxLength - 3)}...` : normalized;
+}
+
+export function formatOpenClawRecallContext(result: OpenClawRecallLikeResult): string {
+  const content = compactText(String(result.memory?.content || ''), 220);
+  const tags = Array.isArray(result.memory?.tags) && result.memory.tags.length > 0
+    ? ` [tags: ${result.memory.tags.slice(0, 4).join(', ')}]`
+    : '';
+  const type = result.memory?.type ? `[${result.memory.type}] ` : '';
+  return `- ${type}${content}${tags}`;
+}
+
+export function dedupeOpenClawRecallResults<T extends OpenClawRecallLikeResult>(results: T[]): T[] {
+  const seen = new Set<string>();
+  return results.filter((entry) => {
+    const key = entry.id || entry.memory?.memory_id || entry.memory?.id || JSON.stringify(entry.memory || {});
+    if (!key || seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+}
+
+export function looksLikeOpenClawProfileCue(result: OpenClawRecallLikeResult): boolean {
+  const content = String(result.memory?.content || '').toLowerCase();
+  const tags = Array.isArray(result.memory?.tags)
+    ? result.memory.tags.map((tag) => String(tag).toLowerCase())
+    : [];
+  const type = String(result.memory?.type || '').toLowerCase();
+  const haystack = [content, type, ...tags].join(' ');
+  return /(name|preferred|timezone|profile|identity|style|pronoun|call me|i am|user|tone|personality|voice)/.test(haystack);
+}
+
+export function buildStartupProfileFromResults(
+  results: OpenClawRecallLikeResult[],
+  options?: { maxEntries?: number }
+): string | undefined {
+  const uniqueResults = dedupeOpenClawRecallResults(results);
+  const preferred = uniqueResults.filter((entry) => looksLikeOpenClawProfileCue(entry));
+  const selected = (preferred.length > 0 ? preferred : uniqueResults).slice(0, options?.maxEntries ?? 4);
+  if (selected.length === 0) {
+    return undefined;
+  }
+
+  return selected
+    .map((entry) => formatOpenClawRecallContext(entry))
+    .join('\n');
+}
+
+export function buildOpenClawStartupContext(params: {
+  startupProfile?: string;
+  startupResults: OpenClawRecallLikeResult[];
+}): string {
+  const profileSection = params.startupProfile?.trim()
+    ? `Cached startup profile:\n${params.startupProfile.trim()}`
+    : '';
+  const resultSection = params.startupResults.length > 0
+    ? `Recovered startup context:\n${params.startupResults
+        .map((entry) => formatOpenClawRecallContext(entry))
+        .join('\n')}`
+    : '';
+  const hasProfileCue =
+    Boolean(params.startupProfile?.trim()) ||
+    params.startupResults.some((entry) => looksLikeOpenClawProfileCue(entry));
+  const guidance = hasProfileCue
+    ? 'Bootstrap is disabled for this workspace. Do not run a bootstrap questionnaire. Treat this as a returning conversation and greet naturally using the recovered identity, personality, and profile details when relevant.'
+    : 'Bootstrap is disabled for this workspace. Do not run a bootstrap questionnaire. Use a generic greeting unless the user volunteers profile details.';
+  const sections = [guidance, profileSection, resultSection].filter(Boolean);
+  return `<automem-startup>\n${sections.join('\n\n')}\n</automem-startup>`;
+}

--- a/templates/CLAUDE_DESKTOP_INSTRUCTIONS.md
+++ b/templates/CLAUDE_DESKTOP_INSTRUCTIONS.md
@@ -31,13 +31,13 @@ Desktop conversations don't look like coding sessions. They open with things lik
 ```javascript
 mcp__memory__recall_memory({
   tags: ["preference"],
-  limit: 15,
+  limit: 20,
   sort: "updated_desc",
   format: "detailed",
 });
 ```
 
-No query, no time gate. Sort by `updated_desc` so the freshest preferences win — a recent one shouldn't get crowded out by an old one. 15 is about the size of the preference-tagged population; no point going higher.
+No query, no time gate. Sort by `updated_desc` so the freshest preferences win — a recent one shouldn't get crowded out by an old one. 20 is the validated default for preference recall.
 
 **Turn 1 (or first substantive turn): one semantic recall on actual content.**
 
@@ -49,7 +49,7 @@ For anything stateful — project work, running threads, requests that assume sh
 mcp__memory__recall_memory({
   query:
     "<proper nouns, product names, people, specific tools from the message>",
-  limit: 25,
+  limit: 30,
   time_query: "last 90 days",
   format: "detailed",
 });
@@ -82,7 +82,7 @@ mcp__memory__recall_memory({
 });
 ```
 
-**Don't re-recall mid-conversation** unless the topic genuinely shifts. With a 1M context, memories pulled on turn 1 are still in scope. Burning another recall on turn 4 of the same thread is waste.
+**Don't re-recall mid-conversation** unless the topic genuinely shifts, a new proper noun enters the conversation, or you're actively debugging. With a 1M context, memories pulled on turn 1 are still in scope. Burning another recall on turn 4 of the same thread is waste.
 
 ---
 

--- a/templates/claude-code/hooks/automem-session-start.sh
+++ b/templates/claude-code/hooks/automem-session-start.sh
@@ -9,9 +9,9 @@ PROJECT=$(basename "$PWD")
 
 cat << EOF
 <automem_session_context>
-MEMORY RECALL — run these phases in order before your first substantive response.
+MEMORY RECALL - run these phases in order before your first substantive response.
 
-Phase 1 — Preferences (tag-only, no time filter, no query):
+Phase 1 - Preferences (tag-only, no time filter, no query):
   mcp__memory__recall_memory({
     tags: ["preference"],
     limit: 20,
@@ -19,16 +19,16 @@ Phase 1 — Preferences (tag-only, no time filter, no query):
     format: "detailed"
   })
 
-Phase 2 — Task context (ONE semantic query from the user's actual nouns; project-slug gate; 90-day window):
+Phase 2 - Task context (ONE semantic query from the user's actual nouns; project-slug gate when unambiguous; 90-day window):
   mcp__memory__recall_memory({
     query: "<proper nouns, product names, tools, specific topics from the user's message>",
-    tags: ["$PROJECT"],
+    tags: ["$PROJECT"],    // drop if slug collides with a common word
     time_query: "last 90 days",
     limit: 30,
     format: "detailed"
   })
 
-Phase 3 — ON-DEMAND (only if the user's message is a debugging/error-symptom question; skip otherwise):
+Phase 3 - ON-DEMAND debugging (only if the user's message is a debugging/error-symptom question; skip otherwise):
   mcp__memory__recall_memory({
     query: "<error symptom>",
     tags: ["bugfix", "solution"],
@@ -38,10 +38,11 @@ Phase 3 — ON-DEMAND (only if the user's message is a debugging/error-symptom q
 Project slug: $PROJECT
 
 Notes:
-- Tags are a HARD GATE — they filter before scoring. For discovery/debugging across the full corpus, drop \`tags\` and rely on semantic \`query\` alone.
-- Do NOT use namespace-prefixed tags (\`project/*\`, \`lang/*\`, etc.) — the corpus uses bare tags.
+- Tags are a HARD GATE - they filter before scoring. For discovery/debugging across the full corpus, drop \`tags\` and rely on semantic \`query\` alone.
+- Do NOT use namespace-prefixed tags (\`project/*\`, \`lang/*\`, etc.) - the corpus uses bare tags.
 - Phase 2 uses ONE targeted query, not \`queries[]\` + \`auto_decompose\`. Sub-queries converge and dedup drops results; a single query built from the real nouns in the user's message wins empirically. Only switch to \`queries[]\` for genuinely multi-topic questions.
-- If the project slug collides with a common topic word (e.g., \`video\`, \`test\`), drop the Phase 2 tag gate and rely on semantic \`query\` alone.
-- If recall fails or returns nothing, continue without memory — do not mention the failure to the user.
+- If the project slug collides with a common topic word (for example \`video\` or \`test\`), drop the Phase 2 tag gate and rely on semantic \`query\` alone.
+- Do not re-recall every turn. After turn 1, recall again only for topic shifts, new proper nouns, or active debugging.
+- If recall fails or returns nothing, continue without memory - do not mention the failure to the user.
 </automem_session_context>
 EOF

--- a/templates/codex/memory-rules.md
+++ b/templates/codex/memory-rules.md
@@ -40,7 +40,17 @@ mcp__memory__recall_memory({
 });
 ```
 
-Skip Phase 2 entirely for pure syntax questions, trivial edits, or direct factual queries about current code. Don't re-recall mid-conversation unless the topic shifts, an unfamiliar proper noun enters, or you need to verify a specific technical claim — with 1M context, turn-1 memories are still in scope on turn 15.
+Skip Phase 2 entirely for pure syntax questions, trivial edits, or direct factual queries about current code. Don't re-recall mid-conversation unless the topic genuinely shifts, an unfamiliar proper noun enters, or you need to verify a specific technical claim — with 1M context, turn-1 memories are still in scope on turn 15.
+
+For active-debugging turns only, add a targeted bugfix recall:
+
+```javascript
+mcp__memory__recall_memory({
+  query: "<error symptom, stack trace keywords>",
+  tags: ["bugfix", "solution"],
+  limit: 20
+});
+```
 
 ### Storage
 
@@ -73,7 +83,7 @@ mcp__memory__store_memory({
 ### Three mid-conversation triggers (and only three)
 
 1. **User correction or override** ("actually…", "no, I prefer…", "stop doing X", "we decided X already") → `Preference`, importance 0.9, confidence 0.95, tag `correction`. Associate `INVALIDATED_BY` the prior memory.
-2. **Decision survives a round of discussion** ("let's go with X", "ship it", "yeah that's the plan") → `Decision`, importance 0.85–0.9. Associate `PREFERS_OVER` alternatives considered.
+2. **Stabilized decision — the decision stabilizes after surviving at least one round of discussion** ("let's go with X", "ship it", "yeah that's the plan") → `Decision`, importance 0.85–0.9. Associate `PREFERS_OVER` alternatives considered.
 3. **Pattern explicitly articulated** ("I always do X", "every time", "my thing is") → `Pattern`, importance 0.8. Associate `EXEMPLIFIES` concrete examples.
 
 For each trigger, run the atomic ritual *this turn* — don't queue for later.

--- a/templates/cursor/automem.mdc.template
+++ b/templates/cursor/automem.mdc.template
@@ -80,7 +80,7 @@ Sort by `updated_desc` so the freshest preferences win; `format: "detailed"` sur
 })
 ```
 
-**Don't re-recall mid-conversation** unless the topic genuinely shifts, you're about to assert a specific technical claim and want to verify it's current, or a proper noun you don't recognize enters the conversation. With 1M context, turn-1 memories are still in scope on turn 15 — re-recalling wastes budget.
+**Don't re-recall mid-conversation** unless the topic genuinely shifts, a proper noun you do not recognize enters the conversation, or you are actively debugging. With 1M context, turn-1 memories are still in scope on turn 15 — re-recalling wastes budget.
 
 ## Storage
 

--- a/templates/openclaw/OPENCLAW_SETUP.md
+++ b/templates/openclaw/OPENCLAW_SETUP.md
@@ -10,14 +10,51 @@ Connect AutoMem (graph-vector memory) to **OpenClaw** with one of three supporte
 
 ### `plugin` (recommended)
 
-- Native OpenClaw plugin with typed tools
+- Happy path wrapper: `curl -fsSL https://automem.ai/install.sh | bash`
+- Lean native OpenClaw plugin with typed tools
 - Uses the existing AutoMem HTTP client directly
-- Ships its own `automem` skill and `before_agent_start` auto-recall hook
+- Adds a `before_prompt_build` auto-recall hook
+- Keeps `memory-core` selected as the active OpenClaw memory slot
 - Default auto-recall exposure is `dm-only`
+- On fresh installs, skips bootstrap only when AutoMem is already populated
+- Hydrates a compact startup profile from AutoMem so the first chat can feel like a returning conversation
 
 ```bash
+curl -fsSL https://automem.ai/install.sh | bash
+
+# Local-build equivalent while developing this repo
+./install.sh
+
+# Raw CLI path when you need it
 npx @verygoodplugins/mcp-automem openclaw --mode plugin
 ```
+
+## What your AI is told
+
+Once AutoMem is installed, OpenClaw prepends a short memory-policy block to every model call (invisibly — it lives in the system prompt, not in the chat). The policy is the same one shipped to Claude Desktop, Claude Code, Cursor, and Codex so your AI behaves consistently across tools.
+
+**Recall** (automatic, no phrasing needed):
+
+- **First substantive turn:** the AI pulls up your top 20 preferences and up to 30 project-scoped memories from the last 90 days, so it starts the conversation knowing who you are.
+- **Mid-conversation:** it recalls again only when the topic shifts, a new proper noun shows up, you're actively debugging, or you explicitly ask ("what do you know about X?").
+- **Routine follow-ups:** no extra recall — it relies on the conversation context and the memory it already loaded.
+
+**Storage** (you trigger it by how you phrase things). The AI only persists a new memory when one of these three cues fires:
+
+1. **You correct it.** Phrases: *"actually"*, *"no, I prefer"*, *"not X, Y"*, *"that's wrong"*, *"stop doing X"*, *"I told you before"*.
+   → Stores a `Preference` (importance 0.9) and links it to the old memory with `INVALIDATED_BY`.
+2. **A decision stabilizes after a round of discussion.** Phrases: *"let's go with X"*, *"yeah, that's the plan"*, *"ship it"*, *"do it that way"*, *"final answer"*.
+   → Stores a `Decision` (importance 0.85–0.9) and links to any alternatives with `PREFERS_OVER`.
+3. **You articulate a pattern.** Phrases: *"I always do X"*, *"every time"*, *"this is how I usually"*, *"my thing is"*.
+   → Stores a `Pattern` (importance 0.8) and links concrete examples with `EXEMPLIFIES`.
+
+Every store runs a four-step atomic ritual: recall related → store → re-recall to verify → associate. If you see the AI do "four tool calls to save one thing", that's why.
+
+**Never stored** (keeps the memory graph clean): session summaries, attentiveness notes ("I'm listening"), speculative context, confirmations like *"great, that worked"*. Memory is for future-you, not performance.
+
+**Relation types** (for your reference if you look at the graph): `RELATES_TO`, `LEADS_TO`, `OCCURRED_BEFORE`, `PREFERS_OVER`, `EXEMPLIFIES`, `CONTRADICTS`, `REINFORCES`, `INVALIDATED_BY`, `EVOLVED_INTO`, `DERIVED_FROM`, `PART_OF`.
+
+Want to see the exact wording the AI sees? It's generated from `renderOpenClawPolicyContext()` in `src/memory-policy/shared.ts`.
 
 ### `mcp`
 
@@ -84,17 +121,27 @@ Options:
   --api-key <key>             AutoMem API key (optional)
   --plugin-source <spec>      npm spec or local path for plugin installs
   --name <name>               Project name used to seed default bare store tags
+  --replace-memory            Disable `memory-core`, disable the `session-memory` hook, and use AutoMem as the only memory system
   --dry-run                   Preview changes without writing files
   --quiet                     Suppress non-error output
 ```
 
 ### In `plugin` mode
 
-- Installs the package as an OpenClaw plugin
+- Installs a lean native plugin package staged inside `@verygoodplugins/mcp-automem`
 - Configures `plugins.entries.automem`
-- Archives old `automem` skill overrides that would shadow the plugin-shipped skill
+- Enables the `/plugins` chat command for easier verification and troubleshooting
+- Adds `automem` to `plugins.allow` only when the user already has a non-empty plugin allowlist
+- Appends the six AutoMem tool names to `tools.alsoAllow` so they are added safely on top of restrictive base profiles such as `tools.profile: "coding"`
+- Probes AutoMem health plus a lightweight recall on fresh installs and sets `agents.defaults.skipBootstrap = true` only when AutoMem is reachable and non-empty
+- Hydrates `plugins.entries.automem.config.startupProfile` from memory-backed identity/personality cues when bootstrap is skipped
+- Disables legacy `automem` skill entries and archives old overrides that would conflict with plugin mode
 - Preserves old AGENTS cleanup only as a migration step
-- Seeds bare project tags for stored memories only; auto-recall stays semantic and separately recalls `preference` memories first
+- Uses the shared AutoMem memory policy from Claude Desktop / Claude Code / Cursor: first-turn preference recall (`limit 20`), first-turn semantic task recall (`limit 30`, `last 90 days`), and debug-only bugfix recall (`tags: ["bugfix", "solution"]`)
+- Keeps bare project tags for stores, while using `defaultTags` only as an unambiguous project gate for first-turn task recall
+- Uses `defaultTags` only as an unambiguous project gate for first-turn task recall; later turns rely on the injected policy plus explicit tool calls instead of unconditional per-turn recall
+- When bootstrap is skipped, the plugin injects the cached startup profile plus live startup recall on the first turn so OpenClaw greets like a returning conversation when possible, or falls back to a generic greeting without asking bootstrap questions again
+- `--replace-memory` switches `plugins.slots.memory` to `"none"`, disables the bundled `session-memory` hook, and turns off `memory-core` dreaming so AutoMem is the only active memory layer
 
 ### In `mcp` mode
 
@@ -126,6 +173,63 @@ What to expect:
 - `mcp` mode: `mcporter list` shows `automem`
 - `skill` mode: `openclaw skills info automem` shows the installed skill
 
+Onboarding behavior in `plugin` mode:
+
+- populated AutoMem + fresh install: OpenClaw skips `BOOTSTRAP.md` and starts with memory-aware startup context
+- empty or unreachable AutoMem: OpenClaw keeps the normal bootstrap flow
+- existing workspaces with onboarding files: installer leaves bootstrap settings unchanged
+
+Installer behavior:
+
+- `install.sh` always chooses plugin mode for OpenClaw
+- it restarts the gateway after config changes
+- it verifies the plugin install and opens or prints the dashboard URL
+
+## Scripted dogfood demo
+
+Use this when you want to prove the clean-install flow end to end.
+
+1. Reset OpenClaw:
+
+```bash
+openclaw reset --scope full --yes --non-interactive
+```
+
+1. Run the interactive installer:
+
+```bash
+./install.sh
+```
+
+1. Answer the prompts:
+
+- `Do you want to install AutoMem to OpenClaw?` -> `y`
+- `What is your AutoMem URL?` -> your populated AutoMem endpoint (the installer checks `/health` and warns if unreachable)
+- `AutoMem API key (optional...)` -> paste key or press Enter if the endpoint is public
+- `Replace OpenClaw's built-in memory with AutoMem? (Y|n)` -> `y` for most users
+
+The installer will then restart the gateway, wait for it to come back healthy, verify the plugin registered, and print a final summary of what changed.
+
+1. Verify the resulting setup:
+
+```bash
+openclaw plugins inspect automem --json
+cat ~/.openclaw/openclaw.json
+```
+
+What to look for:
+
+- `plugins.entries.automem`
+- `commands.plugins: true`
+- `agents.defaults.skipBootstrap: true` for a populated memory instance
+- `plugins.entries.automem.config.startupProfile`
+
+Expected browser-chat behavior on the next OpenClaw session:
+
+- no `BOOTSTRAP.md` questionnaire
+- memory and personality already loaded
+- a normal returning greeting instead of name/timezone/vibe setup
+
 ## Troubleshooting
 
 ### AutoMem plugin not taking effect
@@ -133,6 +237,7 @@ What to expect:
 1. Run `openclaw plugins list`
 2. Restart the OpenClaw gateway
 3. Check `~/.openclaw/openclaw.json` for `plugins.entries.automem`
+4. Make sure `plugins.slots.memory` still points to `memory-core` if you want AutoMem as a complementary layer
 
 ### MCP mode tools are missing
 
@@ -145,6 +250,16 @@ What to expect:
 1. Verify endpoint: `curl "$AUTOMEM_ENDPOINT/health"`
 2. Check the API key if your AutoMem service is authenticated
 3. Prefer `plugin` or `mcp` mode unless you explicitly need curl behavior
+
+### Direct `openclaw plugins install @verygoodplugins/mcp-automem` fails
+
+OpenClaw's native plugin safety gate evaluates the install target itself. The main `@verygoodplugins/mcp-automem` package includes broader CLI code, so plugin installs should go through:
+
+```bash
+npx @verygoodplugins/mcp-automem openclaw --mode plugin
+```
+
+This command installs the lean native plugin sidecar that ships inside the npm package.
 
 ## Support
 


### PR DESCRIPTION
## Summary

Brings OpenClaw to parity with the AutoMem integrations already shipping for Claude Desktop, Claude Code, Cursor, and Codex — specifically around using memory **beyond** the first-turn pre-seed. One-command install (`./install.sh`), non-technical-user friendly flow, and a shared memory-policy module that keeps all client templates in sync.

- **Plugin-first runtime**: native OpenClaw plugin registers typed AutoMem tools and injects a shared policy block via `prependSystemContext` (system prompt space — no leakage into the chat UI).
- **Shared policy surface** (`src/memory-policy/shared.ts`): first-turn preference recall (limit 20) + task recall (limit 30, 90-day window) + debug-only bugfix recall. Three mid-conversation store triggers (user correction / stabilized decision / articulated pattern) with explicit listener-cue phrases. Four-step atomic ritual: recall → store → verify → associate. Bare-tag discipline + 11 authorable relation types + never-store list.
- **One-command install** (`install.sh`): endpoint health-probe, memory-core explanation prompt, post-restart gateway health-poll with loud failure, final summary of what changed + doc link.
- **Cross-client parity tests**: snapshot + surface assertions validate that Claude Desktop, Claude Code session-start hook, Cursor template, Codex memory rules, and OpenClaw policy renderer all stay in lockstep.
- **Non-technical user docs**: new "What your AI is told" section in `OPENCLAW_SETUP.md` explains the policy block, the three storage triggers with example phrases, and the atomic ritual in plain language.

## Live-verified

Exercised on a fresh OpenClaw session against a populated AutoMem instance:

| Trigger | Expected | Result |
|---|---|---|
| First-turn explicit recall ("what do we know about X?") | Pre-seed + agent-initiated `automem_recall_memory` with clean args | ✅ |
| Stabilized decision ("ship it / final answer / lock it in") | Full 4-step ritual; `Decision`, importance 0.9 | ✅ |
| User correction ("actually, no — I prefer X / stop doing Y") | Full 4-step ritual; `Preference` w/ `correction` tag, `INVALIDATED_BY` against prior decision | ✅ |
| Routine follow-up (no trigger phrase) | No re-recall; uses conversation context | ✅ |
| Channel/group/hook sessions (`:group:`, `hook:`, exposure=off) | Policy stays in system prompt, not user bubble | ✅ (3 new regression tests cover this) |

## Tests

- `npx vitest run` → **223 passing** (14 suites)
- New coverage: memory-policy snapshot tests for all client templates including Codex, OpenClaw plugin regression tests for exposure/channel sessionKey edge cases.

## Files

- Core runtime: `src/openclaw-plugin.ts`, `src/memory-policy/shared.ts`, `src/openclaw-startup-profile.ts`, `src/automem-client.ts`
- CLI + install: `src/cli/openclaw.ts`, `install.sh`, `scripts/build-openclaw-plugin-package.mjs`
- Templates: `templates/{cursor,codex,openclaw}/`, `templates/claude-code/hooks/`, `templates/CLAUDE_DESKTOP_INSTRUCTIONS.md`
- Docs: `templates/openclaw/OPENCLAW_SETUP.md`, `INSTALLATION.md`

Fixes #68.

## Test plan

- [ ] Fresh clean install: `./install.sh` against a populated AutoMem endpoint → interactive prompts work, gateway restart completes healthy, summary prints.
- [ ] Fresh clean install against an *unreachable* endpoint → installer warns and re-prompts or exits cleanly.
- [ ] Send "let's ship X" on a fresh session → verify `store_memory(Decision) + associate_memories(PREFERS_OVER|REINFORCES)` fires.
- [ ] Send "actually no, I prefer Y" → verify `store_memory(Preference) + associate_memories(INVALIDATED_BY)` fires.
- [ ] Send a routine follow-up → verify no unnecessary recall.
- [ ] Confirm no `<automem-policy>` block appears in any chat bubble (DM, channel, or hook session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)