### PR TITLE
fix(build): replace Unix chmod with cross-platform chmodSync in postbuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ All notable changes to this project will be documented in this file.
 - sync plugin-distributed Claude Code runtime scripts with the canonical copies under `templates/claude-code/`
 - add plugin migration guidance in `DEPRECATION.md`
 
+### Bug Fixes
+
+- replace Unix `chmod +x` in `postbuild` script with cross-platform `fs.chmodSync` so `npm run build` works on Windows 11. The `chmod` command is not available in cmd.exe (which npm uses for lifecycle scripts on Windows), causing `postbuild` to fail even though `tsc` compiled successfully. The executable bit is now set inside `scripts/build-openclaw-plugin-package.mjs` using Node.js built-in `fs.chmodSync`.
+
 ## [0.13.0](https://github.com/verygoodplugins/mcp-automem/compare/mcp-automem-v0.12.0...mcp-automem-v0.13.0) (2026-03-25)
 
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "prebuild": "node scripts/sync-template-versions.mjs",
     "build": "tsc",
-    "postbuild": "node scripts/build-openclaw-plugin-package.mjs && chmod +x dist/index.js",
+    "postbuild": "node scripts/build-openclaw-plugin-package.mjs",
     "sync-versions": "node scripts/sync-template-versions.mjs",
     "dev": "tsx watch src/index.ts",
     "lint": "eslint .",

--- a/scripts/build-openclaw-plugin-package.mjs
+++ b/scripts/build-openclaw-plugin-package.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -54,4 +54,5 @@ for (const filename of runtimeFiles) {
   cpSync(join(DIST_ROOT, filename), targetPath);
 }
 
+chmodSync(join(DIST_ROOT, 'index.js'), 0o755);
 console.log(`✓ staged lean OpenClaw plugin package in ${join('dist', 'openclaw-plugin-package')}`);


### PR DESCRIPTION
## Summary

Fixes `npm run build` failure on Windows 11.

- `postbuild` script in `package.json` ran `chmod +x dist/index.js` after `tsc`. On Windows, npm lifecycle scripts run via `cmd.exe`, which has no `chmod`, so the postbuild step always failed — even though `tsc` itself compiled successfully.
- The executable bit is now set inside `scripts/build-openclaw-plugin-package.mjs` using Node.js built-in `fs.chmodSync`, which is cross-platform and already used elsewhere in this repo (e.g. `src/cli/claude-code.ts`).
- The `&& chmod +x dist/index.js` suffix is removed from `package.json`.

## Error before this fix (Windows 11)

```
> @verygoodplugins/mcp-automem@0.14.0 postbuild
> node scripts/build-openclaw-plugin-package.mjs && chmod +x dist/index.js

✓ staged lean OpenClaw plugin package in dist\openclaw-plugin-package
'chmod' is not recognized as an internal or external command,
operable program or batch file.
```

## Files changed

| File | Change |
|------|--------|
| `scripts/build-openclaw-plugin-package.mjs` | Import `chmodSync` from `node:fs`; call `chmodSync(join(DIST_ROOT, 'index.js'), 0o755)` before the final log line |
| `package.json` | Remove `&& chmod +x dist/index.js` from `postbuild` |
| `CHANGELOG.md` | Add Bug Fix entry under `[Unreleased]` |

## Test plan

- [x] `npm run build` completes without errors on Windows 11
- [x] `npm run build` still completes without errors on macOS/Linux (no-op, `chmodSync` is cross-platform)
- [x] Existing test suite: same pass/fail ratio as `main` (pre-existing failures in hook/bash tests are unrelated to this change)

## Context

Discovered while testing the fix from PR #113 (`fix/windows-git-bash-hooks-108`). Building locally per the instructions in that PR's test plan triggered this error. This is a separate, independent bug.

Reported-by: BaGRoS <bagros@gmail.com>
Signed-off-by: BaGRoS <bagros@gmail.com>