### PR TITLE
fix(hooks): disable session-summary Stop hook by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **hooks:** disable session-summary Stop hook by default. `session-memory.sh` was emitting "Claude session in X on branch Y. Modified Z files…" rollups that violate AutoMem's "never store session summaries" guideline, polluting recall results with low-signal noise (~74% of recent project-tagged corpus memories were hook-emitted, dominated by these rollups). Build/test/deploy capture and queue draining are unaffected — only the `session-memory.sh` entry was removed from the `Stop` matcher; `queue-cleanup.sh` and the queue drainer remain. The script files are intentionally retained at `templates/claude-code/hooks/session-memory.sh` (and the `plugins/automem/` duplicate) for a future decision-extracting rewrite. **Migration for existing users:** `mergeSettings` is additive, so re-running `npx @verygoodplugins/mcp-automem claude-code` will not remove the legacy entry from your `~/.claude/settings.json`. Open that file and delete the hook object whose `command` references `session-memory.sh` from the `Stop` matcher's `hooks` array, leaving `queue-cleanup.sh` and the `npx ... queue` drainer in place.
+
 ### Features
 
 - parity with AutoMem service v0.15.2 — exposed via mode-multiplexed parameters on existing tools (no new tools, surface stays at 6):

--- a/plugins/automem/hooks/hooks.json
+++ b/plugins/automem/hooks/hooks.json
@@ -35,10 +35,6 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'CLAUDE_HOOK_TYPE=session_end \"${CLAUDE_PLUGIN_ROOT}/scripts/session-memory.sh\"'"
-          },
-          {
-            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/queue-cleanup.sh"
           },
           {

--- a/templates/claude-code/settings.json
+++ b/templates/claude-code/settings.json
@@ -38,10 +38,6 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'CLAUDE_HOOK_TYPE=session_end bash \"$HOME/.claude/hooks/session-memory.sh\"'"
-          },
-          {
-            "type": "command",
             "command": "bash \"$HOME/.claude/scripts/queue-cleanup.sh\""
           },
           {

--- a/tests/installer/hook-commands.test.ts
+++ b/tests/installer/hook-commands.test.ts
@@ -26,7 +26,6 @@ const STUB_SCRIPT_NAMES = [
   'capture-build-result.sh',
   'capture-test-pattern.sh',
   'capture-deployment.sh',
-  'session-memory.sh',
 ];
 
 interface HookEntry {
@@ -98,12 +97,14 @@ describe('shipped hook commands run via the platform exec model (#108)', () => {
   const templateCmds = extractEnvPrefixedCommands(templateSettings);
   const pluginCmds = extractEnvPrefixedCommands(pluginHooks);
 
-  it('finds the four template hook commands that carry CLAUDE_HOOK_TYPE', () => {
-    expect(templateCmds).toHaveLength(4);
+  it('finds the three template hook commands that carry CLAUDE_HOOK_TYPE', () => {
+    // build, test_run, deploy — the session_end hook was retired from the
+    // default Stop matcher (session-summary rollups are low-signal noise).
+    expect(templateCmds).toHaveLength(3);
   });
 
-  it('finds the plugin hook command that carries CLAUDE_HOOK_TYPE', () => {
-    expect(pluginCmds).toHaveLength(1);
+  it('plugin hooks carry no CLAUDE_HOOK_TYPE-prefixed commands', () => {
+    expect(pluginCmds).toHaveLength(0);
   });
 
   // Cross-platform structural guard: on POSIX, execSync uses /bin/sh which
@@ -119,17 +120,7 @@ describe('shipped hook commands run via the platform exec model (#108)', () => {
 
   it.each(templateCmds)('template command executes cleanly: %s', (cmd) => {
     const out = execSync(cmd, { encoding: 'utf8', env: process.env });
-    expect(out).toMatch(/CLAUDE_HOOK_TYPE=(build|test_run|deploy|session_end)/);
-    expect(out).not.toMatch(/MISSING/);
-  });
-
-  it.each(pluginCmds)('plugin command executes cleanly: %s', (cmd) => {
-    // Plugin hooks reference scripts via ${CLAUDE_PLUGIN_ROOT}; in the runtime
-    // Claude Code provides this. Here we resolve it to the same hooks dir we
-    // staged in beforeAll, since the stub script names match.
-    const resolved = cmd.replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, path.join(tmpHome, '.claude'));
-    const out = execSync(resolved, { encoding: 'utf8', env: process.env });
-    expect(out).toMatch(/CLAUDE_HOOK_TYPE=session_end/);
+    expect(out).toMatch(/CLAUDE_HOOK_TYPE=(build|test_run|deploy)/);
     expect(out).not.toMatch(/MISSING/);
   });
 });


### PR DESCRIPTION
## Summary

- Removes the `session-memory.sh` command from the default Claude Code `Stop` hook registration.
- Keeps Stop-time queue cleanup and queue draining in place, so build/test/deploy captures still flush normally.
- Mirrors the same default-hook change in the packaged AutoMem plugin hooks file and documents the manual migration path for existing additive installs.

## Breaking Changes

None. Existing installed settings are additive and are not modified automatically; users with the old Stop hook need to remove the `session-memory.sh` entry manually.

## Validation

- `git diff --check origin/main...HEAD`
- `npm test` (257 passed)
- `npm run typecheck`
- `npm run build`
- `npm run lint` (0 errors, existing warning-only `no-explicit-any` noise)
- JSON parse check for `templates/claude-code/settings.json` and `plugins/automem/hooks/hooks.json`