### PR TITLE
feat: rename AUTOMEM_ENDPOINT to AUTOMEM_API_URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 ### Changes
 
 - rename the AutoMem service URL env var from `AUTOMEM_ENDPOINT` to `AUTOMEM_API_URL`. The old name still works (the server, queue processor, install script, and OpenClaw resolver all read it as a fallback), but a one-line deprecation warning is logged when only the old name is set. Re-running `npx @verygoodplugins/mcp-automem setup` migrates a `.env` file in place; templates and docs now advertise the new name.
+- `mcp-automem config` now accepts `--format=json` (single-arg form) and `--json` as shorthand, and silences the dotenv banner for machine-readable output so the JSON is safe to pipe into `jq`.
 - deprecate the standalone Claude Code plugin in favor of `npx @verygoodplugins/mcp-automem claude-code`
 - sync plugin-distributed Claude Code runtime scripts with the canonical copies under `templates/claude-code/`
 - add plugin migration guidance in `DEPRECATION.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- rename the AutoMem service URL env var from `AUTOMEM_ENDPOINT` to `AUTOMEM_API_URL`. The old name still works (the server, queue processor, install script, and OpenClaw resolver all read it as a fallback), but a one-line deprecation warning is logged when only the old name is set. Re-running `npx @verygoodplugins/mcp-automem setup` migrates a `.env` file in place; templates and docs now advertise the new name.
 - deprecate the standalone Claude Code plugin in favor of `npx @verygoodplugins/mcp-automem claude-code`
 - sync plugin-distributed Claude Code runtime scripts with the canonical copies under `templates/claude-code/`
 - add plugin migration guidance in `DEPRECATION.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ node dist/index.js
 npm start
 ```
 
-The server expects `AUTOMEM_ENDPOINT` (and optionally `AUTOMEM_API_KEY`) in environment or `.env` file.
+The server expects `AUTOMEM_API_URL` (and optionally `AUTOMEM_API_KEY`) in environment or `.env` file. `AUTOMEM_ENDPOINT` is the deprecated alias and is still read as a fallback.
 
 ## Architecture
 
@@ -174,11 +174,12 @@ See `templates/CLAUDE_CODE_INTEGRATION.md` for complete architecture, hook syste
 ## Environment Variables
 
 ```env
-# Required: AutoMem service endpoint
+# Required: AutoMem service URL
 # For local development:
-AUTOMEM_ENDPOINT=http://127.0.0.1:8001
+AUTOMEM_API_URL=http://127.0.0.1:8001
 # Or for Railway deployment (your own instance):
-AUTOMEM_ENDPOINT=https://your-automem-instance.railway.app
+AUTOMEM_API_URL=https://your-automem-instance.railway.app
+# (AUTOMEM_ENDPOINT is the deprecated name and is still read as a fallback.)
 
 # Optional: API key for authenticated AutoMem instances
 AUTOMEM_API_KEY=your_api_key_here

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -91,7 +91,7 @@ Deploy the AutoMem remote MCP sidecar on Railway (one‑click) or any Docker pla
 
 Required env vars for the sidecar:
 
-- `AUTOMEM_ENDPOINT` — URL to your AutoMem service (prefer internal URL on Railway, e.g. `http://memory-service.railway.internal:8001`)
+- `AUTOMEM_API_URL` — URL to your AutoMem service (prefer internal URL on Railway, e.g. `http://memory-service.railway.internal:8001`)
 - `AUTOMEM_API_TOKEN` — Token for your AutoMem service (if enabled)
 
 Sidecar endpoints:
@@ -162,7 +162,7 @@ Common fixes from the sidecar guide:
 - Ensure your memory service listens on `PORT=8001`
 - On Railway, prefer internal DNS: `http://memory-service.railway.internal:8001`
 - Check sidecar logs for errors (e.g., `railway logs --service automem-mcp-sse`)
-- As a fallback, set `AUTOMEM_ENDPOINT` to the public URL of your memory service
+- As a fallback, set `AUTOMEM_API_URL` to the public URL of your memory service
 
 For deeper details, see the AutoMem service docs linked above.
 
@@ -212,7 +212,7 @@ Add AutoMem to your Claude Desktop configuration:
       "command": "npx",
       "args": ["-y", "@verygoodplugins/mcp-automem"],
       "env": {
-        "AUTOMEM_ENDPOINT": "https://your-automem-instance.railway.app",
+        "AUTOMEM_API_URL": "https://your-automem-instance.railway.app",
         "AUTOMEM_API_KEY": "your-api-key-if-required"
       }
     }
@@ -229,7 +229,7 @@ Add AutoMem to your Claude Desktop configuration:
       "command": "npx",
       "args": ["-y", "@verygoodplugins/mcp-automem"],
       "env": {
-        "AUTOMEM_ENDPOINT": "http://127.0.0.1:8001"
+        "AUTOMEM_API_URL": "http://127.0.0.1:8001"
       }
     }
   }
@@ -301,7 +301,7 @@ Click to install AutoMem MCP server in Cursor:
 
 **After installation:**
 
-- Update `AUTOMEM_ENDPOINT` with your AutoMem instance URL in `~/.cursor/mcp.json`
+- Update `AUTOMEM_API_URL` with your AutoMem instance URL in `~/.cursor/mcp.json`
 - Optionally set `AUTOMEM_API_KEY` if using authentication
 - Restart Cursor to load the server
 
@@ -381,7 +381,7 @@ Add AutoMem to `~/.claude.json`:
       "command": "npx",
       "args": ["-y", "@verygoodplugins/mcp-automem"],
       "env": {
-        "AUTOMEM_ENDPOINT": "http://127.0.0.1:8001",
+        "AUTOMEM_API_URL": "http://127.0.0.1:8001",
         "AUTOMEM_API_KEY": "your-api-key-if-required"
       }
     }
@@ -476,7 +476,7 @@ In your GitHub repository: **Settings → Copilot → Coding agent → MCP confi
       "command": "npx",
       "args": ["-y", "@verygoodplugins/mcp-automem"],
       "env": {
-        "AUTOMEM_ENDPOINT": "https://xxxx.up.railway.app",
+        "AUTOMEM_API_URL": "https://xxxx.up.railway.app",
         "AUTOMEM_API_KEY": "COPILOT_MCP_AUTOMEM_API_KEY"
       }
     }
@@ -486,7 +486,7 @@ In your GitHub repository: **Settings → Copilot → Coding agent → MCP confi
 
 **Notes:**
 
-- `AUTOMEM_ENDPOINT` must be reachable from GitHub's hosted environment (so `localhost` typically won't work).
+- `AUTOMEM_API_URL` must be reachable from GitHub's hosted environment (so `localhost` typically won't work).
 - GitHub Copilot coding agent supports MCP **tools** (not resources/prompts), and supports MCP server types `"local"`, `"http"`, and `"sse"`.
 
 ### Optional: organization/enterprise-level setup (custom agents)
@@ -554,7 +554,7 @@ command = "npx"
 args = ["-y", "@verygoodplugins/mcp-automem"]
 
 [mcp_servers.memory.env]
-AUTOMEM_ENDPOINT = "https://your-automem-instance.railway.app"
+AUTOMEM_API_URL = "https://your-automem-instance.railway.app"
 AUTOMEM_API_KEY = "your-api-key-if-required"
 ```
 
@@ -566,7 +566,7 @@ command = "npx"
 args = ["-y", "@verygoodplugins/mcp-automem"]
 
 [mcp_servers.memory.env]
-AUTOMEM_ENDPOINT = "http://127.0.0.1:8001"
+AUTOMEM_API_URL = "http://127.0.0.1:8001"
 ```
 
 **Using local build (for development):**
@@ -577,7 +577,7 @@ command = "/opt/homebrew/bin/node"  # or "/usr/bin/node" on Linux
 args = ["/path/to/mcp-automem/dist/index.js"]
 
 [mcp_servers.memory.env]
-AUTOMEM_ENDPOINT = "https://your-automem-instance.railway.app"
+AUTOMEM_API_URL = "https://your-automem-instance.railway.app"
 AUTOMEM_API_KEY = "your-api-key"
 ```
 
@@ -730,7 +730,7 @@ You can also copy it directly from [templates/antigravity/mcp_config.json](templ
       "command": "npx",
       "args": ["-y", "@verygoodplugins/mcp-automem"],
       "env": {
-        "AUTOMEM_ENDPOINT": "https://your-automem-instance.railway.app",
+        "AUTOMEM_API_URL": "https://your-automem-instance.railway.app",
         "AUTOMEM_API_KEY": "your-api-key-if-required"
       }
     }
@@ -747,7 +747,7 @@ You can also copy it directly from [templates/antigravity/mcp_config.json](templ
       "command": "npx",
       "args": ["-y", "@verygoodplugins/mcp-automem"],
       "env": {
-        "AUTOMEM_ENDPOINT": "http://127.0.0.1:8001"
+        "AUTOMEM_API_URL": "http://127.0.0.1:8001"
       }
     }
   }
@@ -903,12 +903,14 @@ For mode-by-mode setup, migration notes, and troubleshooting:
 Create `.env` file or set in your shell:
 
 ```env
-# Required: AutoMem service endpoint
-AUTOMEM_ENDPOINT=https://your-automem-instance.railway.app
+# Required: AutoMem service URL
+AUTOMEM_API_URL=https://your-automem-instance.railway.app
 
 # Optional: API key for authenticated instances
 AUTOMEM_API_KEY=your_api_key_here
 ```
+
+> **Deprecated alias:** `AUTOMEM_ENDPOINT` is the previous name for this variable. It still works (the server falls back to it when `AUTOMEM_API_URL` is unset), but new configurations should use `AUTOMEM_API_URL`.
 
 **Note**: Do not use shared/public AutoMem URLs. Deploy your own instance for production use.
 
@@ -1178,7 +1180,7 @@ npx @verygoodplugins/mcp-automem help
 
 #### Service unreachable
 
-- Verify `AUTOMEM_ENDPOINT` is correct and accessible
+- Verify `AUTOMEM_API_URL` is correct and accessible
 - Check if AutoMem service is running (`/health` endpoint should return 200)
 - Ensure no firewall blocking the connection
 
@@ -1225,7 +1227,7 @@ npx @verygoodplugins/mcp-automem help
 - Verify config file exists at `~/.codex/config.toml`
 - Check TOML syntax is valid (no missing brackets or quotes)
 - Ensure command path is correct (use `which npx` or `which node`)
-- Check AutoMem endpoint is accessible: `curl $AUTOMEM_ENDPOINT/health`
+- Check AutoMem endpoint is accessible: `curl $AUTOMEM_API_URL/health`
 - Restart Codex CLI or reload IDE extension
 - Ensure you have ChatGPT Plus/Pro/Team/Enterprise subscription
 

--- a/PLUGIN_INSTALLATION.md
+++ b/PLUGIN_INSTALLATION.md
@@ -141,7 +141,7 @@ If using cloud deployment, update the service URL:
          "command": "npx",
          "args": ["-y", "@verygoodplugins/mcp-automem"],
          "env": {
-           "AUTOMEM_ENDPOINT": "https://your-instance.railway.app"
+           "AUTOMEM_API_URL": "https://your-instance.railway.app"
          }
        }
      }
@@ -232,7 +232,7 @@ docker run -p 8001:8001 verygoodplugins/automem
 
 # 3. If cloud deployment, verify URL in .mcp.json:
 cat ~/.claude/plugins/automem@*/.claude-plugin/.mcp.json
-# Update AUTOMEM_ENDPOINT if needed
+# Update AUTOMEM_API_URL if needed
 
 # 4. Restart Claude Code after URL change
 ```

--- a/README.md
+++ b/README.md
@@ -175,14 +175,14 @@ Then paste [`templates/CLAUDE_DESKTOP_INSTRUCTIONS.md`](templates/CLAUDE_DESKTOP
 
 **For Cursor IDE:**
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](cursor://anysphere.cursor-deeplink/mcp/install?name=memory&config=eyJlbnYiOnsiQVVUT01FTV9FTkRQT0lOVCI6Imh0dHA6Ly8xMjcuMC4wLjE6ODAwMSIsIkFVVE9NRU1fQVBJX0tFWSI6InlvdXItYXBpLWtleS1pZi1yZXF1aXJlZCJ9LCJjb21tYW5kIjoibnB4IC15IEB2ZXJ5Z29vZHBsdWdpbnMvbWNwLWF1dG9tZW0ifQ%3D%3D)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](cursor://anysphere.cursor-deeplink/mcp/install?name=memory&config=eyJlbnYiOnsiQVVUT01FTV9BUElfVVJMIjoiaHR0cDovLzEyNy4wLjAuMTo4MDAxIiwiQVVUT01FTV9BUElfS0VZIjoieW91ci1hcGkta2V5LWlmLXJlcXVpcmVkIn0sImNvbW1hbmQiOiJucHggLXkgQHZlcnlnb29kcGx1Z2lucy9tY3AtYXV0b21lbSJ9)
 
 ```bash
 # Or use CLI to install automem.mdc rule file
 npx @verygoodplugins/mcp-automem cursor
 ```
 
-> **Note:** After one-click install, configure your `AUTOMEM_ENDPOINT` in `~/.cursor/mcp.json` or Claude Desktop config
+> **Note:** After one-click install, configure your `AUTOMEM_API_URL` in `~/.cursor/mcp.json` or Claude Desktop config
 
 **For Claude Code:**
 

--- a/env.example
+++ b/env.example
@@ -1,12 +1,14 @@
 # AutoMem MCP Server Configuration
 # Generate this file automatically with: npx @verygoodplugins/mcp-automem setup
 
-# Required: AutoMem service endpoint
+# Required: AutoMem service URL
 # For local development (using docker-compose or local Flask app)
-AUTOMEM_ENDPOINT=http://127.0.0.1:8001
+AUTOMEM_API_URL=http://127.0.0.1:8001
 
 # For Railway deployment (deploy your own instance)
-# AUTOMEM_ENDPOINT=https://your-automem-instance.railway.app
+# AUTOMEM_API_URL=https://your-automem-instance.railway.app
+
+# Note: AUTOMEM_ENDPOINT is the deprecated name and is still read for backwards compatibility.
 
 # Optional: API key for authentication (if your AutoMem service requires it)
 # AUTOMEM_API_KEY=your_api_key_here

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 package_spec="${AUTOMEM_PACKAGE_SPEC:-@verygoodplugins/mcp-automem}"
 default_endpoint="${AUTOMEM_DEFAULT_ENDPOINT:-http://127.0.0.1:8001}"
-endpoint="${AUTOMEM_ENDPOINT:-}"
+endpoint="${AUTOMEM_API_URL:-${AUTOMEM_ENDPOINT:-}}"
 api_key="${AUTOMEM_API_KEY:-}"
 scope="${AUTOMEM_OPENCLAW_SCOPE:-shared}"
 selected_client="${AUTOMEM_CLIENT:-openclaw}"

--- a/manifest.json
+++ b/manifest.json
@@ -35,7 +35,7 @@
         "${__dirname}/dist/index.js"
       ],
       "env": {
-        "AUTOMEM_ENDPOINT": "${user_config.automem_endpoint}",
+        "AUTOMEM_API_URL": "${user_config.automem_api_url}",
         "AUTOMEM_API_KEY": "${user_config.automem_api_key}"
       }
     }
@@ -67,9 +67,9 @@
     }
   ],
   "user_config": {
-    "automem_endpoint": {
+    "automem_api_url": {
       "type": "string",
-      "title": "AutoMem Endpoint",
+      "title": "AutoMem API URL",
       "description": "URL of your AutoMem service (e.g., http://127.0.0.1:8001 for local, or https://your-app.railway.app for cloud)",
       "required": true,
       "default": "http://127.0.0.1:8001"

--- a/plugins/automem/.mcp.json
+++ b/plugins/automem/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": ["-y", "@verygoodplugins/mcp-automem"],
       "env": {
-        "AUTOMEM_ENDPOINT": "${AUTOMEM_ENDPOINT:-http://127.0.0.1:8001}"
+        "AUTOMEM_API_URL": "${AUTOMEM_API_URL:-${AUTOMEM_ENDPOINT:-http://127.0.0.1:8001}}"
       }
     }
   }

--- a/plugins/automem/README.md
+++ b/plugins/automem/README.md
@@ -25,7 +25,7 @@ npx @verygoodplugins/mcp-automem claude-code
 ### Requirements
 
 - AutoMem service running (see [main README](../../README.md))
-- `AUTOMEM_ENDPOINT` environment variable set
+- `AUTOMEM_API_URL` environment variable set (`AUTOMEM_ENDPOINT` is the deprecated name and still works)
 - `AUTOMEM_API_KEY` if your AutoMem deployment requires auth
 
 ## What's Included
@@ -62,14 +62,14 @@ Configures the AutoMem MCP server with these tools:
 
 ## Configuration
 
-Set the `AUTOMEM_ENDPOINT` environment variable:
+Set the `AUTOMEM_API_URL` environment variable:
 
 ```bash
 # Local development
-export AUTOMEM_ENDPOINT=http://127.0.0.1:8001
+export AUTOMEM_API_URL=http://127.0.0.1:8001
 
 # Or in your shell profile
-echo 'export AUTOMEM_ENDPOINT=http://127.0.0.1:8001' >> ~/.zshrc
+echo 'export AUTOMEM_API_URL=http://127.0.0.1:8001' >> ~/.zshrc
 ```
 
 If your AutoMem deployment requires authentication, also export `AUTOMEM_API_KEY`:

--- a/plugins/automem/commands/memory-health.md
+++ b/plugins/automem/commands/memory-health.md
@@ -18,7 +18,7 @@ Verify the AutoMem memory service is working:
    - Any error messages
 
 3. **Troubleshooting** (if unhealthy):
-   - Verify `AUTOMEM_ENDPOINT` environment variable is set
+   - Verify `AUTOMEM_API_URL` environment variable is set
    - Check if AutoMem service is running
    - Confirm network connectivity
 

--- a/skills/automem/SKILL.md
+++ b/skills/automem/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: true
 metadata: {"openclaw":{"skillKey":"automem"}}
 ---
 
-<!-- automem-template-version: 0.13.0 -->
+<!-- automem-template-version: 0.14.0 -->
 
 # AutoMem
 

--- a/src/cli/cursor.ts
+++ b/src/cli/cursor.ts
@@ -175,7 +175,12 @@ function isCursorAutoMemServerConfig(serverConfig: any): boolean {
 
   const env = serverConfig.env;
   if (env && typeof env === 'object') {
-    if ('AUTOMEM_ENDPOINT' in env || 'AUTOMEM_API_KEY' in env || 'AUTOMEM_API_TOKEN' in env) {
+    if (
+      'AUTOMEM_API_URL' in env ||
+      'AUTOMEM_ENDPOINT' in env ||
+      'AUTOMEM_API_KEY' in env ||
+      'AUTOMEM_API_TOKEN' in env
+    ) {
       return true;
     }
   }
@@ -332,7 +337,7 @@ export async function applyCursorSetup(cliOptions: CursorSetupOptions): Promise<
     log(`        "command": "npx",`, cliOptions.quiet);
     log(`        "args": ["-y", "@verygoodplugins/mcp-automem"],`, cliOptions.quiet);
     log(`        "env": {`, cliOptions.quiet);
-    log(`          "AUTOMEM_ENDPOINT": "http://127.0.0.1:8001"`, cliOptions.quiet);
+    log(`          "AUTOMEM_API_URL": "http://127.0.0.1:8001"`, cliOptions.quiet);
     log(`        }`, cliOptions.quiet);
     log(`      }`, cliOptions.quiet);
     log(`    }`, cliOptions.quiet);

--- a/src/cli/openclaw.test.ts
+++ b/src/cli/openclaw.test.ts
@@ -146,7 +146,7 @@ describe('openclaw cli helpers', () => {
       enabled: true,
       apiKey: 'top-secret',
       env: {
-        AUTOMEM_ENDPOINT: 'https://memory.example',
+        AUTOMEM_API_URL: 'https://memory.example',
         AUTOMEM_DEFAULT_TAGS: 'project-x',
       },
     });

--- a/src/cli/openclaw.ts
+++ b/src/cli/openclaw.ts
@@ -7,7 +7,7 @@ import { AutoMemClient } from '../automem-client.js';
 import { readAutoMemApiKeyFromEnv } from '../env.js';
 import { buildDefaultProjectTags } from '../memory-policy/shared.js';
 import { buildStartupProfileFromResults } from '../openclaw-startup-profile.js';
-import { DEFAULT_AUTOMEM_ENDPOINT } from './templates.js';
+import { DEFAULT_AUTOMEM_API_URL } from './templates.js';
 
 export type OpenClawSetupMode = 'plugin' | 'mcp' | 'skill';
 export type OpenClawSetupScope = 'workspace' | 'shared';
@@ -542,7 +542,7 @@ export function buildSkillConfigEntry(params: {
     ...(params.apiKey || existingApiKey ? { apiKey: params.apiKey || existingApiKey } : {}),
     env: {
       ...existingEnv,
-      AUTOMEM_ENDPOINT: params.endpoint,
+      AUTOMEM_API_URL: params.endpoint,
       ...(params.defaultTags.length > 0
         ? { AUTOMEM_DEFAULT_TAGS: params.defaultTags.join(',') }
         : {}),
@@ -1067,7 +1067,12 @@ function resolveModeSummary(mode: OpenClawSetupMode): string {
 }
 
 function resolveEndpoint(options: OpenClawSetupOptions): string {
-  return options.endpoint?.trim() || process.env.AUTOMEM_ENDPOINT || DEFAULT_AUTOMEM_ENDPOINT;
+  return (
+    options.endpoint?.trim() ||
+    process.env.AUTOMEM_API_URL ||
+    process.env.AUTOMEM_ENDPOINT ||
+    DEFAULT_AUTOMEM_API_URL
+  );
 }
 
 function resolveApiKey(options: OpenClawSetupOptions): string | undefined {

--- a/src/cli/queue.ts
+++ b/src/cli/queue.ts
@@ -58,7 +58,7 @@ function ensureObject(value: unknown): Record<string, unknown> {
 type AutoMemConfig = { endpoint: string; apiKey?: string };
 
 function resolveAutoMemConfig(): AutoMemConfig {
-  const envEndpoint = process.env.AUTOMEM_ENDPOINT;
+  const envEndpoint = process.env.AUTOMEM_API_URL ?? process.env.AUTOMEM_ENDPOINT;
   const envApiKey = readAutoMemApiKeyFromEnv();
 
   if (envEndpoint || envApiKey) {
@@ -79,9 +79,10 @@ function resolveAutoMemConfig(): AutoMemConfig {
     for (const server of Object.values(servers)) {
       const env = server?.env ?? {};
       const keyFromServerEnv = readAutoMemApiKeyFromEnv(env);
-      if (env.AUTOMEM_ENDPOINT || keyFromServerEnv) {
+      const serverEndpoint = env.AUTOMEM_API_URL ?? env.AUTOMEM_ENDPOINT;
+      if (serverEndpoint || keyFromServerEnv) {
         return {
-          endpoint: env.AUTOMEM_ENDPOINT ?? 'http://127.0.0.1:8001',
+          endpoint: serverEndpoint ?? 'http://127.0.0.1:8001',
           apiKey: keyFromServerEnv,
         };
       }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import path from 'path';
 import { stdin as input, stdout as output } from 'node:process';
 import { createInterface } from 'node:readline/promises';
-import { buildClaudeCodeExport, buildClaudeDesktopSnippet, buildSummaryInstructions, DEFAULT_AUTOMEM_ENDPOINT } from './templates.js';
+import { buildClaudeCodeExport, buildClaudeDesktopSnippet, buildSummaryInstructions, DEFAULT_AUTOMEM_API_URL } from './templates.js';
 import { applyClaudeCodeSetup } from './claude-code.js';
 
 interface SetupOptions {
@@ -20,7 +20,8 @@ interface ConfigOptions {
   format: 'text' | 'json';
 }
 
-const ENV_ENDPOINT_KEY = 'AUTOMEM_ENDPOINT';
+const ENV_API_URL_KEY = 'AUTOMEM_API_URL';
+const LEGACY_ENV_ENDPOINT_KEY = 'AUTOMEM_ENDPOINT';
 const ENV_API_KEY = 'AUTOMEM_API_KEY';
 
 function parseSetupArgs(args: string[]): SetupOptions {
@@ -163,9 +164,11 @@ export async function runSetup(args: string[] = []): Promise<void> {
 
   const existingValues = loadEnvValues(envPath);
   const defaultEndpoint = options.endpoint
-    ?? existingValues[ENV_ENDPOINT_KEY]
-    ?? process.env[ENV_ENDPOINT_KEY]
-    ?? DEFAULT_AUTOMEM_ENDPOINT;
+    ?? existingValues[ENV_API_URL_KEY]
+    ?? existingValues[LEGACY_ENV_ENDPOINT_KEY]
+    ?? process.env[ENV_API_URL_KEY]
+    ?? process.env[LEGACY_ENV_ENDPOINT_KEY]
+    ?? DEFAULT_AUTOMEM_API_URL;
 
   const defaultApiKey = options.apiKey
     ?? existingValues[ENV_API_KEY]
@@ -173,7 +176,7 @@ export async function runSetup(args: string[] = []): Promise<void> {
     ?? '';
 
   const endpoint = options.endpoint
-    ?? await promptValue('AutoMem endpoint', DEFAULT_AUTOMEM_ENDPOINT, defaultEndpoint);
+    ?? await promptValue('AutoMem API URL', DEFAULT_AUTOMEM_API_URL, defaultEndpoint);
 
   let apiKey = options.apiKey ?? defaultApiKey;
   if (!options.apiKey && input.isTTY && output.isTTY) {
@@ -205,7 +208,7 @@ export async function runSetup(args: string[] = []): Promise<void> {
   }
 
   const updates: Record<string, string> = {
-    [ENV_ENDPOINT_KEY]: endpoint,
+    [ENV_API_URL_KEY]: endpoint,
   };
   if (apiKey && apiKey !== '<required>' && apiKey !== '<unchanged>') {
     updates[ENV_API_KEY] = apiKey;
@@ -232,7 +235,9 @@ export async function runSetup(args: string[] = []): Promise<void> {
 
 export async function runConfig(args: string[] = []): Promise<void> {
   const options = parseConfigArgs(args);
-  const endpoint = process.env[ENV_ENDPOINT_KEY] ?? DEFAULT_AUTOMEM_ENDPOINT;
+  const endpoint = process.env[ENV_API_URL_KEY]
+    ?? process.env[LEGACY_ENV_ENDPOINT_KEY]
+    ?? DEFAULT_AUTOMEM_API_URL;
   const apiKey = process.env[ENV_API_KEY] ?? '${AUTOMEM_API_KEY}';
 
   if (options.format === 'json') {
@@ -242,7 +247,7 @@ export async function runConfig(args: string[] = []): Promise<void> {
           command: 'npx',
           args: ['@verygoodplugins/mcp-automem'],
           env: {
-            AUTOMEM_ENDPOINT: endpoint,
+            AUTOMEM_API_URL: endpoint,
             AUTOMEM_API_KEY: apiKey,
           },
         },

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -3,7 +3,7 @@ import os from 'os';
 import path from 'path';
 import { stdin as input, stdout as output } from 'node:process';
 import { createInterface } from 'node:readline/promises';
-import { buildClaudeCodeExport, buildClaudeDesktopSnippet, buildSummaryInstructions, DEFAULT_AUTOMEM_API_URL } from './templates.js';
+import { buildClaudeCodeExport, buildClaudeDesktopSnippet, buildMcpConfigJson, buildSummaryInstructions, DEFAULT_AUTOMEM_API_URL } from './templates.js';
 import { applyClaudeCodeSetup } from './claude-code.js';
 
 interface SetupOptions {
@@ -67,12 +67,17 @@ function parseConfigArgs(args: string[]): ConfigOptions {
   const options: ConfigOptions = { format: 'text' };
   for (let i = 0; i < args.length; i += 1) {
     const arg = args[i];
+    let formatValue: string | undefined;
     if (arg === '--format' && args[i + 1]) {
-      const formatValue = args[i + 1].toLowerCase();
-      if (formatValue === 'json') {
-        options.format = 'json';
-      }
+      formatValue = args[i + 1];
       i += 1;
+    } else if (arg.startsWith('--format=')) {
+      formatValue = arg.slice('--format='.length);
+    } else if (arg === '--json') {
+      formatValue = 'json';
+    }
+    if (formatValue && formatValue.toLowerCase() === 'json') {
+      options.format = 'json';
     }
   }
   return options;
@@ -241,19 +246,7 @@ export async function runConfig(args: string[] = []): Promise<void> {
   const apiKey = process.env[ENV_API_KEY] ?? '${AUTOMEM_API_KEY}';
 
   if (options.format === 'json') {
-    const snippet = {
-      mcpServers: {
-        memory: {
-          command: 'npx',
-          args: ['@verygoodplugins/mcp-automem'],
-          env: {
-            AUTOMEM_API_URL: endpoint,
-            AUTOMEM_API_KEY: apiKey,
-          },
-        },
-      },
-    };
-    console.log(JSON.stringify(snippet, null, 2));
+    console.log(JSON.stringify(buildMcpConfigJson(endpoint, apiKey), null, 2));
     return;
   }
 

--- a/src/cli/templates.test.ts
+++ b/src/cli/templates.test.ts
@@ -21,8 +21,8 @@ describe('config snippets — canonical AUTOMEM_API_URL only', () => {
   it('Claude Code shell export emits AUTOMEM_API_URL only (no deprecated alias line)', () => {
     const out = buildClaudeCodeExport(endpoint, apiKey);
 
-    expect(out).toMatch(new RegExp(`export AUTOMEM_API_URL="${endpoint}"`));
-    expect(out).toMatch(new RegExp(`export AUTOMEM_API_KEY="${apiKey}"`));
+    expect(out).toContain(`export AUTOMEM_API_URL="${endpoint}"`);
+    expect(out).toContain(`export AUTOMEM_API_KEY="${apiKey}"`);
     expect(out).not.toContain('AUTOMEM_ENDPOINT');
   });
 

--- a/src/cli/templates.test.ts
+++ b/src/cli/templates.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildClaudeCodeExport,
+  buildClaudeDesktopSnippet,
+  buildMcpConfigJson,
+} from './templates.js';
+
+describe('config snippets — canonical AUTOMEM_API_URL only', () => {
+  const endpoint = 'https://memory.example.com';
+  const apiKey = 'sk-test-123';
+
+  it('Claude Desktop snippet emits AUTOMEM_API_URL and not the deprecated AUTOMEM_ENDPOINT', () => {
+    const raw = buildClaudeDesktopSnippet(endpoint, apiKey);
+    const env = JSON.parse(raw).mcpServers.memory.env;
+
+    expect(env).toHaveProperty('AUTOMEM_API_URL', endpoint);
+    expect(env).toHaveProperty('AUTOMEM_API_KEY', apiKey);
+    expect(env).not.toHaveProperty('AUTOMEM_ENDPOINT');
+  });
+
+  it('Claude Code shell export emits AUTOMEM_API_URL only (no deprecated alias line)', () => {
+    const out = buildClaudeCodeExport(endpoint, apiKey);
+
+    expect(out).toMatch(new RegExp(`export AUTOMEM_API_URL="${endpoint}"`));
+    expect(out).toMatch(new RegExp(`export AUTOMEM_API_KEY="${apiKey}"`));
+    expect(out).not.toContain('AUTOMEM_ENDPOINT');
+  });
+
+  it('mcp-automem config --json snippet emits AUTOMEM_API_URL only', () => {
+    const env = buildMcpConfigJson(endpoint, apiKey).mcpServers.memory.env;
+
+    expect(env.AUTOMEM_API_URL).toBe(endpoint);
+    expect(env.AUTOMEM_API_KEY).toBe(apiKey);
+    expect(env).not.toHaveProperty('AUTOMEM_ENDPOINT');
+  });
+});

--- a/src/cli/templates.ts
+++ b/src/cli/templates.ts
@@ -25,6 +25,21 @@ export function buildClaudeCodeExport(endpoint = DEFAULT_AUTOMEM_API_URL, apiKey
   ].join(os.EOL);
 }
 
+export function buildMcpConfigJson(endpoint: string, apiKey: string) {
+  return {
+    mcpServers: {
+      memory: {
+        command: 'npx',
+        args: ['@verygoodplugins/mcp-automem'],
+        env: {
+          AUTOMEM_API_URL: endpoint,
+          AUTOMEM_API_KEY: apiKey,
+        },
+      },
+    },
+  };
+}
+
 export function buildSummaryInstructions(endpoint: string, apiKeyProvided: boolean) {
   const lines: string[] = [
     '',

--- a/src/cli/templates.ts
+++ b/src/cli/templates.ts
@@ -1,15 +1,15 @@
 import os from 'os';
 
-export const DEFAULT_AUTOMEM_ENDPOINT = 'http://127.0.0.1:8001';
+export const DEFAULT_AUTOMEM_API_URL = 'http://127.0.0.1:8001';
 
-export function buildClaudeDesktopSnippet(endpointVar = '${AUTOMEM_ENDPOINT}', apiKeyVar = '${AUTOMEM_API_KEY}') {
+export function buildClaudeDesktopSnippet(endpointVar = '${AUTOMEM_API_URL}', apiKeyVar = '${AUTOMEM_API_KEY}') {
   return `{
   "mcpServers": {
     "memory": {
       "command": "npx",
       "args": ["-y", "@verygoodplugins/mcp-automem"],
       "env": {
-        "AUTOMEM_ENDPOINT": "${endpointVar}",
+        "AUTOMEM_API_URL": "${endpointVar}",
         "AUTOMEM_API_KEY": "${apiKeyVar}"
       }
     }
@@ -17,10 +17,10 @@ export function buildClaudeDesktopSnippet(endpointVar = '${AUTOMEM_ENDPOINT}', a
 }`;
 }
 
-export function buildClaudeCodeExport(endpoint = DEFAULT_AUTOMEM_ENDPOINT, apiKey = 'your-auto-mem-api-key') {
+export function buildClaudeCodeExport(endpoint = DEFAULT_AUTOMEM_API_URL, apiKey = 'your-auto-mem-api-key') {
   return [
     'claude mcp add memory "npx -y @verygoodplugins/mcp-automem"',
-    `export AUTOMEM_ENDPOINT="${endpoint}"`,
+    `export AUTOMEM_API_URL="${endpoint}"`,
     `export AUTOMEM_API_KEY="${apiKey}"`
   ].join(os.EOL);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,12 +37,18 @@ function isInteractiveTerminal(): boolean {
 
 const command = (process.argv[2] || "").toLowerCase();
 const isServerMode = command.length === 0;
+const isMachineReadableCommand =
+  command === "config" && process.argv.slice(3).some(
+    (arg) => arg === "--json" || arg === "--format=json" || arg === "--format"
+  );
+const shouldSilenceDotenv = isServerMode || isMachineReadableCommand;
+
+// Prevent dotenv from writing its banner to stdout when the caller expects clean
+// machine-readable output (stdio server mode, or `config --format=json`).
+process.env.DOTENV_CONFIG_QUIET = shouldSilenceDotenv ? "true" : process.env.DOTENV_CONFIG_QUIET ?? "false";
+process.env.DOTENV_CONFIG_DEBUG = "false";
 
 if (isServerMode) {
-  // Prevent dotenv (and other deps) from writing to stdout in stdio server mode.
-  // Note: dotenv logs if debug=true even when quiet=true, so force both off.
-  process.env.DOTENV_CONFIG_QUIET = "true";
-  process.env.DOTENV_CONFIG_DEBUG = "false";
   const logToStderr = (...args: unknown[]) => console.error(...args);
   console.log = logToStderr;
   console.info = logToStderr;
@@ -50,7 +56,7 @@ if (isServerMode) {
   console.warn = logToStderr;
 }
 
-config({ quiet: isServerMode });
+config({ quiet: shouldSilenceDotenv });
 
 // Optional: allow upstream supervisors (AutoHub, etc.) to set a stable process title for safe cleanup.
 // This prevents "kill by package name" from taking down other running MCP clients (Codex/Cursor/etc.).

--- a/src/index.ts
+++ b/src/index.ts
@@ -261,17 +261,19 @@ if (command === "queue") {
 }
 
 if (command === "recall") {
-  const AUTOMEM_ENDPOINT =
-    process.env.AUTOMEM_ENDPOINT || "http://127.0.0.1:8001";
+  const AUTOMEM_API_URL =
+    process.env.AUTOMEM_API_URL ||
+    process.env.AUTOMEM_ENDPOINT ||
+    "http://127.0.0.1:8001";
   const AUTOMEM_API_KEY = readAutoMemApiKeyFromEnv();
 
-  if (!AUTOMEM_ENDPOINT) {
-    console.error("❌ AUTOMEM_ENDPOINT not set");
+  if (!AUTOMEM_API_URL) {
+    console.error("❌ AUTOMEM_API_URL not set");
     process.exit(1);
   }
 
   const client = new AutoMemClient({
-    endpoint: AUTOMEM_ENDPOINT,
+    endpoint: AUTOMEM_API_URL,
     apiKey: AUTOMEM_API_KEY,
   });
 
@@ -301,20 +303,26 @@ if (command === "recall") {
   }
 }
 
-const AUTOMEM_ENDPOINT =
-  process.env.AUTOMEM_ENDPOINT || "http://127.0.0.1:8001";
+const AUTOMEM_API_URL =
+  process.env.AUTOMEM_API_URL ||
+  process.env.AUTOMEM_ENDPOINT ||
+  "http://127.0.0.1:8001";
 const AUTOMEM_API_KEY = readAutoMemApiKeyFromEnv();
 
-if (!process.env.AUTOMEM_ENDPOINT) {
+if (!process.env.AUTOMEM_API_URL && !process.env.AUTOMEM_ENDPOINT) {
   if (isInteractiveTerminal()) {
     console.warn(
-      "⚠️  AUTOMEM_ENDPOINT not set. Run `npx @verygoodplugins/mcp-automem setup` or export the environment variable before connecting."
+      "⚠️  AUTOMEM_API_URL not set. Run `npx @verygoodplugins/mcp-automem setup` or export the environment variable before connecting."
     );
   }
+} else if (!process.env.AUTOMEM_API_URL && process.env.AUTOMEM_ENDPOINT) {
+  console.warn(
+    "⚠️  AUTOMEM_ENDPOINT is deprecated; rename it to AUTOMEM_API_URL. The old name still works for now."
+  );
 }
 
 const clientConfig: AutoMemConfig = {
-  endpoint: AUTOMEM_ENDPOINT,
+  endpoint: AUTOMEM_API_URL,
   apiKey: AUTOMEM_API_KEY,
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -267,11 +267,6 @@ if (command === "recall") {
     "http://127.0.0.1:8001";
   const AUTOMEM_API_KEY = readAutoMemApiKeyFromEnv();
 
-  if (!AUTOMEM_API_URL) {
-    console.error("❌ AUTOMEM_API_URL not set");
-    process.exit(1);
-  }
-
   const client = new AutoMemClient({
     endpoint: AUTOMEM_API_URL,
     apiKey: AUTOMEM_API_KEY,

--- a/templates/CLAUDE_CODE_INTEGRATION.md
+++ b/templates/CLAUDE_CODE_INTEGRATION.md
@@ -51,7 +51,7 @@ Add to `~/.claude.json`:
       "command": "npx",
       "args": ["-y", "@verygoodplugins/mcp-automem"],
       "env": {
-        "AUTOMEM_ENDPOINT": "http://127.0.0.1:8001",
+        "AUTOMEM_API_URL": "http://127.0.0.1:8001",
         "AUTOMEM_API_KEY": "your-api-key-if-required"
       }
     }
@@ -150,7 +150,7 @@ Claude stores significant events:
 ### Memories not storing
 
 - Check MCP server is configured in `~/.claude.json`
-- Verify AutoMem service is running: `curl $AUTOMEM_ENDPOINT/health`
+- Verify AutoMem service is running: `curl $AUTOMEM_API_URL/health`
 - Check permissions in `~/.claude/settings.json`
 
 ### Recall not finding results

--- a/templates/CLAUDE_DESKTOP_INSTRUCTIONS.md
+++ b/templates/CLAUDE_DESKTOP_INSTRUCTIONS.md
@@ -1,6 +1,6 @@
 # Claude Desktop Personal Preferences Template
 
-<!-- automem-template-version: 0.13.0 -->
+<!-- automem-template-version: 0.14.0 -->
 
 Copy everything below the divider into **Claude Desktop → Settings → Profile → Personal Preferences**.
 

--- a/templates/CLAUDE_MD_MEMORY_RULES.md
+++ b/templates/CLAUDE_MD_MEMORY_RULES.md
@@ -1,6 +1,6 @@
 # AutoMem Memory Rules for CLAUDE.md
 
-<!-- automem-template-version: 0.13.0 -->
+<!-- automem-template-version: 0.14.0 -->
 
 Add this section to your `~/.claude/CLAUDE.md` file for Claude Code. The SessionStart hook will prompt memory recall automatically.
 

--- a/templates/antigravity/mcp_config.json
+++ b/templates/antigravity/mcp_config.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": ["-y", "@verygoodplugins/mcp-automem"],
       "env": {
-        "AUTOMEM_ENDPOINT": "https://your-automem-instance.railway.app",
+        "AUTOMEM_API_URL": "https://your-automem-instance.railway.app",
         "AUTOMEM_API_KEY": "your-api-key-if-required"
       }
     }

--- a/templates/claude_desktop_config.json
+++ b/templates/claude_desktop_config.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": ["-y", "@verygoodplugins/mcp-automem"],
       "env": {
-        "AUTOMEM_ENDPOINT": "https://your-automem-instance.railway.app",
+        "AUTOMEM_API_URL": "https://your-automem-instance.railway.app",
         "AUTOMEM_API_KEY": "your-api-key-if-required"
       }
     }

--- a/templates/codex/config.toml
+++ b/templates/codex/config.toml
@@ -11,14 +11,14 @@ args = ["-y", "@verygoodplugins/mcp-automem"]
 [mcp_servers.memory.env]
 # Replace with your AutoMem instance URL
 # Deploy your own: https://github.com/verygoodplugins/automem#deployment
-AUTOMEM_ENDPOINT = "https://your-automem-instance.railway.app"
+AUTOMEM_API_URL = "https://your-automem-instance.railway.app"
 
 # Optional: Add API key if your instance requires authentication
 # Remove this line if not using authentication
 AUTOMEM_API_KEY = "your-api-key-if-required"
 
 # For local development, use:
-# AUTOMEM_ENDPOINT = "http://127.0.0.1:8001"
+# AUTOMEM_API_URL = "http://127.0.0.1:8001"
 
 # For local builds (development), use:
 # [mcp_servers.memory]

--- a/templates/codex/memory-rules.md
+++ b/templates/codex/memory-rules.md
@@ -1,5 +1,5 @@
 <!-- BEGIN AUTOMEM CODEX RULES -->
-<!-- automem-template-version: 0.13.0 -->
+<!-- automem-template-version: 0.14.0 -->
 
 ## Memory — AutoMem (persistent context for {{PROJECT_NAME}})
 

--- a/templates/cursor/automem.mdc.template
+++ b/templates/cursor/automem.mdc.template
@@ -2,7 +2,7 @@
 description: AutoMem persistent memory — validated two-phase recall, curated storage, mandatory associations
 alwaysApply: true
 ---
-<!-- automem-template-version: 0.13.0 -->
+<!-- automem-template-version: 0.14.0 -->
 
 # AutoMem Memory Integration
 

--- a/templates/cursor/rule-evals.md
+++ b/templates/cursor/rule-evals.md
@@ -1,4 +1,4 @@
-<!-- automem-template-version: 0.13.0 -->
+<!-- automem-template-version: 0.14.0 -->
 
 # Cursor Rule Eval Set
 

--- a/templates/cursor/user-rules.md
+++ b/templates/cursor/user-rules.md
@@ -1,4 +1,4 @@
-<!-- automem-template-version: 0.13.0 -->
+<!-- automem-template-version: 0.14.0 -->
 
 # Cursor Global User Rules (AutoMem)
 

--- a/templates/cursor_mcp.json
+++ b/templates/cursor_mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": ["-y", "@verygoodplugins/mcp-automem"],
       "env": {
-        "AUTOMEM_ENDPOINT": "https://your-automem-instance.railway.app",
+        "AUTOMEM_API_URL": "https://your-automem-instance.railway.app",
         "AUTOMEM_API_KEY": "your-api-key-if-required"
       }
     }

--- a/templates/openclaw/OPENCLAW_SETUP.md
+++ b/templates/openclaw/OPENCLAW_SETUP.md
@@ -243,11 +243,11 @@ Expected browser-chat behavior on the next OpenClaw session:
 
 1. Run `mcporter list`
 2. Verify `<workspace>/config/mcporter.json` contains the `automem` server
-3. Confirm `skills.entries.automem.env.AUTOMEM_ENDPOINT` is set in `~/.openclaw/openclaw.json`
+3. Confirm `skills.entries.automem.env.AUTOMEM_API_URL` is set in `~/.openclaw/openclaw.json`
 
 ### Legacy skill cannot reach AutoMem
 
-1. Verify endpoint: `curl "$AUTOMEM_ENDPOINT/health"`
+1. Verify endpoint: `curl "$AUTOMEM_API_URL/health"`
 2. Check the API key if your AutoMem service is authenticated
 3. Prefer `plugin` or `mcp` mode unless you explicitly need curl behavior
 

--- a/templates/openclaw/skill-legacy/SKILL.md
+++ b/templates/openclaw/skill-legacy/SKILL.md
@@ -2,11 +2,11 @@
 name: automem
 description: Persistent AutoMem memory via the legacy curl-based AutoMem skill.
 requires_env:
-  - AUTOMEM_ENDPOINT
+  - AUTOMEM_API_URL
 optional_env:
   - AUTOMEM_API_KEY
 user-invocable: true
-metadata: {"openclaw":{"skillKey":"automem","primaryEnv":"AUTOMEM_API_KEY","requires":{"env":["AUTOMEM_ENDPOINT"]}}}
+metadata: {"openclaw":{"skillKey":"automem","primaryEnv":"AUTOMEM_API_KEY","requires":{"env":["AUTOMEM_API_URL"]}}}
 ---
 
 <!-- automem-template-version: 0.13.0 -->
@@ -17,12 +17,12 @@ This mode uses direct HTTP calls with `curl`.
 
 ## API usage
 
-Base URL: `$AUTOMEM_ENDPOINT`
+Base URL: `$AUTOMEM_API_URL`
 
 Store memory:
 
 ```bash
-curl -s -X POST "$AUTOMEM_ENDPOINT/memory" \
+curl -s -X POST "$AUTOMEM_API_URL/memory" \
   -H "Content-Type: application/json" \
   ${AUTOMEM_API_KEY:+-H "Authorization: Bearer $AUTOMEM_API_KEY"} \
   -d '{
@@ -37,13 +37,13 @@ Recall memory:
 ```bash
 curl -s \
   ${AUTOMEM_API_KEY:+-H "Authorization: Bearer $AUTOMEM_API_KEY"} \
-  "$AUTOMEM_ENDPOINT/recall?query=QUERY&limit=20&format=detailed"
+  "$AUTOMEM_API_URL/recall?query=QUERY&limit=20&format=detailed"
 ```
 
 Update memory:
 
 ```bash
-curl -s -X PATCH "$AUTOMEM_ENDPOINT/memory/MEMORY_ID" \
+curl -s -X PATCH "$AUTOMEM_API_URL/memory/MEMORY_ID" \
   -H "Content-Type: application/json" \
   ${AUTOMEM_API_KEY:+-H "Authorization: Bearer $AUTOMEM_API_KEY"} \
   -d '{"content":"Updated context."}'
@@ -52,7 +52,7 @@ curl -s -X PATCH "$AUTOMEM_ENDPOINT/memory/MEMORY_ID" \
 Delete memory:
 
 ```bash
-curl -s -X DELETE "$AUTOMEM_ENDPOINT/memory/MEMORY_ID" \
+curl -s -X DELETE "$AUTOMEM_API_URL/memory/MEMORY_ID" \
   ${AUTOMEM_API_KEY:+-H "Authorization: Bearer $AUTOMEM_API_KEY"}
 ```
 

--- a/templates/openclaw/skill-legacy/SKILL.md
+++ b/templates/openclaw/skill-legacy/SKILL.md
@@ -9,7 +9,7 @@ user-invocable: true
 metadata: {"openclaw":{"skillKey":"automem","primaryEnv":"AUTOMEM_API_KEY","requires":{"env":["AUTOMEM_API_URL"]}}}
 ---
 
-<!-- automem-template-version: 0.13.0 -->
+<!-- automem-template-version: 0.14.0 -->
 
 # AutoMem Legacy Skill
 

--- a/templates/openclaw/skill-mcp/SKILL.md
+++ b/templates/openclaw/skill-mcp/SKILL.md
@@ -2,7 +2,7 @@
 name: automem
 description: Persistent AutoMem memory via mcporter-exposed AutoMem tools.
 user-invocable: true
-metadata: {"openclaw":{"skillKey":"automem","primaryEnv":"AUTOMEM_API_KEY","requires":{"env":["AUTOMEM_ENDPOINT"]}}}
+metadata: {"openclaw":{"skillKey":"automem","primaryEnv":"AUTOMEM_API_KEY","requires":{"env":["AUTOMEM_API_URL"]}}}
 ---
 
 <!-- automem-template-version: 0.13.0 -->

--- a/templates/openclaw/skill-mcp/SKILL.md
+++ b/templates/openclaw/skill-mcp/SKILL.md
@@ -5,7 +5,7 @@ user-invocable: true
 metadata: {"openclaw":{"skillKey":"automem","primaryEnv":"AUTOMEM_API_KEY","requires":{"env":["AUTOMEM_API_URL"]}}}
 ---
 
-<!-- automem-template-version: 0.13.0 -->
+<!-- automem-template-version: 0.14.0 -->
 
 # AutoMem
 

--- a/tests/cli/smoke.test.ts
+++ b/tests/cli/smoke.test.ts
@@ -88,10 +88,13 @@ describe('CLI Smoke Tests', () => {
       delete cleanEnv.AUTOMEM_API_URL;
       cleanEnv.AUTOMEM_ENDPOINT = 'http://legacy-host:8765';
 
+      // Run from tempDir so dotenv doesn't pick up the project root's .env file
+      // and inject AUTOMEM_API_URL, which would defeat the fallback assertion.
       const stdout = execFileSync(process.execPath, [CLI_PATH, 'config', '--format=json'], {
         encoding: 'utf8',
         timeout: 10000,
         env: cleanEnv,
+        cwd: tempDir,
       });
 
       expect(stdout).toContain('http://legacy-host:8765');

--- a/tests/cli/smoke.test.ts
+++ b/tests/cli/smoke.test.ts
@@ -26,7 +26,7 @@ function runCli(
       cwd: options.cwd || process.cwd(),
       env: {
         ...process.env,
-        AUTOMEM_ENDPOINT: 'http://localhost:9999',
+        AUTOMEM_API_URL: 'http://localhost:9999',
         ...options.env,
       },
     });
@@ -80,7 +80,21 @@ describe('CLI Smoke Tests', () => {
     it('should include Claude Desktop snippet', () => {
       const output = runCliExpectSuccess(['config']);
       expect(output).toMatch(/Claude Desktop/i);
-      expect(output).toMatch(/AUTOMEM_ENDPOINT/i);
+      expect(output).toMatch(/AUTOMEM_API_URL/i);
+    });
+
+    it('falls back to AUTOMEM_ENDPOINT when AUTOMEM_API_URL is unset (deprecation alias)', () => {
+      const cleanEnv: NodeJS.ProcessEnv = { ...process.env };
+      delete cleanEnv.AUTOMEM_API_URL;
+      cleanEnv.AUTOMEM_ENDPOINT = 'http://legacy-host:8765';
+
+      const stdout = execFileSync(process.execPath, [CLI_PATH, 'config', '--format=json'], {
+        encoding: 'utf8',
+        timeout: 10000,
+        env: cleanEnv,
+      });
+
+      expect(stdout).toContain('http://legacy-host:8765');
     });
 
     it('should include Claude Code setup', () => {

--- a/tests/hooks/helpers.ts
+++ b/tests/hooks/helpers.ts
@@ -79,6 +79,7 @@ export function runCaptureHook(
       // Hooks should never need the API key to run — the queue drain is a
       // separate Stop-hook step. Unset to catch accidental dependencies.
       AUTOMEM_API_KEY: '',
+      AUTOMEM_API_URL: '',
       AUTOMEM_ENDPOINT: '',
     },
   });

--- a/tests/integration/automem-service.test.ts
+++ b/tests/integration/automem-service.test.ts
@@ -3,14 +3,18 @@
  * These tests run against a real AutoMem instance (local Docker or remote).
  *
  * Run with: npm run test:integration
- * Requires: AutoMem service at AUTOMEM_TEST_ENDPOINT (default: http://localhost:8001)
+ * Requires: AutoMem service at AUTOMEM_TEST_API_URL (default: http://localhost:8001).
+ * AUTOMEM_TEST_ENDPOINT is the deprecated alias and is still read as a fallback.
  */
 
 import { describe, it, expect, beforeAll, afterEach } from 'vitest';
 import { AutoMemClient } from '../../src/automem-client.js';
 import { AUTHORABLE_RELATION_TYPES } from '../../src/types.js';
 
-const AUTOMEM_ENDPOINT = process.env.AUTOMEM_TEST_ENDPOINT || 'http://localhost:8001';
+const AUTOMEM_TEST_API_URL =
+  process.env.AUTOMEM_TEST_API_URL ||
+  process.env.AUTOMEM_TEST_ENDPOINT ||
+  'http://localhost:8001';
 const TEST_TAG = `test-${Date.now()}`;
 
 let client: AutoMemClient;
@@ -19,7 +23,7 @@ const createdMemoryIds: string[] = [];
 
 // Check if service is available before running tests
 beforeAll(async () => {
-  client = new AutoMemClient({ endpoint: AUTOMEM_ENDPOINT });
+  client = new AutoMemClient({ endpoint: AUTOMEM_TEST_API_URL });
 
   try {
     const health = await client.checkHealth();
@@ -28,7 +32,7 @@ beforeAll(async () => {
       console.warn(`AutoMem service not healthy: ${JSON.stringify(health)}`);
     }
   } catch (error) {
-    console.warn(`AutoMem service not available at ${AUTOMEM_ENDPOINT}: ${error}`);
+    console.warn(`AutoMem service not available at ${AUTOMEM_TEST_API_URL}: ${error}`);
     serviceAvailable = false;
   }
 });
@@ -342,4 +346,4 @@ describe.skipIf(!serviceAvailable)('AutoMem Service Integration', () => {
 });
 
 // Export for conditional running
-export { serviceAvailable, AUTOMEM_ENDPOINT };
+export { serviceAvailable, AUTOMEM_TEST_API_URL };


### PR DESCRIPTION
## Summary

- Renames the AutoMem service URL env var from `AUTOMEM_ENDPOINT` to `AUTOMEM_API_URL` across all user-facing docs, env templates, manifest user-config keys, and source code.
- Adds backwards compatibility: the MCP server, queue processor, install script, OpenClaw resolver, Cursor detector, and `setup` CLI all read `AUTOMEM_API_URL` first and fall back to `AUTOMEM_ENDPOINT`. A one-line stderr warning fires when only the deprecated name is set.
- Existing `.env` files are migrated in place on the next `npx @verygoodplugins/mcp-automem setup` run (the new key is written; the old line is left harmless).

## What didn't change

- `CHANGELOG.md` history is intact — only a new `[Unreleased]` entry was added.
- `manifest.json`'s `user_config.automem_endpoint` key was renamed to `automem_api_url`. Existing `.mcpb` users will be re-prompted on update.
- The legacy OpenClaw skill metadata `requires.env` now lists `AUTOMEM_API_URL`. Users with only the old env name still work because the OpenClaw resolver falls back.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` passes (224/224), including the new `tests/cli/smoke.test.ts` assertion: `falls back to AUTOMEM_ENDPOINT when AUTOMEM_API_URL is unset`
- [ ] Smoke-test fresh install: `AUTOMEM_API_URL=... npx @verygoodplugins/mcp-automem` connects without warnings
- [ ] Smoke-test backwards-compat: `AUTOMEM_ENDPOINT=... npx @verygoodplugins/mcp-automem` connects and emits the deprecation warning to stderr
- [ ] Manual: run `setup` against a `.env` that only has `AUTOMEM_ENDPOINT=…` and verify the file gains an `AUTOMEM_API_URL` line afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)