### PR TITLE
fix: wrap hook commands in bash -c for Windows Git Bash (#108)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,29 @@ jobs:
       - name: Test coverage
         run: npm run test:coverage
         continue-on-error: true
+
+  hooks-windows:
+    name: Hook commands (windows-latest)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      # Regression guard for #108: hook commands shipped in templates/plugins
+      # must execute via Node child_process (cmd.exe /d /s /c on Windows), the
+      # same model Claude Code uses to launch hooks. On Windows there is no
+      # parent shell to parse `VAR=value command` prefixes, so the wrapped
+      # `bash -c '…'` form is the only one that works. This test fails loudly
+      # if the wrap regresses.
+      - name: Verify wrapped hook commands run on Windows
+        run: npx vitest run tests/installer/hook-commands.test.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- wrap hook commands in `bash -c '…'` so they execute correctly on Windows Git Bash. Claude Code on Windows invokes hook commands via `CreateProcess` (no parent shell), which couldn't parse the previous inline `CLAUDE_HOOK_TYPE=… bash …` prefix and broke `PostToolUse:Bash` and `Stop` hooks with `bash: CLAUDE_HOOK_TYPE=…: No such file or directory` ([#108](https://github.com/verygoodplugins/mcp-automem/issues/108)). Affects `templates/claude-code/settings.json` and `plugins/automem/hooks/hooks.json`. The wrapped form is a no-op on macOS/Linux. Adds a `windows-latest` CI job that exercises the wrapped commands via Node `child_process` to catch future regressions.
+
 ### Changes
 
 - rename the AutoMem service URL env var from `AUTOMEM_ENDPOINT` to `AUTOMEM_API_URL`. The old name still works (the server, queue processor, install script, and OpenClaw resolver all read it as a fallback), but a one-line deprecation warning is logged when only the old name is set. Re-running `npx @verygoodplugins/mcp-automem setup` migrates a `.env` file in place; templates and docs now advertise the new name.

--- a/plugins/automem/hooks/hooks.json
+++ b/plugins/automem/hooks/hooks.json
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "CLAUDE_HOOK_TYPE=session_end ${CLAUDE_PLUGIN_ROOT}/scripts/session-memory.sh"
+            "command": "bash -c 'CLAUDE_HOOK_TYPE=session_end \"${CLAUDE_PLUGIN_ROOT}/scripts/session-memory.sh\"'"
           },
           {
             "type": "command",

--- a/templates/claude-code/settings.json
+++ b/templates/claude-code/settings.json
@@ -9,7 +9,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "CLAUDE_HOOK_TYPE=build bash \"$HOME/.claude/hooks/capture-build-result.sh\""
+            "command": "bash -c 'CLAUDE_HOOK_TYPE=build bash \"$HOME/.claude/hooks/capture-build-result.sh\"'"
           }
         ]
       },
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "CLAUDE_HOOK_TYPE=test_run bash \"$HOME/.claude/hooks/capture-test-pattern.sh\""
+            "command": "bash -c 'CLAUDE_HOOK_TYPE=test_run bash \"$HOME/.claude/hooks/capture-test-pattern.sh\"'"
           }
         ]
       },
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "CLAUDE_HOOK_TYPE=deploy bash \"$HOME/.claude/hooks/capture-deployment.sh\""
+            "command": "bash -c 'CLAUDE_HOOK_TYPE=deploy bash \"$HOME/.claude/hooks/capture-deployment.sh\"'"
           }
         ]
       }
@@ -38,7 +38,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "CLAUDE_HOOK_TYPE=session_end bash \"$HOME/.claude/hooks/session-memory.sh\""
+            "command": "bash -c 'CLAUDE_HOOK_TYPE=session_end bash \"$HOME/.claude/hooks/session-memory.sh\"'"
           },
           {
             "type": "command",

--- a/tests/installer/hook-commands.test.ts
+++ b/tests/installer/hook-commands.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Regression guard for #108 — hook commands shipped in our templates must
+ * survive the platform's native command-line execution model. Claude Code
+ * launches hooks via Node's child_process (`/bin/sh -c` on POSIX,
+ * `cmd.exe /d /s /c` on Windows). On Windows there is no shell to parse the
+ * `VAR=value command` prefix, so any command using that syntax must wrap the
+ * whole thing in `bash -c '…'` to re-introduce a real shell.
+ *
+ * This test extracts every command from settings.json / hooks.json that
+ * carries an env-var prefix, stages a stub for the script it references, and
+ * runs it via execSync. On POSIX it always passes; on `windows-latest` CI it
+ * fails loudly if the wrapper regresses.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const SETTINGS_PATH = path.join(REPO_ROOT, 'templates/claude-code/settings.json');
+const PLUGIN_HOOKS_PATH = path.join(REPO_ROOT, 'plugins/automem/hooks/hooks.json');
+
+const STUB_SCRIPT_NAMES = [
+  'capture-build-result.sh',
+  'capture-test-pattern.sh',
+  'capture-deployment.sh',
+  'session-memory.sh',
+];
+
+interface HookEntry {
+  command: string;
+}
+interface HookGroup {
+  matcher?: string;
+  hooks: HookEntry[];
+}
+interface HookConfig {
+  hooks: {
+    PostToolUse?: HookGroup[];
+    Stop?: HookGroup[];
+    SessionStart?: HookGroup[];
+  };
+}
+
+function extractEnvPrefixedCommands(config: HookConfig): string[] {
+  const all: string[] = [];
+  for (const section of [config.hooks.PostToolUse, config.hooks.Stop, config.hooks.SessionStart]) {
+    for (const group of section ?? []) {
+      for (const entry of group.hooks ?? []) {
+        all.push(entry.command);
+      }
+    }
+  }
+  return all.filter((c) => /CLAUDE_HOOK_TYPE=/.test(c));
+}
+
+describe('shipped hook commands run via the platform exec model (#108)', () => {
+  let tmpHome: string;
+  let originalHome: string | undefined;
+  let originalUserProfile: string | undefined;
+
+  beforeAll(() => {
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-automem-hookcmd-'));
+    // Templates reference $HOME/.claude/hooks/*.sh; plugin references
+    // ${CLAUDE_PLUGIN_ROOT}/scripts/*.sh which we map to tmpHome/.claude/scripts.
+    const hooksDir = path.join(tmpHome, '.claude', 'hooks');
+    const scriptsDir = path.join(tmpHome, '.claude', 'scripts');
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.mkdirSync(scriptsDir, { recursive: true });
+
+    const stub =
+      '#!/usr/bin/env bash\necho "${0##*/} CLAUDE_HOOK_TYPE=${CLAUDE_HOOK_TYPE:-MISSING}"\nexit 0\n';
+    for (const name of STUB_SCRIPT_NAMES) {
+      for (const dir of [hooksDir, scriptsDir]) {
+        const p = path.join(dir, name);
+        fs.writeFileSync(p, stub);
+        fs.chmodSync(p, 0o755);
+      }
+    }
+
+    originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+  });
+
+  afterAll(() => {
+    process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalUserProfile;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  const templateSettings = JSON.parse(fs.readFileSync(SETTINGS_PATH, 'utf8')) as HookConfig;
+  const pluginHooks = JSON.parse(fs.readFileSync(PLUGIN_HOOKS_PATH, 'utf8')) as HookConfig;
+
+  const templateCmds = extractEnvPrefixedCommands(templateSettings);
+  const pluginCmds = extractEnvPrefixedCommands(pluginHooks);
+
+  it('finds the four template hook commands that carry CLAUDE_HOOK_TYPE', () => {
+    expect(templateCmds).toHaveLength(4);
+  });
+
+  it('finds the plugin hook command that carries CLAUDE_HOOK_TYPE', () => {
+    expect(pluginCmds).toHaveLength(1);
+  });
+
+  // Cross-platform structural guard: on POSIX, execSync uses /bin/sh which
+  // happily parses the `VAR=value command` prefix, so a regression that drops
+  // the bash wrapper would still pass the exec tests above on Linux/macOS.
+  // This assertion fails on every platform if anyone removes the wrap.
+  it.each([...templateCmds, ...pluginCmds])(
+    'env-prefixed command is wrapped in `bash -c` (#108): %s',
+    (cmd) => {
+      expect(cmd).toMatch(/^bash -c '/);
+    }
+  );
+
+  it.each(templateCmds)('template command executes cleanly: %s', (cmd) => {
+    const out = execSync(cmd, { encoding: 'utf8', env: process.env });
+    expect(out).toMatch(/CLAUDE_HOOK_TYPE=(build|test_run|deploy|session_end)/);
+    expect(out).not.toMatch(/MISSING/);
+  });
+
+  it.each(pluginCmds)('plugin command executes cleanly: %s', (cmd) => {
+    // Plugin hooks reference scripts via ${CLAUDE_PLUGIN_ROOT}; in the runtime
+    // Claude Code provides this. Here we resolve it to the same hooks dir we
+    // staged in beforeAll, since the stub script names match.
+    const resolved = cmd.replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, path.join(tmpHome, '.claude'));
+    const out = execSync(resolved, { encoding: 'utf8', env: process.env });
+    expect(out).toMatch(/CLAUDE_HOOK_TYPE=session_end/);
+    expect(out).not.toMatch(/MISSING/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #108 — `PostToolUse:Bash` and `Stop` hooks fail on Windows Git Bash with `bash: CLAUDE_HOOK_TYPE=build: No such file or directory`.

@BaGRoS diagnosed the root cause in the issue thread: Claude Code on Windows launches hook commands directly via `CreateProcess` (no parent shell), so the inline `CLAUDE_HOOK_TYPE=… bash …` prefix in our shipped settings is treated as the executable name. The same wall blocks `\$HOME` expansion, since that's also a shell feature.

The fix wraps each affected command in `bash -c '…'`, re-introducing a real shell that parses both the env-var assignment and `\$HOME`. The wrap is a no-op on macOS/Linux (where `/bin/sh` already parses these), so we ship one command form on every platform — no installer-side platform branching.

### What changed

- `templates/claude-code/settings.json` — 4 hook commands rewrapped (build, test_run, deploy, session_end).
- `plugins/automem/hooks/hooks.json` — 1 hook command rewrapped (session_end).
- `.github/workflows/ci.yml` — new `hooks-windows` job on `windows-latest` that runs the rendered commands through Node `child_process` (which uses `cmd.exe /d /s /c` on Windows — the same model Claude Code uses), so a future regression of the wrap fails CI loudly.
- `tests/installer/hook-commands.test.ts` — new vitest covering both files. Also includes a structural guard (`expect(cmd).toMatch(/^bash -c '/)`) that catches a missing wrap on every platform, not just Windows.
- `CHANGELOG.md` — entry under `[Unreleased] / Bug Fixes`.

### Why not the alternatives

- **Pass `CLAUDE_HOOK_TYPE` as a positional arg.** Cleaner JSON, but breaks the contract for users who customized hooks, and still doesn't solve `\$HOME` expansion on Windows.
- **Detect Windows in the installer (`src/cli/claude-code.ts`) and emit different commands per OS.** Two code paths to maintain, no upside over a wrapper that works everywhere.

## Test plan

- [x] `npm run lint && npm run build && npm test` (239 tests passing, no regressions on macOS).
- [x] New \`tests/installer/hook-commands.test.ts\` — 12 tests, all pass on macOS. Will run automatically on the new \`hooks-windows\` CI job.
- [x] CI \`hooks-windows\` job goes green on \`windows-latest\`.
- [ ] @BaGRoS — would you mind installing this branch and confirming the \`bash: CLAUDE_HOOK_TYPE=build: No such file or directory\` error stops appearing? You can build locally:
  \`\`\`bash
  git clone -b fix/windows-git-bash-hooks-108 https://github.com/verygoodplugins/mcp-automem.git
  cd mcp-automem && npm ci && npm run build
  node dist/cli.js claude-code --dry-run --dir \$HOME/.claude-test
  \`\`\`
  Or wait for the next \`@verygoodplugins/mcp-automem\` release once this merges. Either way, thanks for the precise diagnosis — it made this a one-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)