### PR TITLE
feat(store): add supersede memory mode

### DIFF
--- a/src/automem-client.test.ts
+++ b/src/automem-client.test.ts
@@ -91,10 +91,6 @@ describe('AutoMemClient', () => {
       mockFetch
         .mockResolvedValueOnce({
           ok: true,
-          json: async () => ({ memory_id: 'new-memory-id', message: 'Memory stored' }),
-        } as any)
-        .mockResolvedValueOnce({
-          ok: true,
           json: async () => ({
             memory: {
               id: 'old-memory-id',
@@ -102,6 +98,10 @@ describe('AutoMemClient', () => {
               metadata: { source: 'test', existing: true },
             },
           }),
+        } as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ memory_id: 'new-memory-id', message: 'Memory stored' }),
         } as any)
         .mockResolvedValueOnce({
           ok: true,
@@ -124,17 +124,17 @@ describe('AutoMemClient', () => {
       expect(result.superseded_memory_id).toBe('old-memory-id');
       expect(result.association_created).toBe(true);
 
-      const storeCall = mockFetch.mock.calls[0];
+      const fetchOldCall = mockFetch.mock.calls[0];
+      expect(fetchOldCall[0]).toBe('http://localhost:8001/memory/old-memory-id');
+      expect(fetchOldCall[1]?.method).toBe('GET');
+
+      const storeCall = mockFetch.mock.calls[1];
       expect(storeCall[0]).toBe('http://localhost:8001/memory');
       expect(JSON.parse(storeCall[1]?.body as string)).toMatchObject({
         content: 'Corrected memory',
         tags: ['project-x', 'correction'],
         metadata: { source: 'replacement' },
       });
-
-      const fetchOldCall = mockFetch.mock.calls[1];
-      expect(fetchOldCall[0]).toBe('http://localhost:8001/memory/old-memory-id');
-      expect(fetchOldCall[1]?.method).toBe('GET');
 
       const patchCall = mockFetch.mock.calls[2];
       expect(patchCall[0]).toBe('http://localhost:8001/memory/old-memory-id');
@@ -164,11 +164,11 @@ describe('AutoMemClient', () => {
       mockFetch
         .mockResolvedValueOnce({
           ok: true,
-          json: async () => ({ memory_id: 'new-memory-id' }),
+          json: async () => ({ memory: { id: 'old-memory-id', metadata: {} } }),
         } as any)
         .mockResolvedValueOnce({
           ok: true,
-          json: async () => ({ memory: { id: 'old-memory-id', metadata: {} } }),
+          json: async () => ({ memory_id: 'new-memory-id' }),
         } as any)
         .mockResolvedValueOnce({
           ok: true,
@@ -187,6 +187,91 @@ describe('AutoMemClient', () => {
 
       const associateBody = JSON.parse(mockFetch.mock.calls[3][1]?.body as string);
       expect(associateBody.type).toBe('EVOLVED_INTO');
+    });
+
+    it('should prevalidate superseded memory before storing a replacement', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        json: async () => ({ message: 'Not found' }),
+      } as any);
+
+      await expect(
+        client.storeMemory({
+          content: 'Corrected memory',
+          supersedes_memory_id: 'missing-memory-id',
+        })
+      ).rejects.toThrow('store_memory: superseded memory not found: missing-memory-id');
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:8001/memory/missing-memory-id');
+    });
+
+    it('should report patch failures and clean up the replacement before old memory is updated', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ memory: { id: 'old-memory-id', metadata: {} } }),
+        } as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ memory_id: 'new-memory-id' }),
+        } as any)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 400,
+          json: async () => ({ message: 'Patch failed' }),
+        } as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ memory_id: 'new-memory-id', message: 'Deleted' }),
+        } as any);
+
+      await expect(
+        client.storeMemory({
+          content: 'Corrected memory',
+          supersedes_memory_id: 'old-memory-id',
+        })
+      ).rejects.toThrow(
+        /old_memory_updated=false, association_created=false; replacement cleanup succeeded.*Patch failed/
+      );
+
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+      expect(mockFetch.mock.calls[3][0]).toBe('http://localhost:8001/memory/new-memory-id');
+      expect(mockFetch.mock.calls[3][1]?.method).toBe('DELETE');
+    });
+
+    it('should report association failures without deleting a replacement linked from the old memory', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ memory: { id: 'old-memory-id', metadata: {} } }),
+        } as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ memory_id: 'new-memory-id' }),
+        } as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ memory_id: 'old-memory-id', message: 'Updated' }),
+        } as any)
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 400,
+          json: async () => ({ message: 'Association failed' }),
+        } as any);
+
+      await expect(
+        client.storeMemory({
+          content: 'Corrected memory',
+          supersedes_memory_id: 'old-memory-id',
+        })
+      ).rejects.toThrow(
+        /old_memory_updated=true, association_created=false; replacement cleanup not attempted.*Association failed/
+      );
+
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+      expect(mockFetch.mock.calls.map((call) => call[1]?.method)).not.toContain('DELETE');
     });
   });
 
@@ -614,6 +699,24 @@ describe('AutoMemClient', () => {
       expect(result.memory_id).toBe('mem-123');
       expect(mockFetch).toHaveBeenCalledWith(
         'http://localhost:8001/memory/mem-123',
+        expect.objectContaining({ method: 'PATCH' })
+      );
+    });
+
+    it('should URL-encode custom memory IDs when patching', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ memory_id: 'custom/id?#', message: 'Updated' }),
+      } as any);
+
+      const result = await client.updateMemory({
+        memory_id: 'custom/id?#',
+        importance: 0.95,
+      });
+
+      expect(result.memory_id).toBe('custom/id?#');
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://localhost:8001/memory/custom%2Fid%3F%23',
         expect.objectContaining({ method: 'PATCH' })
       );
     });

--- a/src/automem-client.test.ts
+++ b/src/automem-client.test.ts
@@ -86,6 +86,108 @@ describe('AutoMemClient', () => {
 
       await expect(client.storeMemory({ content: 'Test' })).rejects.toThrow('Server error');
     });
+
+    it('should supersede an existing memory by storing replacement, patching old state, and associating old to new', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ memory_id: 'new-memory-id', message: 'Memory stored' }),
+        } as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            memory: {
+              id: 'old-memory-id',
+              content: 'Old memory',
+              metadata: { source: 'test', existing: true },
+            },
+          }),
+        } as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ memory_id: 'old-memory-id', message: 'Updated' }),
+        } as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ message: 'Association created' }),
+        } as any);
+
+      const result = await client.storeMemory({
+        content: 'Corrected memory',
+        tags: ['project-x', 'correction'],
+        metadata: { source: 'replacement' },
+        supersedes_memory_id: 'old-memory-id',
+        supersede_reason: 'FAMA stale fact correction',
+      });
+
+      expect(result.memory_id).toBe('new-memory-id');
+      expect(result.superseded_memory_id).toBe('old-memory-id');
+      expect(result.association_created).toBe(true);
+
+      const storeCall = mockFetch.mock.calls[0];
+      expect(storeCall[0]).toBe('http://localhost:8001/memory');
+      expect(JSON.parse(storeCall[1]?.body as string)).toMatchObject({
+        content: 'Corrected memory',
+        tags: ['project-x', 'correction'],
+        metadata: { source: 'replacement' },
+      });
+
+      const fetchOldCall = mockFetch.mock.calls[1];
+      expect(fetchOldCall[0]).toBe('http://localhost:8001/memory/old-memory-id');
+      expect(fetchOldCall[1]?.method).toBe('GET');
+
+      const patchCall = mockFetch.mock.calls[2];
+      expect(patchCall[0]).toBe('http://localhost:8001/memory/old-memory-id');
+      expect(patchCall[1]?.method).toBe('PATCH');
+      const patchBody = JSON.parse(patchCall[1]?.body as string);
+      expect(patchBody.t_invalid).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+      expect(patchBody.metadata).toEqual({
+        source: 'test',
+        existing: true,
+        deprecated: true,
+        superseded_by: 'new-memory-id',
+        supersede_relation: 'INVALIDATED_BY',
+        supersede_reason: 'FAMA stale fact correction',
+      });
+
+      const associateCall = mockFetch.mock.calls[3];
+      expect(associateCall[0]).toBe('http://localhost:8001/associate');
+      expect(JSON.parse(associateCall[1]?.body as string)).toEqual({
+        memory1_id: 'old-memory-id',
+        memory2_id: 'new-memory-id',
+        type: 'INVALIDATED_BY',
+        strength: 0.9,
+      });
+    });
+
+    it('should support EVOLVED_INTO as a supersede relation', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ memory_id: 'new-memory-id' }),
+        } as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ memory: { id: 'old-memory-id', metadata: {} } }),
+        } as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ memory_id: 'old-memory-id' }),
+        } as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ message: 'Association created' }),
+        } as any);
+
+      await client.storeMemory({
+        content: 'Updated concept memory',
+        supersedes_memory_id: 'old-memory-id',
+        supersede_relation: 'EVOLVED_INTO',
+      });
+
+      const associateBody = JSON.parse(mockFetch.mock.calls[3][1]?.body as string);
+      expect(associateBody.type).toBe('EVOLVED_INTO');
+    });
   });
 
   describe('recallMemory', () => {
@@ -171,6 +273,23 @@ describe('AutoMemClient', () => {
       expect(url).toContain('expand_entities=true');
       expect(url).toContain('expand_relations=true');
       expect(url).toContain('auto_decompose=true');
+    });
+
+    it('should forward current-state recall flags', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ results: [], count: 0 }),
+      } as any);
+
+      await client.recallMemory({
+        query: 'stale correction',
+        current_only: false,
+        state_debug: true,
+      });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain('current_only=false');
+      expect(url).toContain('state_debug=true');
     });
 
     it('should support expansion filtering', async () => {
@@ -445,6 +564,15 @@ describe('AutoMemClient', () => {
           memories: [{ content: 'one' }],
         } as any)
       ).rejects.toThrow('Remove top-level single-mode field(s): tags, importance');
+    });
+
+    it('should reject supersede fields in batch mode', async () => {
+      await expect(
+        client.storeMemory({
+          memories: [{ content: 'one' }],
+          supersedes_memory_id: 'old-memory-id',
+        } as any)
+      ).rejects.toThrow('Remove top-level single-mode field(s): supersedes_memory_id');
     });
   });
 

--- a/src/automem-client.ts
+++ b/src/automem-client.ts
@@ -46,6 +46,10 @@ function nonEmptyTags(tags: unknown): string[] {
     .filter((t) => t.length > 0);
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 function mapStoredMemory(raw: any) {
   return {
     memory_id: raw?.id || raw?.memory_id || '',
@@ -214,6 +218,15 @@ export class AutoMemClient {
       ...(args.last_accessed && { last_accessed: args.last_accessed }),
     };
 
+    let supersededMemory: any | undefined;
+    if (supersedesMemoryId) {
+      const oldMemory = await this.fetchMemoryById(supersedesMemoryId);
+      if (!oldMemory) {
+        throw new Error(`store_memory: superseded memory not found: ${supersedesMemoryId}`);
+      }
+      supersededMemory = oldMemory;
+    }
+
     const response = await this.makeRequest('POST', 'memory', body);
     const memoryId =
       response.memory_id ??
@@ -231,32 +244,51 @@ export class AutoMemClient {
       throw new Error('store_memory: replacement memory response did not include a memory_id');
     }
 
-    const oldMemory = await this.fetchMemoryById(supersedesMemoryId);
-    if (!oldMemory) {
-      throw new Error(`store_memory: superseded memory not found: ${supersedesMemoryId}`);
-    }
-
     const oldMetadata =
-      oldMemory.metadata && typeof oldMemory.metadata === 'object' && !Array.isArray(oldMemory.metadata)
-        ? oldMemory.metadata
+      supersededMemory?.metadata &&
+      typeof supersededMemory.metadata === 'object' &&
+      !Array.isArray(supersededMemory.metadata)
+        ? supersededMemory.metadata
         : {};
-    await this.updateMemory({
-      memory_id: supersedesMemoryId,
-      t_invalid: new Date().toISOString(),
-      metadata: {
-        ...oldMetadata,
-        deprecated: true,
-        superseded_by: memoryId,
-        supersede_relation: supersedeRelation,
-        ...(args.supersede_reason && { supersede_reason: args.supersede_reason }),
-      },
-    });
-    await this.associateMemories({
-      memory1_id: supersedesMemoryId,
-      memory2_id: memoryId,
-      type: supersedeRelation,
-      strength: 0.9,
-    });
+    let oldMemoryUpdated = false;
+    let associationCreated = false;
+    try {
+      await this.updateMemory({
+        memory_id: supersedesMemoryId,
+        t_invalid: new Date().toISOString(),
+        metadata: {
+          ...oldMetadata,
+          deprecated: true,
+          superseded_by: memoryId,
+          supersede_relation: supersedeRelation,
+          ...(args.supersede_reason && { supersede_reason: args.supersede_reason }),
+        },
+      });
+      oldMemoryUpdated = true;
+
+      await this.associateMemories({
+        memory1_id: supersedesMemoryId,
+        memory2_id: memoryId,
+        type: supersedeRelation,
+        strength: 0.9,
+      });
+      associationCreated = true;
+    } catch (error) {
+      let cleanupStatus = 'replacement cleanup not attempted';
+      if (!oldMemoryUpdated) {
+        try {
+          await this.deleteMemory({ memory_id: memoryId });
+          cleanupStatus = 'replacement cleanup succeeded';
+        } catch (cleanupError) {
+          cleanupStatus = `replacement cleanup failed: ${errorMessage(cleanupError)}`;
+        }
+      }
+
+      throw new Error(
+        `store_memory: supersede failed after creating replacement memory ${memoryId} (old_memory_updated=${oldMemoryUpdated}, association_created=${associationCreated}; ${cleanupStatus}): ${errorMessage(error)}`,
+        { cause: error }
+      );
+    }
 
     return {
       memory_id: memoryId,
@@ -631,13 +663,14 @@ export class AutoMemClient {
 
   async updateMemory(args: UpdateMemoryArgs): Promise<{ memory_id: string; message: string }> {
     const { memory_id, ...updates } = args;
-    if (!memory_id) {
+    const memoryId = typeof memory_id === 'string' ? memory_id.trim() : '';
+    if (!memoryId) {
       throw new Error('memory_id is required');
     }
 
-    const response = await this.makeRequest('PATCH', `memory/${memory_id}`, updates);
+    const response = await this.makeRequest('PATCH', `memory/${encodeURIComponent(memoryId)}`, updates);
     return {
-      memory_id: response.memory_id || memory_id,
+      memory_id: response.memory_id || memoryId,
       message: response.message || 'Memory updated successfully',
     };
   }

--- a/src/automem-client.ts
+++ b/src/automem-client.ts
@@ -11,6 +11,7 @@ import type {
   UpdateMemoryArgs,
   DeleteMemoryArgs,
   DeleteMemoryResult,
+  SupersedeRelationType,
 } from './types.js';
 
 const BATCH_DISALLOWED_FIELDS = ['id', 'embedding', 't_valid', 't_invalid'] as const;
@@ -28,8 +29,15 @@ const BATCH_TOP_LEVEL_SINGLE_FIELDS = [
   't_invalid',
   'updated_at',
   'last_accessed',
+  'supersedes_memory_id',
+  'supersede_relation',
+  'supersede_reason',
 ] as const;
 const BATCH_MAX_ITEMS = 500;
+const SUPERSEDE_RELATIONS: readonly SupersedeRelationType[] = [
+  'INVALIDATED_BY',
+  'EVOLVED_INTO',
+];
 
 function nonEmptyTags(tags: unknown): string[] {
   if (!Array.isArray(tags)) return [];
@@ -176,6 +184,20 @@ export class AutoMemClient {
       throw new Error('store_memory: `content` is required (or pass `memories` for batch mode)');
     }
 
+    const supersedesMemoryId =
+      typeof args.supersedes_memory_id === 'string'
+        ? args.supersedes_memory_id.trim()
+        : '';
+    const supersedeRelation = args.supersede_relation || 'INVALIDATED_BY';
+    if (
+      supersedesMemoryId &&
+      !SUPERSEDE_RELATIONS.includes(supersedeRelation)
+    ) {
+      throw new Error(
+        `store_memory: supersede_relation must be one of ${SUPERSEDE_RELATIONS.join(', ')}`
+      );
+    }
+
     const body: MemoryRecord = {
       content: args.content,
       ...(args.type && { type: args.type }),
@@ -193,11 +215,53 @@ export class AutoMemClient {
     };
 
     const response = await this.makeRequest('POST', 'memory', body);
+    const memoryId =
+      response.memory_id ??
+      response.id ??
+      response.response?.memory_id;
+
+    if (!supersedesMemoryId) {
+      return {
+        memory_id: memoryId,
+        message: response.message || 'Memory stored successfully',
+      };
+    }
+
+    if (!memoryId) {
+      throw new Error('store_memory: replacement memory response did not include a memory_id');
+    }
+
+    const oldMemory = await this.fetchMemoryById(supersedesMemoryId);
+    if (!oldMemory) {
+      throw new Error(`store_memory: superseded memory not found: ${supersedesMemoryId}`);
+    }
+
+    const oldMetadata =
+      oldMemory.metadata && typeof oldMemory.metadata === 'object' && !Array.isArray(oldMemory.metadata)
+        ? oldMemory.metadata
+        : {};
+    await this.updateMemory({
+      memory_id: supersedesMemoryId,
+      t_invalid: new Date().toISOString(),
+      metadata: {
+        ...oldMetadata,
+        deprecated: true,
+        superseded_by: memoryId,
+        supersede_relation: supersedeRelation,
+        ...(args.supersede_reason && { supersede_reason: args.supersede_reason }),
+      },
+    });
+    await this.associateMemories({
+      memory1_id: supersedesMemoryId,
+      memory2_id: memoryId,
+      type: supersedeRelation,
+      strength: 0.9,
+    });
+
     return {
-      memory_id:
-        response.memory_id ??
-        response.id ??
-        response.response?.memory_id,
+      memory_id: memoryId,
+      superseded_memory_id: supersedesMemoryId,
+      association_created: true,
       message: response.message || 'Memory stored successfully',
     };
   }
@@ -297,6 +361,8 @@ export class AutoMemClient {
         'relation_limit',
         'expand_min_importance',
         'expand_min_strength',
+        'current_only',
+        'state_debug',
         'sort',
       ];
       const conflicting = rankedOnlyParams.filter((key) => {
@@ -391,6 +457,14 @@ export class AutoMemClient {
       params.set('expand_min_strength', String(args.expand_min_strength));
     }
 
+    if (typeof args.current_only === 'boolean') {
+      params.set('current_only', String(args.current_only));
+    }
+
+    if (typeof args.state_debug === 'boolean') {
+      params.set('state_debug', String(args.state_debug));
+    }
+
     // Context hints for smarter recall
     if (args.context) {
       params.set('context', args.context);
@@ -472,6 +546,7 @@ export class AutoMemClient {
       expansion: response.expansion,
       entity_expansion: response.entity_expansion,
       context_priority: response.context_priority,
+      state_filter: response.state_filter,
     };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1167,6 +1167,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
         // Single-store mode response
         let responseText = `Memory stored successfully!\n\nMemory ID: ${result.memory_id}`;
+        if (result.superseded_memory_id) {
+          responseText += `\nSuperseded memory ID: ${result.superseded_memory_id}`;
+        }
+        if (typeof result.association_created === "boolean") {
+          responseText += `\nAssociation created: ${result.association_created ? "yes" : "no"}`;
+        }
         if (result.message) {
           responseText += `\nMessage: ${result.message}`;
         }
@@ -1184,6 +1190,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const output = {
           memory_id: result.memory_id,
           message: result.message,
+          ...(result.superseded_memory_id && {
+            superseded_memory_id: result.superseded_memory_id,
+          }),
+          ...(typeof result.association_created === "boolean" && {
+            association_created: result.association_created,
+          }),
           ...(summarized && {
             summarized,
             original_length: originalLength,

--- a/src/index.ts
+++ b/src/index.ts
@@ -342,6 +342,8 @@ const tools: Tool[] = [
 
 **Mode 1 — Single (default):** pass top-level \`content\` plus any optional fields (tags, importance, metadata, type, confidence, embedding, t_valid, t_invalid, id, etc.).
 
+**Mode 1b — Supersede/correct:** pass top-level \`content\` plus \`supersedes_memory_id\`. The server stores the replacement, marks the old memory invalid with \`t_invalid=now\`, merges supersede metadata, and associates old → new with \`INVALIDATED_BY\` (default) or \`EVOLVED_INTO\`.
+
 **Mode 2 — Batch:** pass \`memories: [{ content, tags?, importance?, metadata?, timestamp?, type?, confidence? }, ...]\` to store up to 500 memories in one request. Faster for bulk ingestion (imports, benchmark seeding). Batch mode does NOT accept \`id\`, \`embedding\`, \`t_valid\`, or \`t_invalid\` per-item — use single mode for those.
 
 **Content size guidelines (per item):**
@@ -360,6 +362,7 @@ const tools: Tool[] = [
 **Examples:**
 - store_memory({ content: "Chose PostgreSQL over MongoDB for user service. Need ACID for transactions.", tags: ["architecture", "database"], importance: 0.9 })
 - store_memory({ content: "User prefers early returns over nested conditionals.", tags: ["code-style"], importance: 0.7 })
+- store_memory({ content: "User now prefers SQLite for small local tools.", supersedes_memory_id: "old-id", supersede_reason: "Correction from user" })
 - store_memory({ memories: [{ content: "...", tags: ["import"] }, { content: "...", tags: ["import"] }] })  // Batch`,
     annotations: {
       title: "Store Memory",
@@ -458,6 +461,23 @@ const tools: Tool[] = [
           type: "string",
           description: "Single-memory mode. ISO 8601 last-accessed timestamp",
         },
+        supersedes_memory_id: {
+          type: "string",
+          description:
+            "Single-memory supersede mode. Existing memory ID that this new memory replaces or corrects.",
+        },
+        supersede_relation: {
+          type: "string",
+          enum: ["INVALIDATED_BY", "EVOLVED_INTO"],
+          default: "INVALIDATED_BY",
+          description:
+            "Single-memory supersede mode. Relationship to create from old memory to new memory.",
+        },
+        supersede_reason: {
+          type: "string",
+          description:
+            "Single-memory supersede mode. Optional reason stored on the old memory's metadata.",
+        },
       },
     },
     outputSchema: {
@@ -472,6 +492,14 @@ const tools: Tool[] = [
           type: "array",
           items: { type: "string" },
           description: "Batch-mode result: IDs of the stored memories.",
+        },
+        superseded_memory_id: {
+          type: "string",
+          description: "Supersede-mode result: ID of the old memory marked invalid.",
+        },
+        association_created: {
+          type: "boolean",
+          description: "Supersede-mode result: whether old → new association was created.",
         },
         stored: {
           type: "integer",
@@ -506,7 +534,7 @@ const tools: Tool[] = [
 
 **Mode 2 — Tag enumeration:** pass \`tags\` + \`exhaustive: true\` for paginated exact-match listing (NOT ranked retrieval). Use this for cleanup/audit workflows where ranked retrieval silently undercounts large tag sets. Pair with \`limit\` (≤200) and \`offset\`. Returns \`has_more\`/\`limit\`/\`offset\` page metadata. Tag matching is exact, case-insensitive, any-of mode — \`tag_match: "prefix"\` and \`tag_mode: "all"\` are rejected in this mode.
 
-**Mode 3 — Ranked retrieval (default):** hybrid search across vector, keyword, tags, recency, and optional graph expansion. The primary tool for finding relevant context.
+**Mode 3 — Ranked retrieval (default):** hybrid search across vector, keyword, tags, recency, and optional graph expansion. The primary tool for finding relevant context. By default, ranked recall requests current active memories only; set \`current_only: false\` for audits.
 
 **When to use ranked (mode 3):**
 - At conversation start: recall context about the current project/topic
@@ -522,6 +550,7 @@ const tools: Tool[] = [
 - recall_memory({ tags: ["benchmark-test"], exhaustive: true, limit: 50 })  // Mode 2
 - recall_memory({ tags: ["benchmark-test"], exhaustive: true, limit: 50, offset: 50 })  // Mode 2 page 2
 - recall_memory({ query: "auth", exclude_tags: ["deprecated"] })  // Mode 3 with exclusion
+- recall_memory({ query: "preference corrections", state_debug: true })  // Mode 3 with state-filter diagnostics
 - recall_memory({ query: "What is Sarah's sister's job?", expand_entities: true })  // Mode 3 multi-hop`,
     annotations: {
       title: "Recall Memory",
@@ -647,6 +676,18 @@ const tools: Tool[] = [
           description:
             "Minimum relation strength to follow during graph expansion. Only traverses edges above this threshold. Recommended: 0.3 for exploratory, 0.6+ for high-confidence connections only. Does not affect entity expansion.",
         },
+        current_only: {
+          type: "boolean",
+          default: true,
+          description:
+            "Ranked-mode only. When true, server suppresses archived, not-yet-valid, expired, invalidated, or superseded memories from active context.",
+        },
+        state_debug: {
+          type: "boolean",
+          default: false,
+          description:
+            "Ranked-mode only. Include state-filter suppression/replacement IDs and reasons when current_only is true.",
+        },
         context: {
           type: "string",
           description:
@@ -757,6 +798,11 @@ const tools: Tool[] = [
           type: "integer",
           description:
             "Number of duplicate results removed (when using multiple queries)",
+        },
+        state_filter: {
+          type: "object",
+          description:
+            "Current-state filtering diagnostics. Includes aggregate counts by default and detailed IDs/reasons only when state_debug=true.",
         },
       },
       required: ["count", "results"],
@@ -883,6 +929,14 @@ ${Object.entries(RELATION_TYPE_METADATA).map(([k, v]) => `- ${k}: ${v}`).join('\
         timestamp: {
           type: "string",
           description: "Override creation timestamp",
+        },
+        t_valid: {
+          type: "string",
+          description: "ISO 8601 timestamp when the memory becomes valid",
+        },
+        t_invalid: {
+          type: "string",
+          description: "ISO 8601 timestamp when the memory expires or was superseded",
         },
         updated_at: {
           type: "string",

--- a/src/openclaw-plugin.test.ts
+++ b/src/openclaw-plugin.test.ts
@@ -96,12 +96,23 @@ describe('openclaw AutoMem plugin', () => {
       const tools = captureRegisteredTools();
       const recall = tools.find((t) => t.name === 'automem_recall_memory');
       const store = tools.find((t) => t.name === 'automem_store_memory');
+      const update = tools.find((t) => t.name === 'automem_update_memory');
       const del = tools.find((t) => t.name === 'automem_delete_memory');
       expect(recall?.parameters?.properties?.memory_id).toBeDefined();
       expect(recall?.parameters?.properties?.exhaustive).toBeDefined();
       expect(recall?.parameters?.properties?.exclude_tags).toBeDefined();
+      expect(recall?.parameters?.properties?.current_only).toBeDefined();
+      expect(recall?.parameters?.properties?.state_debug).toBeDefined();
       expect(store?.parameters?.properties?.memories).toBeDefined();
       expect(store?.parameters?.properties?.memories?.maxItems).toBe(500);
+      expect(store?.parameters?.properties?.supersedes_memory_id).toBeDefined();
+      expect(store?.parameters?.properties?.supersede_relation?.enum).toEqual([
+        'INVALIDATED_BY',
+        'EVOLVED_INTO',
+      ]);
+      expect(store?.parameters?.properties?.supersede_reason).toBeDefined();
+      expect(update?.parameters?.properties?.t_valid).toBeDefined();
+      expect(update?.parameters?.properties?.t_invalid).toBeDefined();
       expect(del?.parameters?.properties?.tags).toBeDefined();
       expect(del?.parameters?.required).toBeUndefined();
     });

--- a/src/openclaw-plugin.ts
+++ b/src/openclaw-plugin.ts
@@ -346,6 +346,19 @@ const storeMemorySchema = {
     t_invalid: { type: 'string' },
     updated_at: { type: 'string' },
     last_accessed: { type: 'string' },
+    supersedes_memory_id: {
+      type: 'string',
+      description: 'Single-mode supersede/correction workflow. Existing memory ID replaced by this new memory.',
+    },
+    supersede_relation: {
+      type: 'string',
+      enum: ['INVALIDATED_BY', 'EVOLVED_INTO'],
+      description: 'Relationship created old → new in supersede mode. Defaults to INVALIDATED_BY.',
+    },
+    supersede_reason: {
+      type: 'string',
+      description: 'Optional reason stored in old memory metadata during supersede mode.',
+    },
   },
 };
 
@@ -373,6 +386,14 @@ const recallMemorySchema = {
     relation_limit: { type: 'number' },
     expand_min_importance: { type: 'number' },
     expand_min_strength: { type: 'number' },
+    current_only: {
+      type: 'boolean',
+      description: 'Ranked-mode only. Suppress archived, expired, not-yet-valid, invalidated, or superseded memories. Defaults to true server-side.',
+    },
+    state_debug: {
+      type: 'boolean',
+      description: 'Ranked-mode only. Include state-filter IDs/reasons in server diagnostics.',
+    },
     context: { type: 'string' },
     language: { type: 'string' },
     active_path: { type: 'string' },
@@ -397,6 +418,8 @@ const updateMemorySchema = {
     importance: { type: 'number' },
     metadata: { type: 'object' },
     timestamp: { type: 'string' },
+    t_valid: { type: 'string' },
+    t_invalid: { type: 'string' },
     updated_at: { type: 'string' },
     last_accessed: { type: 'string' },
     type: { type: 'string' },
@@ -533,7 +556,7 @@ const openClawPlugin = {
       name: 'automem_store_memory',
       label: 'AutoMem Store Memory',
       description:
-        'Store a durable memory in AutoMem. Single-mode (set `content`) or batch mode (set `memories: [...]`, up to 500). Batch mode does not accept per-item id/embedding/t_valid/t_invalid.',
+        'Store a durable memory in AutoMem. Single-mode (set `content`), supersede/correction mode (set `content` + `supersedes_memory_id`), or batch mode (set `memories: [...]`, up to 500). Batch mode does not accept per-item id/embedding/t_valid/t_invalid.',
       parameters: storeMemorySchema,
       async execute(_toolCallId, params) {
         const request = params as StoreMemoryArgs;
@@ -566,7 +589,7 @@ const openClawPlugin = {
       name: 'automem_recall_memory',
       label: 'AutoMem Recall Memory',
       description:
-        'Recall memories in one of three modes. (1) ID fetch: pass `memory_id`. (2) Tag enumeration: pass `tags` + `exhaustive: true` for paginated exact-match listing. (3) Ranked retrieval (default): hybrid search across vector/keyword/tags/recency.',
+        'Recall memories in one of three modes. (1) ID fetch: pass `memory_id`. (2) Tag enumeration: pass `tags` + `exhaustive: true` for paginated exact-match listing. (3) Ranked retrieval (default): hybrid search across vector/keyword/tags/recency, current-only by default server-side.',
       parameters: recallMemorySchema,
       async execute(_toolCallId, params) {
         const request = params as RecallMemoryArgs;

--- a/src/recall-memory.test.ts
+++ b/src/recall-memory.test.ts
@@ -125,6 +125,28 @@ describe('buildRecallMemoryResponse', () => {
     });
   });
 
+  it('surfaces state-filter diagnostics in structured content and text notes', async () => {
+    const stateFilter = {
+      current_only: true,
+      suppressed_count: 2,
+      replacement_count: 1,
+      suppressed: [{ memory_id: 'old-1', reason: 'invalidated' }],
+      replacements: [{ old_id: 'old-1', new_id: 'new-1' }],
+    };
+    const client = {
+      recallMemory: vi.fn().mockResolvedValue(makeRecallResult({ state_filter: stateFilter })),
+    };
+
+    const response = await buildRecallMemoryResponse(client, { query: 'corrections' });
+
+    expect(response.structuredContent).toMatchObject({
+      state_filter: stateFilter,
+    });
+    expect(response.content[0].text).toContain(
+      'state filter suppressed 2, replacements 1'
+    );
+  });
+
   it('surfaces enumeration metadata (mode/has_more/limit/offset) when present', async () => {
     const recallResult = makeRecallResult({
       mode: 'enumeration',

--- a/src/recall-memory.ts
+++ b/src/recall-memory.ts
@@ -76,6 +76,7 @@ function buildStructuredRecallOutput(
     ...(recallResult.context_priority
       ? { context_priority: recallResult.context_priority }
       : {}),
+    ...(recallResult.state_filter ? { state_filter: recallResult.state_filter } : {}),
   };
 }
 
@@ -147,6 +148,11 @@ export async function buildRecallMemoryResponse(
   }
   if (recallResult.expansion?.enabled && recallResult.expansion.expanded_count > 0) {
     notes.push(`${recallResult.expansion.expanded_count} via relation expansion`);
+  }
+  if (recallResult.state_filter) {
+    notes.push(
+      `state filter suppressed ${recallResult.state_filter.suppressed_count}, replacements ${recallResult.state_filter.replacement_count}`
+    );
   }
   if (recallResult.mode === 'enumeration') {
     const offset = recallResult.offset ?? 0;

--- a/src/types.test.ts
+++ b/src/types.test.ts
@@ -111,6 +111,17 @@ describe('Type Definitions', () => {
       expect(args.memories).toHaveLength(2);
       expect(args.content).toBeUndefined();
     });
+
+    it('should accept supersede mode fields', () => {
+      const args: StoreMemoryArgs = {
+        content: 'Corrected preference',
+        supersedes_memory_id: 'old-id',
+        supersede_relation: 'INVALIDATED_BY',
+        supersede_reason: 'User correction',
+      };
+      expect(args.supersedes_memory_id).toBe('old-id');
+      expect(args.supersede_relation).toBe('INVALIDATED_BY');
+    });
   });
 
   describe('RecallMemoryArgs', () => {
@@ -157,9 +168,12 @@ describe('Type Definitions', () => {
         expand_relations: true,
         expand_min_importance: 0.5,
         expand_min_strength: 0.3,
+        current_only: true,
+        state_debug: true,
       };
       expect(args.expand_min_importance).toBe(0.5);
       expect(args.expand_min_strength).toBe(0.3);
+      expect(args.current_only).toBe(true);
     });
 
     it('should support context hints', () => {
@@ -212,9 +226,11 @@ describe('Type Definitions', () => {
       const args: UpdateMemoryArgs = {
         memory_id: 'mem-123',
         importance: 0.95,
+        t_invalid: '2026-05-22T12:00:00Z',
         // content, tags, metadata are optional
       };
       expect(args.importance).toBe(0.95);
+      expect(args.t_invalid).toContain('2026');
     });
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,7 @@ export const MEMORY_TYPES = [
 export type AuthorableRelationType = (typeof AUTHORABLE_RELATION_TYPES)[number];
 /** @deprecated Use AuthorableRelationType. */
 export type RelationType = AuthorableRelationType;
+export type SupersedeRelationType = Extract<AuthorableRelationType, 'INVALIDATED_BY' | 'EVOLVED_INTO'>;
 export type MemoryType = (typeof MEMORY_TYPES)[number];
 
 export interface AutoMemConfig {
@@ -115,6 +116,13 @@ export interface RecallResult {
     priority_types?: string[];
     injected?: boolean;
   };
+  state_filter?: {
+    current_only?: boolean;
+    suppressed_count: number;
+    replacement_count: number;
+    suppressed?: Array<Record<string, any>>;
+    replacements?: Array<Record<string, any>>;
+  };
 }
 
 export interface HealthStatus {
@@ -158,6 +166,9 @@ export interface StoreMemoryArgs {
   t_invalid?: string;
   updated_at?: string;
   last_accessed?: string;
+  supersedes_memory_id?: string;
+  supersede_relation?: SupersedeRelationType;
+  supersede_reason?: string;
   // Batch mode (XOR with `content`): up to 500 memories in one request.
   memories?: BatchMemoryInput[];
 }
@@ -165,6 +176,9 @@ export interface StoreMemoryArgs {
 export interface StoreMemoryResult {
   // Single-store mode populates these:
   memory_id?: string;
+  // Supersede mode populates these:
+  superseded_memory_id?: string;
+  association_created?: boolean;
   // Batch-store mode populates these:
   memory_ids?: string[];
   stored?: number;
@@ -202,6 +216,9 @@ export interface RecallMemoryArgs {
   // Expansion filtering (reduces noise in expanded results)
   expand_min_importance?: number;
   expand_min_strength?: number;
+  // Current-state filtering
+  current_only?: boolean;
+  state_debug?: boolean;
   // Context hints for smarter recall
   context?: string;
   language?: string;
@@ -230,6 +247,8 @@ export interface UpdateMemoryArgs {
   importance?: number;
   metadata?: Record<string, any>;
   timestamp?: string;
+  t_valid?: string;
+  t_invalid?: string;
   updated_at?: string;
   last_accessed?: string;
   type?: MemoryType;


### PR DESCRIPTION
Summary
- Adds store_memory supersede mode using supersedes_memory_id, supersede_relation, and supersede_reason.
- Implements the workflow as store replacement, patch old memory t_invalid and merged metadata, then associate old memory to new memory.
- Exposes current_only and state_debug through recall_memory.
- Updates MCP and OpenClaw schemas without adding a new standalone tool.

Tests
- npm test
- npm run typecheck
- npm run build
- npm run lint (0 errors, existing warnings)

Related issues
Closes #131
Depends on verygoodplugins/automem#170