### PR TITLE
feat(api): parity with AutoMem v0.15.2 via mode-multiplexed params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+- parity with AutoMem service v0.15.2 — exposed via mode-multiplexed parameters on existing tools (no new tools, surface stays at 6):
+  - `recall_memory` gains three modes: ID fetch (`memory_id`), tag enumeration (`exhaustive: true` + `tags`, paginated via `limit`/`offset`, returns `has_more`), and ranked retrieval (default, now also supports `exclude_tags`).
+  - `store_memory` gains batch mode (`memories: [...]`, ≤500 items) routed to `POST /memory/batch`. Per-item `id`/`embedding`/`t_valid`/`t_invalid` are not supported in batch mode by design.
+  - `delete_memory` gains bulk-by-tag mode (`tags: [...]`) routed to `DELETE /memory/by-tag`. Exact-match, case-insensitive, no dry-run.
+- the OpenClaw plugin's six `automem_*` tools mirror the new modes via extended schemas; batch store applies the configured `defaultTags` per item, while bulk-delete-by-tag never injects defaults.
+
 ### Changes
 
 - rename the AutoMem service URL env var from `AUTOMEM_ENDPOINT` to `AUTOMEM_API_URL`. The old name still works (the server, queue processor, install script, and OpenClaw resolver all read it as a fallback), but a one-line deprecation warning is logged when only the old name is set. Re-running `npx @verygoodplugins/mcp-automem setup` migrates a `.env` file in place; templates and docs now advertise the new name.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,19 +133,23 @@ templates/
 
 ## MCP Tools
 
-The server exposes these tools to AI assistants:
+The server exposes 6 tools to AI assistants. Several are mode-multiplexed — the mode is selected by which params you pass, so the tool count stays small while the surface area covers all of AutoMem's memory CRUD endpoints.
 
-1. **store_memory** - Store memory with content, tags, importance, metadata, type, confidence, timestamps, embedding
-2. **recall_memory** - Hybrid search (vector + keyword + tags + recency)
-   - Supports `query`, `embedding`, `limit`, `time_query`, `tags`, `tag_mode`, `tag_match`
-   - Pagination/output: `per_query_limit`, `sort`, `format`, `offset`
-   - When `tags` provided: merges results from `/recall` and `/memory/by-tag` for better coverage
-3. **associate_memories** - Create relationships (11 public authorable types only)
-4. **update_memory** - Update existing memory fields (supports MEMORY_TYPES enum for `type`)
-5. **delete_memory** - Delete memory and embedding
-6. **check_database_health** - Check FalkorDB/Qdrant connection status
+1. **store_memory** — Two modes:
+   - **Single (default):** `content` plus optional `tags`, `importance`, `metadata`, `type`, `confidence`, `embedding`, `t_valid`, `t_invalid`, `id`.
+   - **Batch:** `memories: [...]` (≤500 items) for bulk ingestion. Per-item `id`, `embedding`, `t_valid`, `t_invalid` are NOT supported in batch mode — use single-mode for those.
+2. **recall_memory** — Three modes:
+   - **ID fetch:** `memory_id` → routes to `GET /memory/{id}` and ignores other params.
+   - **Tag enumeration:** `tags` + `exhaustive: true` → routes to `GET /memory/by-tag` for paginated exact-match listing. Pair with `limit` (≤200) and `offset`. Returns `has_more`/`limit`/`offset`. Use this for cleanup/audit workflows where ranked recall undercounts.
+   - **Ranked retrieval (default):** hybrid search across vector, keyword, tags, recency, and graph expansion. Supports `query`/`queries`, `embedding`, `limit`, `time_query`, `tags`, `tag_mode`, `tag_match`, `exclude_tags`, expansion options, context hints, and pagination (`offset`, `sort`, `format`).
+3. **associate_memories** — Create relationships (11 public authorable types only).
+4. **update_memory** — Update existing memory fields (supports `MEMORY_TYPES` enum for `type`).
+5. **delete_memory** — Two modes:
+   - **Single (default):** `memory_id` → deletes one memory + its embedding.
+   - **Bulk-by-tag:** `tags: [...]` → bulk-deletes ALL memories matching ANY tag (exact, case-insensitive). No dry-run; verify with `recall_memory({ tags, exhaustive: true })` first.
+6. **check_database_health** — Check FalkorDB/Qdrant connection status.
 
-**Note:** `search_by_tag` tool removed in v0.2.0; use `recall_memory` with `tags` parameter instead.
+**Note:** `search_by_tag` tool removed in v0.2.0; use `recall_memory` with `tags` parameter instead. The `get_memory`, `list_memories_by_tag`, `delete_memories_by_tag`, and `store_memories_batch` capabilities ship as parameter-extended modes on the tools above (per the global "Resist Tool Bloat" guidance) rather than as separate tools.
 
 ## Claude Code Integration
 

--- a/README.md
+++ b/README.md
@@ -315,16 +315,19 @@ _Claude Mobile (iOS) connected to AutoMem via remote MCP_
 
 ### Core Memory Operations
 
-- **`store_memory`** - Save memories with content, tags, importance, metadata
-- **`recall_memory`** - Hybrid search with graph expansion and context awareness:
-  - **Basic search**: query, multi-query, tags, time filters
-  - **Graph expansion**: entity expansion (multi-hop reasoning), relation following
-  - **Expansion filtering**: `expand_min_importance` and `expand_min_strength` to reduce noise in expanded results
-  - **Context hints**: language, active file, priority types/tags
-- **`associate_memories`** - Create relationships (11 public authorable types; recall results may also include read-only system relations)
-- **`update_memory`** - Modify existing memories
-- **`delete_memory`** - Remove memories
-- **`check_database_health`** - Monitor service status
+- **`store_memory`** — Save memories with content, tags, importance, metadata. Two modes:
+  - **Single (default)**: top-level `content` plus optional fields, including `embedding`, `t_valid`, `t_invalid`, custom `id`.
+  - **Batch**: `memories: [...]` (≤500 items) for bulk ingestion. Per-item `id`/`embedding`/`t_valid`/`t_invalid` are not supported in batch mode.
+- **`recall_memory`** — Three modes selected by which params you pass:
+  - **ID fetch**: `memory_id` → fetches one memory by ID; updates `last_accessed`.
+  - **Tag enumeration**: `tags` + `exhaustive: true` → paginated exact-match listing for cleanup/audit workflows where ranked recall undercounts. Pair with `limit` (≤200) and `offset`; returns `has_more`.
+  - **Ranked retrieval (default)**: hybrid search across vector, keyword, tags, recency, with optional graph expansion and `exclude_tags` to filter out unwanted scopes.
+- **`associate_memories`** — Create relationships (11 public authorable types; recall results may also include read-only system relations)
+- **`update_memory`** — Modify existing memories
+- **`delete_memory`** — Two modes:
+  - **Single (default)**: `memory_id` → removes one memory and its embedding.
+  - **Bulk-by-tag**: `tags: [...]` → bulk-delete all memories matching ANY tag (exact, case-insensitive). No dry-run; verify with `recall_memory({ tags, exhaustive: true })` first.
+- **`check_database_health`** — Monitor service status
 
 ### Advanced Recall (v0.8.0+)
 

--- a/src/automem-client.test.ts
+++ b/src/automem-client.test.ts
@@ -213,6 +213,231 @@ describe('AutoMemClient', () => {
     });
   });
 
+  describe('recallMemory — ID fetch mode', () => {
+    it('should route memory_id to GET /memory/{id}', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          status: 'success',
+          memory: { id: 'mem-abc', content: 'hello', tags: ['x'], importance: 0.7 },
+        }),
+      } as any);
+
+      const result = await client.recallMemory({ memory_id: 'mem-abc' });
+
+      expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:8001/memory/mem-abc');
+      expect(mockFetch.mock.calls[0][1]?.method).toBe('GET');
+      expect(result.mode).toBe('id_fetch');
+      expect(result.count).toBe(1);
+      expect(result.results[0].memory.memory_id).toBe('mem-abc');
+      expect(result.results[0].memory.content).toBe('hello');
+    });
+
+    it('should ignore other params when memory_id is set', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ memory: { id: 'mem-1', content: 'x' } }),
+      } as any);
+
+      await client.recallMemory({ memory_id: 'mem-1', query: 'should be ignored', tags: ['x'] });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('http://localhost:8001/memory/mem-1');
+      expect(url).not.toContain('query=');
+      expect(url).not.toContain('tags=');
+    });
+  });
+
+  describe('recallMemory — enumeration mode', () => {
+    it('should route exhaustive+tags to GET /memory/by-tag', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          status: 'success',
+          tags: ['benchmark'],
+          count: 2,
+          limit: 20,
+          offset: 0,
+          has_more: false,
+          memories: [
+            { id: 'mem-1', content: 'A', tags: ['benchmark'] },
+            { id: 'mem-2', content: 'B', tags: ['benchmark'] },
+          ],
+        }),
+      } as any);
+
+      const result = await client.recallMemory({ tags: ['benchmark'], exhaustive: true });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain('memory/by-tag');
+      expect(url).toContain('tags=benchmark');
+      expect(result.mode).toBe('enumeration');
+      expect(result.count).toBe(2);
+      expect(result.has_more).toBe(false);
+      expect(result.limit).toBe(20);
+      expect(result.offset).toBe(0);
+      expect(result.results).toHaveLength(2);
+    });
+
+    it('should pass through limit and offset, clamping limit at 200', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ memories: [], count: 0, limit: 200, offset: 100, has_more: false }),
+      } as any);
+
+      await client.recallMemory({
+        tags: ['x'],
+        exhaustive: true,
+        limit: 9999,
+        offset: 100,
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain('limit=200');
+      expect(url).toContain('offset=100');
+    });
+
+    it('should reject exhaustive without tags', async () => {
+      await expect(
+        client.recallMemory({ exhaustive: true } as any)
+      ).rejects.toThrow('non-empty `tags`');
+    });
+
+    it('should reject exhaustive + tag_match=prefix', async () => {
+      await expect(
+        client.recallMemory({
+          tags: ['x'],
+          exhaustive: true,
+          tag_match: 'prefix',
+        } as any)
+      ).rejects.toThrow('exact tag matching');
+    });
+
+    it('should reject exhaustive + tag_mode=all', async () => {
+      await expect(
+        client.recallMemory({ tags: ['x'], exhaustive: true, tag_mode: 'all' } as any)
+      ).rejects.toThrow('any-of tag matching');
+    });
+
+    it('should reject exhaustive combined with ranked-only params (e.g., time_query)', async () => {
+      await expect(
+        client.recallMemory({
+          tags: ['x'],
+          exhaustive: true,
+          time_query: 'last 7 days',
+        } as any)
+      ).rejects.toThrow(/Remove ranked-only param\(s\): time_query/);
+    });
+
+    it('should reject exhaustive combined with multiple ranked-only params at once', async () => {
+      await expect(
+        client.recallMemory({
+          tags: ['x'],
+          exhaustive: true,
+          query: 'foo',
+          exclude_tags: ['y'],
+          expand_relations: true,
+        } as any)
+      ).rejects.toThrow(/query.*exclude_tags.*expand_relations/);
+    });
+
+    it('should accept exhaustive + format (format is allowed in enumeration mode)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ memories: [], count: 0, has_more: false }),
+      } as any);
+
+      await expect(
+        client.recallMemory({ tags: ['x'], exhaustive: true, format: 'detailed' } as any)
+      ).resolves.toBeDefined();
+    });
+  });
+
+  describe('recallMemory — exclude_tags', () => {
+    it('should emit exclude_tags as repeated query params', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ results: [], count: 0 }),
+      } as any);
+
+      await client.recallMemory({
+        query: 'auth',
+        exclude_tags: ['deprecated', 'archived'],
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain('exclude_tags=deprecated');
+      expect(url).toContain('exclude_tags=archived');
+    });
+  });
+
+  describe('storeMemory — batch mode', () => {
+    it('should route memories[] to POST /memory/batch', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          status: 'success',
+          stored: 2,
+          memory_ids: ['m1', 'm2'],
+        }),
+      } as any);
+
+      const result = await client.storeMemory({
+        memories: [
+          { content: 'one', tags: ['x'] },
+          { content: 'two', tags: ['x'] },
+        ],
+      });
+
+      const callArgs = mockFetch.mock.calls[0];
+      const url = callArgs[0] as string;
+      expect(url).toBe('http://localhost:8001/memory/batch');
+      expect(callArgs[1]?.method).toBe('POST');
+      const body = JSON.parse(callArgs[1]?.body as string);
+      expect(body.memories).toHaveLength(2);
+      expect(body.memories[0].content).toBe('one');
+      expect(result.stored).toBe(2);
+      expect(result.memory_ids).toEqual(['m1', 'm2']);
+    });
+
+    it('should reject empty memories array', async () => {
+      await expect(
+        client.storeMemory({ memories: [] } as any)
+      ).rejects.toThrow('at least one item');
+    });
+
+    it('should reject memories array exceeding 500 items', async () => {
+      const big = Array.from({ length: 501 }, (_, i) => ({ content: `item ${i}` }));
+      await expect(client.storeMemory({ memories: big } as any)).rejects.toThrow('exceeds max 500');
+    });
+
+    it('should reject items with disallowed fields (id, embedding, t_valid, t_invalid)', async () => {
+      await expect(
+        client.storeMemory({
+          memories: [{ content: 'x', t_valid: '2026-01-01T00:00:00Z' } as any],
+        } as any)
+      ).rejects.toThrow('not allowed in batch mode');
+      await expect(
+        client.storeMemory({ memories: [{ content: 'x', id: 'custom-id' } as any] } as any)
+      ).rejects.toThrow('not allowed in batch mode');
+      await expect(
+        client.storeMemory({ memories: [{ content: 'x', embedding: [0.1, 0.2] } as any] } as any)
+      ).rejects.toThrow('not allowed in batch mode');
+    });
+
+    it('should reject items with empty content', async () => {
+      await expect(
+        client.storeMemory({ memories: [{ content: '   ' }] } as any)
+      ).rejects.toThrow('content is required');
+    });
+
+    it('should reject XOR collision (content + memories)', async () => {
+      await expect(
+        client.storeMemory({ content: 'single', memories: [{ content: 'one' }] } as any)
+      ).rejects.toThrow('not both');
+    });
+  });
+
   describe('associateMemories', () => {
     it('should create association', async () => {
       mockFetch.mockResolvedValueOnce({
@@ -276,8 +501,39 @@ describe('AutoMemClient', () => {
       );
     });
 
-    it('should throw if memory_id missing', async () => {
-      await expect(client.deleteMemory({} as any)).rejects.toThrow('memory_id is required');
+    it('should throw if neither memory_id nor tags provided', async () => {
+      await expect(client.deleteMemory({} as any)).rejects.toThrow(
+        '`memory_id` or `tags` is required'
+      );
+    });
+
+    it('should bulk-delete by tag and emit no limit/offset on DELETE', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ status: 'success', tags: ['benchmark'], deleted_count: 42 }),
+      } as any);
+
+      const result = await client.deleteMemory({ tags: ['benchmark'] });
+
+      expect(result.deleted_count).toBe(42);
+      expect(result.tags).toEqual(['benchmark']);
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toBe('http://localhost:8001/memory/by-tag?tags=benchmark');
+      expect(url).not.toContain('limit=');
+      expect(url).not.toContain('offset=');
+      expect(mockFetch.mock.calls[0][1]?.method).toBe('DELETE');
+    });
+
+    it('should reject when both memory_id and tags are passed', async () => {
+      await expect(
+        client.deleteMemory({ memory_id: 'mem-1', tags: ['x'] } as any)
+      ).rejects.toThrow('not both');
+    });
+
+    it('should reject when tags contains only whitespace entries (treated as no input)', async () => {
+      await expect(
+        client.deleteMemory({ tags: ['', '  '] } as any)
+      ).rejects.toThrow('`memory_id` or `tags` is required');
     });
   });
 

--- a/src/automem-client.test.ts
+++ b/src/automem-client.test.ts
@@ -434,7 +434,17 @@ describe('AutoMemClient', () => {
     it('should reject XOR collision (content + memories)', async () => {
       await expect(
         client.storeMemory({ content: 'single', memories: [{ content: 'one' }] } as any)
-      ).rejects.toThrow('not both');
+      ).rejects.toThrow('Remove top-level single-mode field(s): content');
+    });
+
+    it('should reject shared top-level fields in batch mode instead of dropping them', async () => {
+      await expect(
+        client.storeMemory({
+          tags: ['import'],
+          importance: 0.8,
+          memories: [{ content: 'one' }],
+        } as any)
+      ).rejects.toThrow('Remove top-level single-mode field(s): tags, importance');
     });
   });
 

--- a/src/automem-client.ts
+++ b/src/automem-client.ts
@@ -150,7 +150,8 @@ export class AutoMemClient {
           ? ' (check AUTOMEM_API_KEY or AUTOMEM_API_TOKEN is set for the MCP server process)'
           : '';
 
-      const error = new Error(`${baseMessage}${hint}`);
+      const error = new Error(`${baseMessage}${hint}`) as Error & { status?: number };
+      error.status = response.status;
       console.error(`AutoMem API error (${method} ${url}):`, error);
       throw error;
     }
@@ -475,8 +476,17 @@ export class AutoMemClient {
   }
 
   private async fetchMemoryById(memoryId: string): Promise<any | null> {
-    const response = await this.makeRequest('GET', `memory/${encodeURIComponent(memoryId)}`);
-    return response?.memory ?? response ?? null;
+    try {
+      const response = await this.makeRequest('GET', `memory/${encodeURIComponent(memoryId)}`);
+      return response?.memory ?? response ?? null;
+    } catch (error) {
+      // A missing ID should yield an empty result, not an exception. recallMemory's
+      // ID-fetch branch maps `null` to `{ count: 0, results: [] }`.
+      if ((error as { status?: number })?.status === 404) {
+        return null;
+      }
+      throw error;
+    }
   }
 
   private async listByTag(
@@ -501,7 +511,7 @@ export class AutoMemClient {
       tags: response.tags ?? tags,
       limit: response.limit,
       offset: response.offset,
-      has_more: Boolean(response.has_more),
+      has_more: typeof response.has_more === 'boolean' ? response.has_more : undefined,
     };
   }
 
@@ -576,9 +586,10 @@ export class AutoMemClient {
       throw new Error('delete_memory: `memory_id` or `tags` is required');
     }
 
-    const response = await this.makeRequest('DELETE', `memory/${args.memory_id}`);
+    const memoryId = args.memory_id!.trim();
+    const response = await this.makeRequest('DELETE', `memory/${encodeURIComponent(memoryId)}`);
     return {
-      memory_id: response.memory_id || args.memory_id,
+      memory_id: response.memory_id || memoryId,
       message: response.message || 'Memory deleted successfully',
     };
   }

--- a/src/automem-client.ts
+++ b/src/automem-client.ts
@@ -14,6 +14,21 @@ import type {
 } from './types.js';
 
 const BATCH_DISALLOWED_FIELDS = ['id', 'embedding', 't_valid', 't_invalid'] as const;
+const BATCH_TOP_LEVEL_SINGLE_FIELDS = [
+  'content',
+  'type',
+  'confidence',
+  'id',
+  'tags',
+  'importance',
+  'embedding',
+  'metadata',
+  'timestamp',
+  't_valid',
+  't_invalid',
+  'updated_at',
+  'last_accessed',
+] as const;
 const BATCH_MAX_ITEMS = 500;
 
 function nonEmptyTags(tags: unknown): string[] {
@@ -145,9 +160,12 @@ export class AutoMemClient {
 
   async storeMemory(args: StoreMemoryArgs): Promise<StoreMemoryResult> {
     if (Array.isArray(args.memories)) {
-      if (typeof args.content === 'string' && args.content.length > 0) {
+      const conflictingFields = BATCH_TOP_LEVEL_SINGLE_FIELDS.filter(
+        (field) => args[field] !== undefined
+      );
+      if (conflictingFields.length > 0) {
         throw new Error(
-          'store_memory: pass either `content` (single) or `memories` (batch), not both'
+          `store_memory: batch mode accepts per-item fields inside \`memories\` only. Remove top-level single-mode field(s): ${conflictingFields.join(', ')}.`
         );
       }
       return this.batchStore(args.memories);

--- a/src/automem-client.ts
+++ b/src/automem-client.ts
@@ -1,14 +1,55 @@
 import type {
   AutoMemConfig,
+  BatchMemoryInput,
   MemoryRecord,
   RecallResult,
   HealthStatus,
   StoreMemoryArgs,
+  StoreMemoryResult,
   RecallMemoryArgs,
   AssociateMemoryArgs,
   UpdateMemoryArgs,
   DeleteMemoryArgs,
+  DeleteMemoryResult,
 } from './types.js';
+
+const BATCH_DISALLOWED_FIELDS = ['id', 'embedding', 't_valid', 't_invalid'] as const;
+const BATCH_MAX_ITEMS = 500;
+
+function nonEmptyTags(tags: unknown): string[] {
+  if (!Array.isArray(tags)) return [];
+  return tags
+    .map((t) => (typeof t === 'string' ? t.trim() : ''))
+    .filter((t) => t.length > 0);
+}
+
+function mapStoredMemory(raw: any) {
+  return {
+    memory_id: raw?.id || raw?.memory_id || '',
+    content: raw?.content || '',
+    tags: raw?.tags || [],
+    importance: raw?.importance ?? 0,
+    created_at: raw?.timestamp || raw?.created_at || '',
+    updated_at: raw?.updated_at || raw?.timestamp || '',
+    metadata: raw?.metadata || {},
+    type: raw?.type,
+    confidence: raw?.confidence,
+    last_accessed: raw?.last_accessed,
+  };
+}
+
+function wrapMemoryAsRecallResult(raw: any): RecallResult['results'][number] {
+  const memory = mapStoredMemory(raw);
+  return {
+    id: memory.memory_id,
+    match_type: 'direct',
+    final_score: 1,
+    score_components: {},
+    relations: [],
+    related_to: [],
+    memory: memory as any,
+  };
+}
 
 export class AutoMemClient {
   private config: AutoMemConfig;
@@ -102,7 +143,20 @@ export class AutoMemClient {
     return data;
   }
 
-  async storeMemory(args: StoreMemoryArgs): Promise<{ memory_id: string; message: string }> {
+  async storeMemory(args: StoreMemoryArgs): Promise<StoreMemoryResult> {
+    if (Array.isArray(args.memories)) {
+      if (typeof args.content === 'string' && args.content.length > 0) {
+        throw new Error(
+          'store_memory: pass either `content` (single) or `memories` (batch), not both'
+        );
+      }
+      return this.batchStore(args.memories);
+    }
+
+    if (typeof args.content !== 'string' || args.content.length === 0) {
+      throw new Error('store_memory: `content` is required (or pass `memories` for batch mode)');
+    }
+
     const body: MemoryRecord = {
       content: args.content,
       ...(args.type && { type: args.type }),
@@ -129,7 +183,118 @@ export class AutoMemClient {
     };
   }
 
+  private async batchStore(memories: BatchMemoryInput[]): Promise<StoreMemoryResult> {
+    if (memories.length === 0) {
+      throw new Error('store_memory: `memories` array must contain at least one item');
+    }
+    if (memories.length > BATCH_MAX_ITEMS) {
+      throw new Error(
+        `store_memory: \`memories\` array exceeds max ${BATCH_MAX_ITEMS} items (got ${memories.length})`
+      );
+    }
+
+    const sanitized = memories.map((item, index) => {
+      if (!item || typeof item !== 'object') {
+        throw new Error(`store_memory: memories[${index}] must be an object`);
+      }
+      if (typeof item.content !== 'string' || item.content.trim().length === 0) {
+        throw new Error(`store_memory: memories[${index}].content is required`);
+      }
+      for (const field of BATCH_DISALLOWED_FIELDS) {
+        if ((item as any)[field] !== undefined) {
+          throw new Error(
+            `store_memory: memories[${index}].${field} is not allowed in batch mode (use single-store mode for ${field})`
+          );
+        }
+      }
+      const out: BatchMemoryInput = { content: item.content };
+      if (item.tags !== undefined) out.tags = item.tags;
+      if (item.importance !== undefined) out.importance = item.importance;
+      if (item.metadata !== undefined) out.metadata = item.metadata;
+      if (item.timestamp !== undefined) out.timestamp = item.timestamp;
+      if (item.type !== undefined) out.type = item.type;
+      if (item.confidence !== undefined) out.confidence = item.confidence;
+      return out;
+    });
+
+    const response = await this.makeRequest('POST', 'memory/batch', { memories: sanitized });
+    const memoryIds: string[] = Array.isArray(response.memory_ids) ? response.memory_ids : [];
+    const stored: number =
+      typeof response.stored === 'number' ? response.stored : memoryIds.length;
+    return {
+      memory_ids: memoryIds,
+      stored,
+      qdrant: response.qdrant,
+      enrichment: response.enrichment,
+      query_time_ms: response.query_time_ms,
+      message: response.message || `Stored ${stored} memories`,
+    };
+  }
+
   async recallMemory(args: RecallMemoryArgs): Promise<RecallResult> {
+    // Mode 1: ID fetch — short-circuit to GET /memory/{id}.
+    if (typeof args.memory_id === 'string' && args.memory_id.trim().length > 0) {
+      const memory = await this.fetchMemoryById(args.memory_id.trim());
+      return {
+        results: memory ? [wrapMemoryAsRecallResult(memory)] : [],
+        count: memory ? 1 : 0,
+        mode: 'id_fetch',
+      };
+    }
+
+    // Mode 2: tag enumeration — route to GET /memory/by-tag for paginated exact-match listing.
+    if (args.exhaustive === true) {
+      const cleanTags = nonEmptyTags(args.tags);
+      if (cleanTags.length === 0) {
+        throw new Error(
+          'recall_memory: `exhaustive: true` requires non-empty `tags`'
+        );
+      }
+      if (args.tag_match && args.tag_match !== 'exact') {
+        throw new Error(
+          'recall_memory: enumeration mode (`exhaustive: true`) only supports exact tag matching; remove `tag_match: "prefix"`'
+        );
+      }
+      if (args.tag_mode && args.tag_mode !== 'any') {
+        throw new Error(
+          'recall_memory: enumeration mode (`exhaustive: true`) only supports any-of tag matching; remove `tag_mode: "all"`'
+        );
+      }
+      // Reject ranked-only params that would silently change the meaning of the query.
+      // Without this, `recall_memory({ tags, exhaustive: true, time_query: "last 7 days" })`
+      // would return *all* memories tagged X (ignoring the time window), which is misleading.
+      const rankedOnlyParams: Array<keyof RecallMemoryArgs> = [
+        'query',
+        'queries',
+        'embedding',
+        'time_query',
+        'start',
+        'end',
+        'exclude_tags',
+        'expand_relations',
+        'expand_entities',
+        'auto_decompose',
+        'expansion_limit',
+        'relation_limit',
+        'expand_min_importance',
+        'expand_min_strength',
+        'sort',
+      ];
+      const conflicting = rankedOnlyParams.filter((key) => {
+        const v = (args as Record<string, unknown>)[key];
+        if (v === undefined || v === null) return false;
+        if (Array.isArray(v)) return v.length > 0;
+        return true;
+      });
+      if (conflicting.length > 0) {
+        throw new Error(
+          `recall_memory: enumeration mode (\`exhaustive: true\`) only accepts \`tags\`, \`limit\`, \`offset\`, \`tag_mode: "any"\`, \`tag_match: "exact"\`, and \`format\`. Remove ranked-only param(s): ${conflicting.join(', ')}.`
+        );
+      }
+      return this.listByTag(cleanTags, args.limit, args.offset);
+    }
+
+    // Mode 3: ranked retrieval — existing /recall path.
     const params = new URLSearchParams();
 
     // Support single query OR multiple queries
@@ -163,6 +328,10 @@ export class AutoMemClient {
 
     if (Array.isArray(args.tags)) {
       args.tags.forEach((tag) => params.append('tags', tag));
+    }
+
+    if (Array.isArray(args.exclude_tags) && args.exclude_tags.length > 0) {
+      args.exclude_tags.forEach((tag) => params.append('exclude_tags', tag));
     }
 
     if (args.tag_mode && (args.tag_mode === 'any' || args.tag_mode === 'all')) {
@@ -274,6 +443,7 @@ export class AutoMemClient {
         },
       })),
       count: response.count || (response.results ? response.results.length : 0),
+      mode: 'ranked',
       dedup_removed: response.dedup_removed,
       keywords: response.keywords,
       time_window: response.time_window,
@@ -283,6 +453,37 @@ export class AutoMemClient {
       expansion: response.expansion,
       entity_expansion: response.entity_expansion,
       context_priority: response.context_priority,
+    };
+  }
+
+  private async fetchMemoryById(memoryId: string): Promise<any | null> {
+    const response = await this.makeRequest('GET', `memory/${encodeURIComponent(memoryId)}`);
+    return response?.memory ?? response ?? null;
+  }
+
+  private async listByTag(
+    tags: string[],
+    limit?: number,
+    offset?: number
+  ): Promise<RecallResult> {
+    const params = new URLSearchParams();
+    tags.forEach((tag) => params.append('tags', tag));
+    if (typeof limit === 'number' && limit > 0) {
+      params.set('limit', String(Math.min(Math.floor(limit), 200)));
+    }
+    if (typeof offset === 'number' && offset > 0) {
+      params.set('offset', String(Math.floor(offset)));
+    }
+    const response = await this.makeRequest('GET', `memory/by-tag?${params.toString()}`);
+    const memories = Array.isArray(response.memories) ? response.memories : [];
+    return {
+      results: memories.map((m: any) => wrapMemoryAsRecallResult(m)),
+      count: typeof response.count === 'number' ? response.count : memories.length,
+      mode: 'enumeration',
+      tags: response.tags ?? tags,
+      limit: response.limit,
+      offset: response.offset,
+      has_more: Boolean(response.has_more),
     };
   }
 
@@ -338,15 +539,43 @@ export class AutoMemClient {
     };
   }
 
-  async deleteMemory(args: DeleteMemoryArgs): Promise<{ memory_id: string; message: string }> {
-    if (!args.memory_id) {
-      throw new Error('memory_id is required');
+  async deleteMemory(args: DeleteMemoryArgs): Promise<DeleteMemoryResult> {
+    const cleanTags = nonEmptyTags(args.tags);
+    const hasTags = cleanTags.length > 0;
+    const hasId = typeof args.memory_id === 'string' && args.memory_id.trim().length > 0;
+
+    if (hasTags && hasId) {
+      throw new Error(
+        'delete_memory: pass either `memory_id` (single) or `tags` (bulk-by-tag), not both'
+      );
+    }
+
+    if (hasTags) {
+      return this.bulkDeleteByTag(cleanTags);
+    }
+
+    if (!hasId) {
+      throw new Error('delete_memory: `memory_id` or `tags` is required');
     }
 
     const response = await this.makeRequest('DELETE', `memory/${args.memory_id}`);
     return {
       memory_id: response.memory_id || args.memory_id,
       message: response.message || 'Memory deleted successfully',
+    };
+  }
+
+  private async bulkDeleteByTag(tags: string[]): Promise<DeleteMemoryResult> {
+    const params = new URLSearchParams();
+    tags.forEach((tag) => params.append('tags', tag));
+    const response = await this.makeRequest('DELETE', `memory/by-tag?${params.toString()}`);
+    const deleted = typeof response.deleted_count === 'number' ? response.deleted_count : 0;
+    return {
+      deleted_count: deleted,
+      tags: response.tags ?? tags,
+      message:
+        response.message ||
+        `Deleted ${deleted} memor${deleted === 1 ? 'y' : 'ies'} matching tag(s) ${tags.join(', ')}`,
     };
   }
 }

--- a/src/cli/queue.ts
+++ b/src/cli/queue.ts
@@ -178,7 +178,7 @@ export async function runQueueCommand(args: string[] = []): Promise<void> {
     }
 
     if (options.dryRun) {
-      console.log(`[dry-run] would store memory: ${record.content.slice(0, 80)}...`);
+      console.log(`[dry-run] would store memory: ${content.slice(0, 80)}...`);
       storedCount += 1;
       continue;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1047,8 +1047,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case "store_memory": {
         const storeArgs = args as unknown as StoreMemoryArgs;
 
-        // Content size governance applies to single-store mode only.
-        // Batch mode pushes governance into the per-item content trim and the server's auto-summarize.
+        // Content size governance applies to single-store mode only. In batch mode the client
+        // only checks that each item's `content` is non-empty (see batchStore in automem-client.ts);
+        // the AutoMem service enforces its own hard/soft limits and auto-summarizes on the way in.
         const SOFT_LIMIT = 500;
         const HARD_LIMIT = 2000;
         const isBatchMode = Array.isArray(storeArgs.memories);

--- a/src/index.ts
+++ b/src/index.ts
@@ -943,7 +943,7 @@ ${Object.entries(RELATION_TYPE_METADATA).map(([k, v]) => `- ${k}: ${v}`).join('\
       title: "Delete Memory",
       readOnlyHint: false,
       destructiveHint: true,
-      idempotentHint: true,
+      idempotentHint: false,
       openWorldHint: false,
     },
     inputSchema: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -338,9 +338,13 @@ const tools: Tool[] = [
   {
     name: "store_memory",
     title: "Store Memory",
-    description: `Store a memory with optional tags, importance score, and metadata. Use this to persist important information for future recall.
+    description: `Store memory in one of two modes — single-memory (set top-level \`content\`) or batch (set \`memories: [...]\` for up to 500). Use this to persist important information for future recall.
 
-**Content size guidelines:**
+**Mode 1 — Single (default):** pass top-level \`content\` plus any optional fields (tags, importance, metadata, type, confidence, embedding, t_valid, t_invalid, id, etc.).
+
+**Mode 2 — Batch:** pass \`memories: [{ content, tags?, importance?, metadata?, timestamp?, type?, confidence? }, ...]\` to store up to 500 memories in one request. Faster for bulk ingestion (imports, benchmark seeding). Batch mode does NOT accept \`id\`, \`embedding\`, \`t_valid\`, or \`t_invalid\` per-item — use single mode for those.
+
+**Content size guidelines (per item):**
 - Target: 150-300 characters (one meaningful paragraph)
 - Maximum: 500 characters (auto-summarized if exceeded)
 - Hard limit: 2000 characters (rejected)
@@ -351,11 +355,12 @@ const tools: Tool[] = [
 - When discovering a pattern: store the pattern and where it applies
 - After fixing a bug: store the root cause and solution
 - When learning user preferences: store what they prefer and why
+- For bulk ingestion (imports, seeding): use batch mode
 
 **Examples:**
 - store_memory({ content: "Chose PostgreSQL over MongoDB for user service. Need ACID for transactions.", tags: ["architecture", "database"], importance: 0.9 })
-- store_memory({ content: "User prefers early returns over nested conditionals in validation code.", tags: ["code-style", "preferences"], importance: 0.7 })
-- store_memory({ content: "Auth timeout fixed by adding retry with exponential backoff. Root cause: flaky network.", tags: ["bug-fix", "auth"], importance: 0.8 })`,
+- store_memory({ content: "User prefers early returns over nested conditionals.", tags: ["code-style"], importance: 0.7 })
+- store_memory({ memories: [{ content: "...", tags: ["import"] }, { content: "...", tags: ["import"] }] })  // Batch`,
     annotations: {
       title: "Store Memory",
       readOnlyHint: false,
@@ -369,71 +374,91 @@ const tools: Tool[] = [
         content: {
           type: "string",
           description:
-            "The memory content to store. Be specific: include context, reasoning, and outcome.",
+            "Single-memory mode (XOR with `memories`). The memory content to store. Be specific: include context, reasoning, and outcome.",
+        },
+        memories: {
+          type: "array",
+          maxItems: 500,
+          description:
+            "Batch mode (XOR with `content`). Up to 500 memory objects to store in one call. Each item supports content (required), tags, importance, timestamp, type, confidence, metadata. Batch mode does NOT support `id`, `embedding`, `t_valid`, or `t_invalid` per-item — use single-memory mode for those.",
+          items: {
+            type: "object",
+            required: ["content"],
+            properties: {
+              content: { type: "string" },
+              tags: { type: "array", items: { type: "string" } },
+              importance: { type: "number", minimum: 0, maximum: 1 },
+              timestamp: { type: "string" },
+              type: { type: "string", enum: [...MEMORY_TYPES] },
+              confidence: { type: "number", minimum: 0, maximum: 1 },
+              metadata: { type: "object" },
+            },
+          },
         },
         tags: {
           type: "array",
           items: { type: "string" },
           description:
-            'Tags to categorize the memory (e.g., ["project-name", "bug-fix", "auth"])',
+            'Single-memory mode. Tags to categorize the memory (e.g., ["project-name", "bug-fix", "auth"])',
         },
         importance: {
           type: "number",
           minimum: 0,
           maximum: 1,
           description:
-            "Importance score: 0.9+ critical decisions, 0.7-0.9 patterns/bugs, 0.5-0.7 minor notes",
+            "Single-memory mode. Importance: 0.9+ critical decisions, 0.7-0.9 patterns/bugs, 0.5-0.7 minor notes",
         },
         embedding: {
           type: "array",
           items: { type: "number" },
           description:
-            "Optional embedding vector for semantic search (auto-generated if omitted)",
+            "Single-memory mode only. Optional embedding vector for semantic search (auto-generated if omitted). Not supported in batch mode.",
         },
         metadata: {
           type: "object",
           description:
-            'Optional structured metadata (e.g., { files_modified: ["auth.ts"], error_type: "timeout" })',
+            'Single-memory mode. Optional structured metadata (e.g., { files_modified: ["auth.ts"], error_type: "timeout" })',
         },
         timestamp: {
           type: "string",
-          description: "Optional ISO timestamp (defaults to now)",
+          description: "Single-memory mode. Optional ISO timestamp (defaults to now)",
         },
         type: {
           type: "string",
           enum: [...MEMORY_TYPES],
-          description: "Memory type for classification",
+          description: "Single-memory mode. Memory type for classification",
         },
         confidence: {
           type: "number",
           minimum: 0,
           maximum: 1,
           description:
-            "Classification confidence (0-1, default 0.9 when type provided)",
+            "Single-memory mode. Classification confidence (0-1, default 0.9 when type provided)",
         },
         id: {
           type: "string",
-          description: "Custom memory ID (auto-generated if omitted)",
+          description:
+            "Single-memory mode only. Custom memory ID (auto-generated if omitted). Not supported in batch mode.",
         },
         t_valid: {
           type: "string",
           description:
-            "ISO 8601 timestamp when the memory becomes valid",
+            "Single-memory mode only. ISO 8601 timestamp when the memory becomes valid. Not supported in batch mode.",
         },
         t_invalid: {
           type: "string",
-          description: "ISO 8601 timestamp when the memory expires",
+          description:
+            "Single-memory mode only. ISO 8601 timestamp when the memory expires. Not supported in batch mode.",
         },
         updated_at: {
           type: "string",
-          description: "ISO 8601 last-updated timestamp",
+          description: "Single-memory mode. ISO 8601 last-updated timestamp",
         },
         last_accessed: {
           type: "string",
-          description: "ISO 8601 last-accessed timestamp",
+          description: "Single-memory mode. ISO 8601 last-accessed timestamp",
         },
       },
-      required: ["content"],
     },
     outputSchema: {
       type: "object",
@@ -441,41 +466,63 @@ const tools: Tool[] = [
         memory_id: {
           type: "string",
           description:
-            "Unique ID of the stored memory (use this for associations)",
+            "Single-mode result: unique ID of the stored memory (use for associations)",
+        },
+        memory_ids: {
+          type: "array",
+          items: { type: "string" },
+          description: "Batch-mode result: IDs of the stored memories.",
+        },
+        stored: {
+          type: "integer",
+          description: "Batch-mode result: number of memories stored.",
+        },
+        qdrant: {
+          type: "string",
+          description: "Batch-mode result: Qdrant indexing summary from the server.",
+        },
+        enrichment: {
+          type: "string",
+          description: "Batch-mode result: enrichment status from the server.",
+        },
+        query_time_ms: {
+          type: "number",
+          description: "Batch-mode result: server-reported execution time in milliseconds.",
         },
         message: {
           type: "string",
           description: "Confirmation message",
         },
       },
-      required: ["memory_id", "message"],
+      required: ["message"],
     },
   },
   {
     name: "recall_memory",
     title: "Recall Memory",
-    description: `Search and retrieve relevant memories using semantic search, keywords, tags, time filters, and graph expansion. This is the primary tool for accessing stored knowledge.
+    description: `Recall memories from AutoMem in one of three modes. The mode is selected by which params you pass.
 
-**When to use:**
+**Mode 1 — ID fetch:** pass \`memory_id\` to retrieve a single memory by ID. All other params are ignored. Routes to GET /memory/{id} and updates last_accessed.
+
+**Mode 2 — Tag enumeration:** pass \`tags\` + \`exhaustive: true\` for paginated exact-match listing (NOT ranked retrieval). Use this for cleanup/audit workflows where ranked retrieval silently undercounts large tag sets. Pair with \`limit\` (≤200) and \`offset\`. Returns \`has_more\`/\`limit\`/\`offset\` page metadata. Tag matching is exact, case-insensitive, any-of mode — \`tag_match: "prefix"\` and \`tag_mode: "all"\` are rejected in this mode.
+
+**Mode 3 — Ranked retrieval (default):** hybrid search across vector, keyword, tags, recency, and optional graph expansion. The primary tool for finding relevant context.
+
+**When to use ranked (mode 3):**
 - At conversation start: recall context about the current project/topic
 - Before making decisions: check for past decisions on similar topics
 - When debugging: search for similar past errors and their solutions
-- When implementing: find established patterns and preferences
-- For complex questions: use expand_entities for multi-hop reasoning
+- For complex questions: use \`expand_entities\` for multi-hop reasoning
 
-**Search strategies:**
-- Semantic: Use natural language queries like "authentication timeout issues"
-- Tags: Filter by project or category with tags: ["my-project", "bug-fix"]
-- Time: Use time_query for recency like "last 7 days" or "today"
-- Multi-query: Pass multiple queries in 'queries' array for broader recall
-- Multi-hop: Use expand_entities=true for questions requiring connected reasoning
+**When to use enumeration (mode 2):** when you need to know *how many* memories carry a tag, or to walk all of them for cleanup/migration. Ranked recall ignores low-importance hits — enumeration does not.
 
 **Examples:**
 - recall_memory({ query: "database architecture decisions", tags: ["my-project"], limit: 5 })
-- recall_memory({ queries: ["auth patterns", "login flow", "JWT tokens"], limit: 10 })
-- recall_memory({ tags: ["bug-fix"], time_query: "last 30 days", limit: 5 })
-- recall_memory({ query: "What is Sarah's sister's job?", expand_entities: true })  // Multi-hop
-- recall_memory({ query: "Python style preferences", language: "python", context: "coding-style" })`,
+- recall_memory({ memory_id: "abc123" })  // Mode 1
+- recall_memory({ tags: ["benchmark-test"], exhaustive: true, limit: 50 })  // Mode 2
+- recall_memory({ tags: ["benchmark-test"], exhaustive: true, limit: 50, offset: 50 })  // Mode 2 page 2
+- recall_memory({ query: "auth", exclude_tags: ["deprecated"] })  // Mode 3 with exclusion
+- recall_memory({ query: "What is Sarah's sister's job?", expand_entities: true })  // Mode 3 multi-hop`,
     annotations: {
       title: "Recall Memory",
       readOnlyHint: true,
@@ -486,6 +533,22 @@ const tools: Tool[] = [
     inputSchema: {
       type: "object",
       properties: {
+        memory_id: {
+          type: "string",
+          description:
+            "MODE: ID fetch. When set, fetches the single memory by ID and IGNORES all other params. Routes to GET /memory/{id}; updates last_accessed.",
+        },
+        exhaustive: {
+          type: "boolean",
+          description:
+            "MODE: tag enumeration. When true, requires non-empty `tags`. Routes to GET /memory/by-tag for paginated exact-match listing — NOT ranked retrieval. Use for cleanup/audit workflows where ranked recall undercounts. `limit` is clamped to 200. `tag_match: \"prefix\"` and `tag_mode: \"all\"` are rejected in this mode.",
+        },
+        exclude_tags: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Ranked-mode only. Tags to exclude from results (any match excludes). Independent of `tag_match` — supports both exact and prefix matching internally on the server.",
+        },
         query: {
           type: "string",
           description:
@@ -505,10 +568,10 @@ const tools: Tool[] = [
         limit: {
           type: "integer",
           minimum: 1,
-          maximum: 50,
+          maximum: 200,
           default: 5,
           description:
-            "Max memories to return (default: 5, increase for broader context)",
+            "Max memories to return. Schema allows 1–200; in enumeration mode (`exhaustive: true`) the server honors up to 200, while ranked mode is typically clamped server-side to ~50. Default 5.",
         },
         time_query: {
           type: "string",
@@ -655,6 +718,24 @@ const tools: Tool[] = [
         count: {
           type: "integer",
           description: "Number of memories returned",
+        },
+        mode: {
+          type: "string",
+          enum: ["ranked", "enumeration", "id_fetch"],
+          description: "Mode that produced the result.",
+        },
+        has_more: {
+          type: "boolean",
+          description:
+            "Enumeration mode only: true if more pages exist past `offset + limit`.",
+        },
+        limit: {
+          type: "integer",
+          description: "Enumeration mode only: page size used for this response.",
+        },
+        offset: {
+          type: "integer",
+          description: "Enumeration mode only: offset used for this response.",
         },
         results: {
           type: "array",
@@ -843,16 +924,21 @@ ${Object.entries(RELATION_TYPE_METADATA).map(([k, v]) => `- ${k}: ${v}`).join('\
   {
     name: "delete_memory",
     title: "Delete Memory",
-    description: `Permanently delete a memory and its embedding. Use sparingly - consider updating instead.
+    description: `Delete a memory by ID (\`memory_id\`) or bulk-delete by tag (\`tags\`). Use sparingly — consider \`update_memory\` instead.
+
+**Mode 1 — Single (default):** pass \`memory_id\` to delete one memory and its embedding. Idempotent: re-running on the same ID is a no-op.
+
+**Mode 2 — Bulk-by-tag:** pass \`tags: [...]\` to delete ALL memories tagged with ANY of these tags. Tag matching is exact (case-insensitive), any-of mode. There is NO dry-run. This can delete thousands of memories in one call. NOT idempotent in practice — re-running may catch new memories that were tagged the same way after the first call. Verify with \`recall_memory({ tags, exhaustive: true })\` first if uncertain.
 
 **When to use:**
-- Memory contains incorrect information that can't be corrected
-- Memory is a duplicate
-- Memory contains sensitive information that shouldn't persist
-- Memory is no longer relevant and clutters recall results
+- Memory contains incorrect information that can't be corrected (Mode 1)
+- Memory is a duplicate (Mode 1)
+- Cleanup of benchmark/test data scoped by tag (Mode 2)
+- Removing all memories under a deprecated tag namespace (Mode 2)
 
-**Example:**
-- delete_memory({ memory_id: "abc123" })`,
+**Examples:**
+- delete_memory({ memory_id: "abc123" })  // Mode 1
+- delete_memory({ tags: ["benchmark-test"] })  // Mode 2, bulk by tag`,
     annotations: {
       title: "Delete Memory",
       readOnlyHint: false,
@@ -866,24 +952,38 @@ ${Object.entries(RELATION_TYPE_METADATA).map(([k, v]) => `- ${k}: ${v}`).join('\
         memory_id: {
           type: "string",
           description:
-            "ID of the memory to delete (from store_memory or recall results)",
+            "Single-delete mode (XOR with `tags`). ID of the memory to delete (from store_memory or recall results).",
+        },
+        tags: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Bulk-delete mode (XOR with `memory_id`). Bulk-deletes ALL memories tagged with ANY of these tags. Exact match, case-insensitive. No dry-run.",
         },
       },
-      required: ["memory_id"],
     },
     outputSchema: {
       type: "object",
       properties: {
         memory_id: {
           type: "string",
-          description: "ID of the deleted memory",
+          description: "Single-delete result: ID of the deleted memory.",
+        },
+        deleted_count: {
+          type: "integer",
+          description: "Bulk-delete result: number of memories deleted.",
+        },
+        tags: {
+          type: "array",
+          items: { type: "string" },
+          description: "Bulk-delete result: tags that were used for the bulk delete.",
         },
         message: {
           type: "string",
           description: "Confirmation message",
         },
       },
-      required: ["memory_id", "message"],
+      required: ["message"],
     },
   },
   {
@@ -947,39 +1047,70 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case "store_memory": {
         const storeArgs = args as unknown as StoreMemoryArgs;
 
-        // Content size governance: reject if content exceeds hard limit
+        // Content size governance applies to single-store mode only.
+        // Batch mode pushes governance into the per-item content trim and the server's auto-summarize.
         const SOFT_LIMIT = 500;
         const HARD_LIMIT = 2000;
-        const contentLength = storeArgs.content?.length || 0;
+        const isBatchMode = Array.isArray(storeArgs.memories);
+        const contentLength = isBatchMode ? 0 : (storeArgs.content?.length || 0);
         let sizeWarning = "";
 
-        // Hard limit: reject oversized content outright
-        if (contentLength > HARD_LIMIT) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `❌ Memory rejected: Content length (${contentLength} chars) exceeds hard limit (${HARD_LIMIT} chars).\n\nPlease split into smaller, focused memories or summarize the content before storing.`,
+        if (!isBatchMode) {
+          // Hard limit: reject oversized content outright (single mode only)
+          if (contentLength > HARD_LIMIT) {
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: `❌ Memory rejected: Content length (${contentLength} chars) exceeds hard limit (${HARD_LIMIT} chars).\n\nPlease split into smaller, focused memories or summarize the content before storing.`,
+                },
+              ],
+              structuredContent: {
+                error: "content_too_large",
+                content_length: contentLength,
+                hard_limit: HARD_LIMIT,
+                message: `Content exceeds maximum allowed length of ${HARD_LIMIT} characters`,
               },
-            ],
-            structuredContent: {
-              error: "content_too_large",
-              content_length: contentLength,
-              hard_limit: HARD_LIMIT,
-              message: `Content exceeds maximum allowed length of ${HARD_LIMIT} characters`,
-            },
-            isError: true,
-          };
-        }
+              isError: true,
+            };
+          }
 
-        // Soft limit: warn that backend may auto-summarize
-        if (contentLength > SOFT_LIMIT) {
-          sizeWarning = `\n📝 Content length (${contentLength} chars) exceeds recommended size (${SOFT_LIMIT}). Backend may auto-summarize.`;
+          // Soft limit: warn that backend may auto-summarize
+          if (contentLength > SOFT_LIMIT) {
+            sizeWarning = `\n📝 Content length (${contentLength} chars) exceeds recommended size (${SOFT_LIMIT}). Backend may auto-summarize.`;
+          }
         }
 
         const result = await client.storeMemory(storeArgs);
 
-        // Build response text
+        if (isBatchMode) {
+          const stored = result.stored ?? result.memory_ids?.length ?? 0;
+          const ids = result.memory_ids ?? [];
+          const idPreview = ids.length > 10
+            ? `${ids.slice(0, 10).join(', ')}, …(+${ids.length - 10})`
+            : ids.join(', ');
+          const output = {
+            stored,
+            memory_ids: ids,
+            message: result.message,
+            ...(result.qdrant ? { qdrant: result.qdrant } : {}),
+            ...(result.enrichment ? { enrichment: result.enrichment } : {}),
+            ...(typeof result.query_time_ms === 'number'
+              ? { query_time_ms: result.query_time_ms }
+              : {}),
+          };
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Stored ${stored} memories.${idPreview ? `\nIDs: ${idPreview}` : ''}\nMessage: ${result.message}`,
+              },
+            ],
+            structuredContent: output,
+          };
+        }
+
+        // Single-store mode response
         let responseText = `Memory stored successfully!\n\nMemory ID: ${result.memory_id}`;
         if (result.message) {
           responseText += `\nMessage: ${result.message}`;
@@ -1063,6 +1194,26 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case "delete_memory": {
         const deleteArgs = args as unknown as DeleteMemoryArgs;
         const result = await client.deleteMemory(deleteArgs);
+
+        if (typeof result.deleted_count === 'number') {
+          // Bulk-delete-by-tag mode
+          const tags = result.tags ?? deleteArgs.tags ?? [];
+          const output = {
+            deleted_count: result.deleted_count,
+            tags,
+            message: result.message,
+          };
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Bulk delete complete: removed ${result.deleted_count} memor${result.deleted_count === 1 ? 'y' : 'ies'} matching tag(s) ${tags.join(', ')}.`,
+              },
+            ],
+            structuredContent: output,
+          };
+        }
+
         const output = {
           memory_id: result.memory_id,
           message: `Memory ${result.memory_id} deleted successfully!`,

--- a/src/openclaw-plugin.test.ts
+++ b/src/openclaw-plugin.test.ts
@@ -66,6 +66,111 @@ describe('openclaw AutoMem plugin', () => {
     expect(isLikelyStartupTurn([{}, {}])).toBe(false);
   });
 
+  describe('extended schemas (parity with v0.15.2)', () => {
+    function captureRegisteredTools(pluginConfig?: Record<string, unknown>) {
+      const tools: Array<{
+        name: string;
+        execute: (id: string, params: unknown) => Promise<unknown>;
+        parameters: any;
+      }> = [];
+      openClawPlugin.register({
+        pluginConfig: {
+          endpoint: 'http://localhost:8001',
+          autoRecall: false,
+          ...(pluginConfig || {}),
+        },
+        logger: { warn: vi.fn() },
+        registerTool: (tool) => {
+          tools.push({
+            name: tool.name,
+            execute: tool.execute,
+            parameters: tool.parameters,
+          });
+        },
+        on: () => {},
+      });
+      return tools;
+    }
+
+    it('exposes new params on recall, store, delete schemas', () => {
+      const tools = captureRegisteredTools();
+      const recall = tools.find((t) => t.name === 'automem_recall_memory');
+      const store = tools.find((t) => t.name === 'automem_store_memory');
+      const del = tools.find((t) => t.name === 'automem_delete_memory');
+      expect(recall?.parameters?.properties?.memory_id).toBeDefined();
+      expect(recall?.parameters?.properties?.exhaustive).toBeDefined();
+      expect(recall?.parameters?.properties?.exclude_tags).toBeDefined();
+      expect(store?.parameters?.properties?.memories).toBeDefined();
+      expect(store?.parameters?.properties?.memories?.maxItems).toBe(500);
+      expect(del?.parameters?.properties?.tags).toBeDefined();
+      expect(del?.parameters?.required).toBeUndefined();
+    });
+
+    it('keeps the surface at six tools (no new tool registrations)', () => {
+      const tools = captureRegisteredTools();
+      expect(tools.map((t) => t.name).sort()).toEqual([
+        'automem_associate_memories',
+        'automem_check_health',
+        'automem_delete_memory',
+        'automem_recall_memory',
+        'automem_store_memory',
+        'automem_update_memory',
+      ]);
+    });
+
+    it('applies mergeTags per item in batch store mode', async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ stored: 2, memory_ids: ['m1', 'm2'], status: 'success' })
+      );
+
+      const tools = captureRegisteredTools({ defaultTags: ['mcp-automem'] });
+      const store = tools.find((t) => t.name === 'automem_store_memory')!;
+
+      await store.execute('call-1', {
+        memories: [
+          { content: 'one', tags: ['extra'] },
+          { content: 'two' },
+        ],
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1]?.body as string);
+      expect(body.memories).toHaveLength(2);
+      expect(body.memories[0].tags).toEqual(['mcp-automem', 'extra']);
+      expect(body.memories[1].tags).toEqual(['mcp-automem']);
+    });
+
+    it('does not inject defaultTags on bulk-delete-by-tag', async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ status: 'success', tags: ['x'], deleted_count: 1 })
+      );
+
+      const tools = captureRegisteredTools({ defaultTags: ['mcp-automem'] });
+      const del = tools.find((t) => t.name === 'automem_delete_memory')!;
+
+      await del.execute('call-1', { tags: ['x'] });
+
+      const url = getRequestUrl(0);
+      expect(url.pathname).toBe('/memory/by-tag');
+      const tagParams = url.searchParams.getAll('tags');
+      expect(tagParams).toEqual(['x']);
+      expect(tagParams).not.toContain('mcp-automem');
+    });
+
+    it('routes recall_memory({memory_id}) to GET /memory/{id}', async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ status: 'success', memory: { id: 'mem-x', content: 'hi' } })
+      );
+
+      const tools = captureRegisteredTools();
+      const recall = tools.find((t) => t.name === 'automem_recall_memory')!;
+
+      await recall.execute('call-1', { memory_id: 'mem-x' });
+
+      const url = getRequestUrl(0);
+      expect(url.pathname).toBe('/memory/mem-x');
+    });
+  });
+
   it('detects profile-like memories', () => {
     expect(
       looksLikeOpenClawProfileCue({

--- a/src/openclaw-plugin.ts
+++ b/src/openclaw-plugin.ts
@@ -15,6 +15,7 @@ import {
 } from './memory-policy/shared.js';
 import type {
   AssociateMemoryArgs,
+  BatchMemoryInput,
   DeleteMemoryArgs,
   RecallMemoryArgs,
   StoreMemoryArgs,
@@ -312,9 +313,27 @@ const emptyToolSchema = {
 const storeMemorySchema = {
   type: 'object',
   additionalProperties: false,
-  required: ['content'],
   properties: {
-    content: { type: 'string', description: 'Memory content to store.' },
+    content: { type: 'string', description: 'Single-mode (XOR with `memories`). Memory content to store.' },
+    memories: {
+      type: 'array',
+      maxItems: 500,
+      description:
+        'Batch mode (XOR with `content`). Up to 500 memories per call. Per-item `id`/`embedding`/`t_valid`/`t_invalid` are not supported in batch mode.',
+      items: {
+        type: 'object',
+        required: ['content'],
+        properties: {
+          content: { type: 'string' },
+          tags: { type: 'array', items: { type: 'string' } },
+          importance: { type: 'number' },
+          metadata: { type: 'object' },
+          timestamp: { type: 'string' },
+          type: { type: 'string' },
+          confidence: { type: 'number' },
+        },
+      },
+    },
     type: { type: 'string', description: 'Memory classification.' },
     confidence: { type: 'number' },
     id: { type: 'string' },
@@ -334,6 +353,9 @@ const recallMemorySchema = {
   type: 'object',
   additionalProperties: false,
   properties: {
+    memory_id: { type: 'string', description: 'Mode 1: ID fetch. When set, ignores all other params.' },
+    exhaustive: { type: 'boolean', description: 'Mode 2: tag enumeration. When true with `tags`, paginated exact-match listing.' },
+    exclude_tags: { type: 'array', items: { type: 'string' }, description: 'Ranked-mode only. Tags to exclude.' },
     query: { type: 'string' },
     queries: { type: 'array', items: { type: 'string' } },
     embedding: { type: 'array', items: { type: 'number' } },
@@ -385,9 +407,13 @@ const updateMemorySchema = {
 const deleteMemorySchema = {
   type: 'object',
   additionalProperties: false,
-  required: ['memory_id'],
   properties: {
-    memory_id: { type: 'string' },
+    memory_id: { type: 'string', description: 'Single-delete mode (XOR with `tags`).' },
+    tags: {
+      type: 'array',
+      items: { type: 'string' },
+      description: 'Bulk-delete mode (XOR with `memory_id`). Deletes all memories tagged with ANY of these (exact, case-insensitive). No dry-run.',
+    },
   },
 };
 
@@ -506,10 +532,28 @@ const openClawPlugin = {
     api.registerTool({
       name: 'automem_store_memory',
       label: 'AutoMem Store Memory',
-      description: 'Store a durable memory in AutoMem.',
+      description:
+        'Store a durable memory in AutoMem. Single-mode (set `content`) or batch mode (set `memories: [...]`, up to 500). Batch mode does not accept per-item id/embedding/t_valid/t_invalid.',
       parameters: storeMemorySchema,
       async execute(_toolCallId, params) {
         const request = params as StoreMemoryArgs;
+        if (Array.isArray(request.memories)) {
+          const mergedMemories = request.memories.map((item) => {
+            const merged = mergeTags(config.defaultTags, item.tags);
+            const next: BatchMemoryInput = { ...item };
+            if (merged !== undefined) {
+              next.tags = merged;
+            } else {
+              delete next.tags;
+            }
+            return next;
+          });
+          const result = await client.storeMemory({
+            ...request,
+            memories: mergedMemories,
+          });
+          return jsonResult(result);
+        }
         const result = await client.storeMemory({
           ...request,
           tags: mergeTags(config.defaultTags, request.tags),
@@ -521,7 +565,8 @@ const openClawPlugin = {
     api.registerTool({
       name: 'automem_recall_memory',
       label: 'AutoMem Recall Memory',
-      description: 'Recall relevant memories from AutoMem.',
+      description:
+        'Recall memories in one of three modes. (1) ID fetch: pass `memory_id`. (2) Tag enumeration: pass `tags` + `exhaustive: true` for paginated exact-match listing. (3) Ranked retrieval (default): hybrid search across vector/keyword/tags/recency.',
       parameters: recallMemorySchema,
       async execute(_toolCallId, params) {
         const request = params as RecallMemoryArgs;
@@ -551,7 +596,8 @@ const openClawPlugin = {
     api.registerTool({
       name: 'automem_delete_memory',
       label: 'AutoMem Delete Memory',
-      description: 'Delete a stored AutoMem memory by id.',
+      description:
+        'Delete a stored AutoMem memory. Single-mode (set `memory_id`) or bulk-by-tag (set `tags`). Bulk-by-tag has no dry-run; verify with `automem_recall_memory({ tags, exhaustive: true })` first.',
       parameters: deleteMemorySchema,
       async execute(_toolCallId, params) {
         const result = await client.deleteMemory(params as DeleteMemoryArgs);

--- a/src/recall-memory.test.ts
+++ b/src/recall-memory.test.ts
@@ -124,4 +124,47 @@ describe('buildRecallMemoryResponse', () => {
       ],
     });
   });
+
+  it('surfaces enumeration metadata (mode/has_more/limit/offset) when present', async () => {
+    const recallResult = makeRecallResult({
+      mode: 'enumeration',
+      count: 1,
+      limit: 50,
+      offset: 50,
+      has_more: true,
+    });
+    const client = {
+      recallMemory: vi.fn().mockResolvedValue(recallResult),
+    };
+
+    const response = await buildRecallMemoryResponse(client, {
+      tags: ['benchmark'],
+      exhaustive: true,
+      limit: 50,
+      offset: 50,
+    });
+
+    expect(response.structuredContent).toMatchObject({
+      mode: 'enumeration',
+      has_more: true,
+      limit: 50,
+      offset: 50,
+    });
+    expect(response.content[0].text).toContain('enumeration page: offset 50, limit 50');
+    expect(response.content[0].text).toContain('more pages available');
+  });
+
+  it('omits enumeration metadata fields when result is in ranked mode', async () => {
+    const recallResult = makeRecallResult({ mode: 'ranked' });
+    const client = {
+      recallMemory: vi.fn().mockResolvedValue(recallResult),
+    };
+
+    const response = await buildRecallMemoryResponse(client, { query: 'x' });
+
+    expect(response.structuredContent).toMatchObject({ mode: 'ranked' });
+    expect(response.structuredContent).not.toHaveProperty('has_more');
+    expect(response.structuredContent).not.toHaveProperty('offset');
+    expect(response.structuredContent).not.toHaveProperty('limit');
+  });
 });

--- a/src/recall-memory.ts
+++ b/src/recall-memory.ts
@@ -55,6 +55,12 @@ function buildStructuredRecallOutput(
       };
     }),
     count: recallResult.count ?? results.length,
+    ...(recallResult.mode ? { mode: recallResult.mode } : {}),
+    ...(typeof recallResult.has_more === 'boolean'
+      ? { has_more: recallResult.has_more }
+      : {}),
+    ...(typeof recallResult.limit === 'number' ? { limit: recallResult.limit } : {}),
+    ...(typeof recallResult.offset === 'number' ? { offset: recallResult.offset } : {}),
     ...(typeof recallResult.dedup_removed === 'number'
       ? { dedup_removed: recallResult.dedup_removed }
       : {}),
@@ -141,6 +147,12 @@ export async function buildRecallMemoryResponse(
   }
   if (recallResult.expansion?.enabled && recallResult.expansion.expanded_count > 0) {
     notes.push(`${recallResult.expansion.expanded_count} via relation expansion`);
+  }
+  if (recallResult.mode === 'enumeration') {
+    const offset = recallResult.offset ?? 0;
+    const limit = recallResult.limit ?? results.length;
+    const pageSuffix = recallResult.has_more ? ' — more pages available' : '';
+    notes.push(`enumeration page: offset ${offset}, limit ${limit}${pageSuffix}`);
   }
   const notesSuffix = notes.length > 0 ? ` (${notes.join('; ')})` : '';
   const format = recallArgs.format || 'text';

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -83,7 +83,7 @@ describe('Type Definitions', () => {
   });
 
   describe('StoreMemoryArgs', () => {
-    it('should require content', () => {
+    it('should accept single-mode content', () => {
       const args: StoreMemoryArgs = { content: 'test' };
       expect(args.content).toBe('test');
     });
@@ -99,6 +99,17 @@ describe('Type Definitions', () => {
       };
       expect(args.tags).toHaveLength(2);
       expect(args.importance).toBe(0.8);
+    });
+
+    it('should accept batch-mode memories[] without content', () => {
+      const args: StoreMemoryArgs = {
+        memories: [
+          { content: 'one' },
+          { content: 'two', tags: ['x'] },
+        ],
+      };
+      expect(args.memories).toHaveLength(2);
+      expect(args.content).toBeUndefined();
     });
   });
 
@@ -208,9 +219,15 @@ describe('Type Definitions', () => {
   });
 
   describe('DeleteMemoryArgs', () => {
-    it('should require memory_id', () => {
+    it('should accept single-mode memory_id', () => {
       const args: DeleteMemoryArgs = { memory_id: 'mem-to-delete' };
       expect(args.memory_id).toBe('mem-to-delete');
+    });
+
+    it('should accept bulk-by-tag mode', () => {
+      const args: DeleteMemoryArgs = { tags: ['benchmark'] };
+      expect(args.tags).toEqual(['benchmark']);
+      expect(args.memory_id).toBeUndefined();
     });
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,11 @@ export interface RecallResult {
   tags?: string[];
   tag_mode?: 'any' | 'all';
   tag_match?: 'exact' | 'prefix';
+  // Set in enumeration mode (recall with exhaustive: true) — server returns page metadata.
+  mode?: 'ranked' | 'enumeration' | 'id_fetch';
+  has_more?: boolean;
+  limit?: number;
+  offset?: number;
   expansion?: {
     enabled: boolean;
     seed_count: number;
@@ -124,8 +129,23 @@ export interface HealthStatus {
   error?: string;
 }
 
-export interface StoreMemoryArgs {
+/**
+ * Per-item shape for batch store mode. Server-side `POST /memory/batch`
+ * does NOT accept `id`, `embedding`, `t_valid`, or `t_invalid` per-item —
+ * use single-store mode (top-level `content`) for those.
+ */
+export interface BatchMemoryInput {
   content: string;
+  tags?: string[];
+  importance?: number;
+  metadata?: Record<string, any>;
+  timestamp?: string;
+  type?: MemoryType;
+  confidence?: number;
+}
+
+export interface StoreMemoryArgs {
+  content?: string;
   type?: MemoryType;
   confidence?: number;
   id?: string;
@@ -138,9 +158,31 @@ export interface StoreMemoryArgs {
   t_invalid?: string;
   updated_at?: string;
   last_accessed?: string;
+  // Batch mode (XOR with `content`): up to 500 memories in one request.
+  memories?: BatchMemoryInput[];
+}
+
+export interface StoreMemoryResult {
+  // Single-store mode populates these:
+  memory_id?: string;
+  // Batch-store mode populates these:
+  memory_ids?: string[];
+  stored?: number;
+  qdrant?: string;
+  enrichment?: string;
+  query_time_ms?: number;
+  // Always present:
+  message: string;
 }
 
 export interface RecallMemoryArgs {
+  // Mode 1 (ID fetch): when set, route to GET /memory/{id} and ignore everything else.
+  memory_id?: string;
+  // Mode 2 (tag enumeration): when true with `tags`, route to GET /memory/by-tag for paginated
+  // exact-match listing. Pair with `limit` and `offset`. Ignores ranked-only options.
+  exhaustive?: boolean;
+  // Ranked-mode only: tags to exclude from results (any match excludes).
+  exclude_tags?: string[];
   query?: string;
   queries?: string[];
   embedding?: number[];
@@ -195,5 +237,19 @@ export interface UpdateMemoryArgs {
 }
 
 export interface DeleteMemoryArgs {
-  memory_id: string;
+  // Single-delete mode (XOR with `tags`): delete one memory by ID.
+  memory_id?: string;
+  // Bulk-delete mode (XOR with `memory_id`): delete all memories tagged with ANY of these tags.
+  // Tag matching is exact (case-insensitive), any-of mode. No dry-run.
+  tags?: string[];
+}
+
+export interface DeleteMemoryResult {
+  // Single-delete mode populates this:
+  memory_id?: string;
+  // Bulk-delete mode populates these:
+  deleted_count?: number;
+  tags?: string[];
+  // Always present:
+  message: string;
 }

--- a/templates/CLAUDE_CODE_INTEGRATION.md
+++ b/templates/CLAUDE_CODE_INTEGRATION.md
@@ -130,11 +130,11 @@ Claude stores significant events:
 
 ## Available Tools
 
-- `store_memory` - Save memories with tags, importance, metadata
-- `recall_memory` - Hybrid search with graph expansion and context hints
+- `store_memory` - Save memories with tags, importance, metadata. Supports **batch mode** via `memories: [...]` (≤500 items)
+- `recall_memory` - Hybrid search with graph expansion and context hints. Also supports **ID fetch** (`memory_id`) and **tag enumeration** (`exhaustive: true` + `tags`, paginated)
 - `associate_memories` - Create relationships (11 public authorable types)
 - `update_memory` - Modify existing memories
-- `delete_memory` - Remove memories
+- `delete_memory` - Remove memory by ID or **bulk-by-tag** (`tags: [...]`)
 - `check_database_health` - Monitor service status
 
 ## Tips

--- a/templates/CLAUDE_MD_MEMORY_RULES.md
+++ b/templates/CLAUDE_MD_MEMORY_RULES.md
@@ -114,11 +114,14 @@ Don't re-recall mid-conversation unless the topic genuinely shifts. With 1M cont
 
 ## MCP Tools Available
 
-- `store_memory` — save content with tags, importance (0.0–1.0), type, metadata, optional `t_valid` / `t_invalid`
-- `recall_memory` — hybrid search (semantic + keyword + tags + time filters)
+- `store_memory` — save content with tags, importance (0.0–1.0), type, metadata, optional `t_valid` / `t_invalid`. Supports **batch mode** via `memories: [...]` (≤500 items, no per-item `id`/`embedding`/`t_valid`/`t_invalid`).
+- `recall_memory` — three modes:
+  - **ID fetch:** `memory_id` (ignores other params)
+  - **Tag enumeration:** `tags` + `exhaustive: true` (paginated, exact-match, returns `has_more`)
+  - **Ranked retrieval (default):** hybrid search; supports `exclude_tags` to scope out tag namespaces
 - `associate_memories` — create typed relationships between memories
 - `update_memory` — modify existing memories without duplication
-- `delete_memory` — remove by ID
+- `delete_memory` — remove by ID, or **bulk-by-tag** with `tags: [...]` (exact, case-insensitive, no dry-run)
 - `check_database_health` — FalkorDB + Qdrant status
 
 ### Memory schema


### PR DESCRIPTION
## Summary

- Brings the MCP client to parity with AutoMem service v0.15.2's memory CRUD surface (`GET /memory/{id}`, `GET /memory/by-tag`, `DELETE /memory/by-tag`, `POST /memory/batch`, `exclude_tags` on `/recall`) **without adding any new tools** — each capability ships as an additional mode on an existing tool. The server now exposes the same six tools (`store_memory`, `recall_memory`, `associate_memories`, `update_memory`, `delete_memory`, `check_database_health`).
- Engages directly with the user's `~/.claude/CLAUDE.md` "Resist Tool Bloat" guidance, which names `get_memory` and `list_memories_by_tag` as the exact anti-pattern examples to consolidate around.
- Tool descriptions rewritten to lead with mode selection; XOR rejections + ranked-only-param guards in enumeration mode prevent silent misuse (e.g., `recall_memory({ tags, exhaustive: true, time_query: "last 7 days" })` now errors instead of returning unbounded results).

### Modes added

| Tool | New mode | Wraps |
| --- | --- | --- |
| `recall_memory` | `memory_id` → ID fetch (ignores other params) | `GET /memory/{id}` |
| `recall_memory` | `tags` + `exhaustive: true` → paginated enumeration with `has_more`/`limit`/`offset` | `GET /memory/by-tag` |
| `recall_memory` | `exclude_tags` on ranked mode | `/recall` |
| `store_memory` | `memories: [...]` (≤500) — rejects per-item `id`/`embedding`/`t_valid`/`t_invalid` | `POST /memory/batch` |
| `delete_memory` | `tags: [...]` → bulk-by-tag (XOR with `memory_id`, no dry-run) | `DELETE /memory/by-tag` |

OpenClaw plugin schemas mirror the new modes (no new plugin tools either). Batch store applies configured `defaultTags` per item; bulk-delete-by-tag never injects defaults.

### Server-contract fidelity

Verified against `automem/api/memory.py` on `main` (PR verygoodplugins/automem#145, v0.15.2):

- `DELETE /memory/by-tag` URL emits only `tags` (server ignores `limit`/`offset` on DELETE).
- `GET /memory/by-tag` `limit` is clamped to ≤200 client-side.
- Batch body never contains per-item `id`/`embedding`/`t_valid`/`t_invalid` (server rejects).

## Test plan

- [x] `npm run build` passes
- [x] `npx vitest run` — **257/257 tests passing** (covers all three recall modes, batch validation, bulk-delete URL shape, XOR rejections, ranked-only-param guard in enumeration mode, and the plugin's per-item `mergeTags` policy)
- [x] `tools/list` confirms exactly 6 tools with the new mode-multiplexed schemas
- [ ] **Live smoke against the real AutoMem instance** — deferred during local review (sandbox declined the credentialed health probe). Recommended sequence before merging:
  - `store_memory({ memories: [3 items tagged "parity-smoke-test"] })` → assert `stored: 3`
  - `recall_memory({ tags: ["parity-smoke-test"], exhaustive: true })` → `count: 3`, `has_more: false`
  - `recall_memory({ tags: ["parity-smoke-test"], exhaustive: true, limit: 2 })` → `count: 2, has_more: true`; `offset: 2` → `count: 1`
  - `recall_memory({ memory_id: <one id> })` → `count: 1`, `last_accessed` updated
  - `recall_memory({ query: "anything", tags: ["parity-smoke-test"], exclude_tags: ["parity-smoke-test"] })` → empty
  - `delete_memory({ tags: ["parity-smoke-test"] })` → reports 3 deleted
  - Re-run enumeration → `count: 0`
- [ ] Manual MCP Inspector / Claude Desktop walk-through to confirm each new mode renders sensibly in human-readable text output.

## Notes

- `cli/queue.ts` had a pre-existing bug (logged unsanitized `record.content` in dry-run); fixed incidentally as part of typing `StoreMemoryArgs.content` as optional.
- `CLAUDE.md` MCP-Tools section was rewritten; the previously-stale claim that `recall_memory` "merges results from `/recall` and `/memory/by-tag`" is now accurate as a *mode switch* via `exhaustive: true`.
- Commit `02381c1` (on this branch) further hardens the batch-store XOR to reject *any* top-level single-mode field — not just `content` — when `memories[]` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)