### PR TITLE
fix: self-terminate orphaned stdio MCP servers to stop a memory leak

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,14 @@ AUTOMEM_API_URL=https://your-automem-instance.railway.app
 
 # Optional: API key for authenticated AutoMem instances
 AUTOMEM_API_KEY=your_api_key_here
+
+# Optional (advanced): parent-liveness watchdog poll interval, in milliseconds.
+# The stdio server self-terminates when its launching client dies; this controls
+# how often it polls (default 30000). POSIX only — no effect on Windows, which
+# does not reparent orphans. Zero, negative, or non-numeric values fall back to
+# the 30000 default; the watchdog cannot be disabled (it is the fix for an
+# orphaned-process memory leak — see src/lifecycle.ts).
+AUTOMEM_PARENT_WATCHDOG_MS=30000
 ```
 
 ## Common Tasks

--- a/env.example
+++ b/env.example
@@ -12,3 +12,10 @@ AUTOMEM_API_URL=http://127.0.0.1:8001
 
 # Optional: API key for authentication (if your AutoMem service requires it)
 # AUTOMEM_API_KEY=your_api_key_here
+
+# Optional (advanced): parent-liveness watchdog poll interval, in milliseconds.
+# The stdio server self-terminates when its launching client dies; this sets how
+# often it checks (default 30000). POSIX only — has no effect on Windows. Zero,
+# negative, or non-numeric values fall back to the 30000 default (the watchdog
+# cannot be disabled; it is the fix for an orphaned-process memory leak).
+# AUTOMEM_PARENT_WATCHDOG_MS=30000

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import { runMigrateCommand } from "./cli/migrate.js";
 import { runUninstallCommand } from "./cli/uninstall.js";
 import { runQueueCommand } from "./cli/queue.js";
 import { AutoMemClient } from "./automem-client.js";
+import { parseWatchdogIntervalMs, startParentWatchdog } from "./lifecycle.js";
 import { readAutoMemApiKeyFromEnv } from "./env.js";
 import { buildRecallMemoryResponse } from "./recall-memory.js";
 import { AUTHORABLE_RELATION_TYPES, MEMORY_TYPES, RELATION_TYPE_METADATA } from "./types.js";
@@ -1287,8 +1288,51 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 });
 
 async function main() {
+  // Capture the parent pid synchronously, before any await, so the watchdog
+  // can later detect a reparent (orphaning). process.ppid is dynamic on
+  // modern Node, so reading it here pins the original parent.
+  const parentPid = process.ppid;
+
   installStdioErrorGuards();
   const transport = new StdioServerTransport();
+
+  // Defense-in-depth self-termination. The stdio server has no built-in path
+  // to exit when its client disconnects while idle; without these it lingers
+  // as an orphaned ~108 MB process. Each trigger is idempotent via shutdown().
+  let shuttingDown = false;
+  const shutdown = (code = 0) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    try {
+      void transport.close?.();
+    } catch {
+      /* best effort — we're exiting anyway */
+    }
+    process.exit(code);
+  };
+
+  // Layer 1 — stdin EOF (clean client disconnect). Node already drains the
+  // event loop and exits on EOF; this makes the intent explicit.
+  process.stdin.on("end", () => shutdown(0));
+  process.stdin.on("close", () => shutdown(0));
+
+  // Layer 2 — transport/protocol closed by the SDK.
+  server.onclose = () => shutdown(0);
+
+  // Layer 3 — supervisor signals (graceful termination).
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"] as const) {
+    process.on(sig, () => shutdown(0));
+  }
+
+  // Layer 4 — parent-liveness watchdog (load-bearing on POSIX). Catches the
+  // orphan case Layers 1-3 miss: an intermediate wrapper holds stdin open so
+  // no EOF arrives, yet the client is gone. Relies on orphan reparenting, so
+  // it is a no-op on Windows (process.ppid never changes there). Interval is
+  // env-tunable via AUTOMEM_PARENT_WATCHDOG_MS; invalid/zero/negative values
+  // fall back to the 30 s default (see parseWatchdogIntervalMs).
+  const watchdogMs = parseWatchdogIntervalMs(process.env.AUTOMEM_PARENT_WATCHDOG_MS);
+  startParentWatchdog(parentPid, watchdogMs, () => shutdown(0));
+
   await server.connect(transport);
   if (process.env.AUTOMEM_LOG_LEVEL === "debug") {
     console.error("AutoMem MCP server running");

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,0 +1,91 @@
+/**
+ * Parent-liveness watchdog for the stdio MCP server.
+ *
+ * The load-bearing fix for the orphaned-process leak. When an intermediate
+ * wrapper (npx → npm exec → node bin → server) keeps the server's stdin
+ * write-end open, a dead client never delivers EOF, so the leaf sits in the
+ * event loop forever (~108 MB each; 155 leaked → ~18 GB observed). stdin
+ * 'end'/'close', transport close, and signals all miss this case. The
+ * watchdog catches it by noticing the original parent is gone.
+ *
+ * Kept in its own module (no side effects on import) so it can be unit-tested
+ * without spawning the whole server — `src/index.ts` runs `main()` at import.
+ */
+
+export type ParentLivenessProbe = (parentPid: number) => boolean;
+
+/** Poll interval (ms) used when the env override is unset or invalid. */
+export const DEFAULT_PARENT_WATCHDOG_MS = 30_000;
+
+/**
+ * Floor (ms) for the poll interval. Guards against a hostile/typo'd env value:
+ * `Number("-1")` is truthy and would otherwise reach `setInterval(fn, -1)`,
+ * which Node clamps to 1 ms — a CPU-spinning poll. Small enough to keep the
+ * test ticks fast (the integration test uses 250 ms).
+ */
+const MIN_PARENT_WATCHDOG_MS = 100;
+
+/**
+ * Parse `AUTOMEM_PARENT_WATCHDOG_MS` into a safe poll interval.
+ *
+ * Any non-finite, zero, or negative value falls back to the 30 s default. The
+ * watchdog is load-bearing, so there is intentionally NO "disable" value — an
+ * unparseable knob must never silently turn orphan protection off. A positive
+ * value is honoured but floored at {@link MIN_PARENT_WATCHDOG_MS} so a tiny or
+ * negative input can't spin the CPU.
+ */
+export function parseWatchdogIntervalMs(raw: string | undefined): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_PARENT_WATCHDOG_MS;
+  return Math.max(n, MIN_PARENT_WATCHDOG_MS);
+}
+
+/**
+ * Default probe: the server has been reparented away from its original parent.
+ *
+ * `process.ppid` is dynamic on modern Node (re-read on each access), so once
+ * the original parent dies and the leaf is reparented (to launchd/pid 1 or a
+ * subreaper) `process.ppid` no longer equals the pid captured at startup.
+ * Comparing identities — rather than `process.kill(parentPid, 0)` — is immune
+ * to PID reuse: a recycled pid can't masquerade as the original parent.
+ *
+ * POSIX only: this relies on the kernel reparenting an orphan (to pid 1 or a
+ * subreaper) when its parent dies. Windows does not reparent orphans, so
+ * `process.ppid` never changes there and this probe never fires — the watchdog
+ * is a no-op on win32. Orphan mitigation on Windows would need a different
+ * mechanism (e.g. a job object or a stdin heartbeat).
+ */
+export function parentReparented(parentPid: number): boolean {
+  return process.ppid !== parentPid;
+}
+
+/**
+ * Poll for the original parent's death and invoke `onDead` exactly once.
+ *
+ * The interval is `unref()`d so the watchdog never, by itself, keeps the
+ * event loop alive — a clean stdin EOF must still let the process exit
+ * promptly.
+ *
+ * @param parentPid    pid captured synchronously at startup (`process.ppid`)
+ * @param intervalMs   poll interval in milliseconds
+ * @param onDead       called at most once, when the parent is detected gone
+ * @param isParentGone probe override (for tests); defaults to the reparent check
+ * @returns the interval handle (already unref'd) so callers can clear it
+ */
+export function startParentWatchdog(
+  parentPid: number,
+  intervalMs: number,
+  onDead: () => void,
+  isParentGone: ParentLivenessProbe = parentReparented
+): NodeJS.Timeout {
+  let fired = false;
+  const timer = setInterval(() => {
+    if (fired) return;
+    if (isParentGone(parentPid)) {
+      fired = true;
+      onDead();
+    }
+  }, intervalMs);
+  timer.unref();
+  return timer;
+}

--- a/tests/server/lifecycle.test.ts
+++ b/tests/server/lifecycle.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Server-lifecycle tests.
+ *
+ * Root cause (empirically verified — see plan):
+ *   1. CLEAN DISCONNECT (stdin EOF): when a client exits and the stdin
+ *      write-end closes, Node drains the event loop and the server exits on
+ *      its own (~125ms). The `stdin closes` test below is a regression guard
+ *      for that already-working path.
+ *   2. ORPHAN (the actual leak): an intermediate wrapper (npx/npm/node bin)
+ *      keeps the server's stdin write-end open, so the leaf never sees EOF.
+ *      When the wrapper's own parent dies, the leaf is reparented (PPID==1)
+ *      and sits in the event loop forever — ~108 MB each, 155 leaked → ~18 GB.
+ *      Nothing in stdin/transport/signals catches this; only the
+ *      parent-liveness watchdog (Layer 4) does. The `orphaned ... watchdog`
+ *      test below reproduces exactly this and FAILS until the watchdog ships.
+ *
+ * Both spawn the built server, so rebuild (`npm run build`) after editing src.
+ */
+
+import { describe, it, expect, afterEach, beforeAll } from 'vitest';
+import { spawn, type ChildProcess } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+const SERVER_PATH = path.resolve(__dirname, '../../dist/index.js');
+
+function waitForReady(child: ChildProcess, timeoutMs = 5000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let buf = '';
+    const timer = setTimeout(() => {
+      reject(new Error(`server did not become ready within ${timeoutMs}ms; stderr:\n${buf}`));
+    }, timeoutMs);
+    child.stderr?.on('data', (d: Buffer) => {
+      buf += d.toString();
+      if (buf.includes('AutoMem MCP server running')) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    child.on('exit', (code) => {
+      clearTimeout(timer);
+      reject(new Error(`server exited before becoming ready (code ${code})`));
+    });
+  });
+}
+
+function waitForExit(
+  child: ChildProcess,
+  timeoutMs: number
+): Promise<{ exited: boolean; code: number | null }> {
+  return new Promise((resolve) => {
+    let done = false;
+    const timer = setTimeout(() => {
+      if (done) return;
+      done = true;
+      resolve({ exited: false, code: null });
+    }, timeoutMs);
+    child.on('exit', (code) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      resolve({ exited: true, code });
+    });
+  });
+}
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+}
+
+async function waitForPidGone(pid: number, timeoutMs: number): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (!isAlive(pid)) return true;
+    await new Promise((r) => setTimeout(r, 150));
+  }
+  return !isAlive(pid);
+}
+
+// Wrapper that mirrors the npx/npm leaf. The crucial detail: the server's
+// stdin comes from a DETACHED `sleep` (the holder), NOT from a pipe the
+// wrapper or test owns. So when the wrapper is killed, the server is orphaned
+// but its stdin write-end is still held by the (surviving) sleeper — no EOF
+// ever arrives. If stdin instead came from a wrapper/test-owned pipe, Node
+// would auto-close that pipe on wrapper exit and the server would self-heal
+// via plain EOF, masking the leak. The sleeper is the production invariant:
+// "parent dead, stdin still open."
+const WRAPPER_SRC = `
+const { spawn } = require('child_process');
+const sleeper = spawn('sleep', ['600'], { stdio: ['ignore', 'pipe', 'ignore'], detached: true });
+sleeper.unref();
+const server = spawn(process.execPath, [process.argv[1]], { stdio: [sleeper.stdout, 'inherit', 'inherit'] });
+process.stdout.write('SLEEPER_PID=' + sleeper.pid + '\\n');
+process.stdout.write('SERVER_PID=' + server.pid + '\\n');
+setInterval(() => {}, 1 << 30);
+`;
+
+interface OrphanPids {
+  serverPid: number;
+  sleeperPid: number;
+}
+
+function waitForServerPidAndReady(
+  wrapper: ChildProcess,
+  timeoutMs: number
+): Promise<OrphanPids> {
+  return new Promise((resolve, reject) => {
+    let out = '';
+    let err = '';
+    let serverPid: number | undefined;
+    let sleeperPid: number | undefined;
+    const timer = setTimeout(() => {
+      reject(
+        new Error(
+          `wrapper did not produce a ready server within ${timeoutMs}ms\n` +
+            `stdout:\n${out}\nstderr:\n${err}`
+        )
+      );
+    }, timeoutMs);
+    const tryResolve = () => {
+      if (
+        serverPid !== undefined &&
+        sleeperPid !== undefined &&
+        err.includes('AutoMem MCP server running')
+      ) {
+        clearTimeout(timer);
+        resolve({ serverPid, sleeperPid });
+      }
+    };
+    wrapper.stdout?.on('data', (d: Buffer) => {
+      out += d.toString();
+      const sm = out.match(/SERVER_PID=(\d+)/);
+      if (sm) serverPid = Number(sm[1]);
+      const lm = out.match(/SLEEPER_PID=(\d+)/);
+      if (lm) sleeperPid = Number(lm[1]);
+      tryResolve();
+    });
+    wrapper.stderr?.on('data', (d: Buffer) => {
+      err += d.toString();
+      tryResolve();
+    });
+    wrapper.on('exit', (code) => {
+      clearTimeout(timer);
+      reject(new Error(`wrapper exited before server was ready (code ${code})`));
+    });
+  });
+}
+
+// These reproductions spawn a detached `sleep 600` to hold stdin open and
+// exercise the parent-liveness watchdog, which relies on POSIX orphan
+// reparenting. Neither exists on Windows (no `sleep`, no reparenting), so the
+// suite is skipped on win32 — see the POSIX-only note in src/lifecycle.ts.
+describe.skipIf(process.platform === 'win32')('MCP server lifecycle', () => {
+  let child: ChildProcess | undefined;
+  let leafPid: number | undefined;
+  let holderPid: number | undefined;
+
+  beforeAll(() => {
+    if (!fs.existsSync(SERVER_PATH)) {
+      throw new Error(`Server not built. Run 'npm run build' first. Expected: ${SERVER_PATH}`);
+    }
+  });
+
+  afterEach(() => {
+    if (child && child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGKILL');
+    }
+    child = undefined;
+    // Neither the orphaned leaf nor its detached stdin-holder is our direct
+    // child; reap both explicitly so they never leak past the test.
+    for (const pid of [leafPid, holderPid]) {
+      if (pid !== undefined && isAlive(pid)) {
+        try {
+          process.kill(pid, 'SIGKILL');
+        } catch {
+          /* already gone */
+        }
+      }
+    }
+    leafPid = undefined;
+    holderPid = undefined;
+  });
+
+  it(
+    'self-terminates within 3s when stdin closes (client disconnect)',
+    async () => {
+      child = spawn(process.execPath, [SERVER_PATH], {
+        env: {
+          ...process.env,
+          AUTOMEM_API_URL: 'http://localhost:9999',
+          AUTOMEM_LOG_LEVEL: 'debug',
+        },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      await waitForReady(child);
+
+      // Simulate the client going away: close the write-end of the server's
+      // stdin so it receives EOF, exactly as a disconnecting MCP client would.
+      child.stdin?.end();
+
+      const result = await waitForExit(child, 3000);
+      expect(result.exited).toBe(true);
+    },
+    15000
+  );
+
+  it(
+    'orphaned leaf self-terminates via parent-liveness watchdog',
+    async () => {
+      // Spawn the wrapper (the `node -e` WRAPPER_SRC above). It starts a
+      // DETACHED `sleep 600` and wires the sleeper's stdout to the server as
+      // stdin, then spawns the server as its own child. When we SIGKILL the
+      // wrapper, the server is orphaned (reparented to PID 1) but its stdin
+      // write-end is still held by the surviving detached sleeper — so no EOF
+      // ever arrives. That is the production leak; only the watchdog escapes
+      // it. (Routing stdin through a wrapper/test-owned pipe instead would let
+      // Node close it on the wrapper's death and the server self-heal via EOF,
+      // masking the leak — that was the earlier spurious-pass trap.)
+      child = spawn(process.execPath, ['-e', WRAPPER_SRC, SERVER_PATH], {
+        env: {
+          ...process.env,
+          AUTOMEM_API_URL: 'http://localhost:9999',
+          AUTOMEM_LOG_LEVEL: 'debug',
+          // Tick fast so the test doesn't wait the 30s production default.
+          AUTOMEM_PARENT_WATCHDOG_MS: '250',
+        },
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      const pids = await waitForServerPidAndReady(child, 8000);
+      leafPid = pids.serverPid;
+      holderPid = pids.sleeperPid;
+      expect(isAlive(leafPid)).toBe(true);
+
+      // Kill the wrapper (plain SIGKILL). The leaf is now PPID==1 with stdin
+      // held open by the surviving detached sleeper — the orphan condition.
+      child.kill('SIGKILL');
+
+      // Watchdog ticks at 250ms; allow generous margin for reparent + reap.
+      const gone = await waitForPidGone(leafPid, 8000);
+      expect(gone).toBe(true);
+    },
+    20000
+  );
+});

--- a/tests/server/parent-watchdog.test.ts
+++ b/tests/server/parent-watchdog.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for the parent-liveness watchdog. These import from `src/`
+ * directly (not `dist/`), so they exercise the watchdog logic without
+ * spawning a server or rebuilding.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  DEFAULT_PARENT_WATCHDOG_MS,
+  parentReparented,
+  parseWatchdogIntervalMs,
+  startParentWatchdog,
+} from '../../src/lifecycle.js';
+
+describe('parentReparented', () => {
+  it('is false while the captured pid is still our parent', () => {
+    expect(parentReparented(process.ppid)).toBe(false);
+  });
+
+  it('is true once the captured pid no longer matches our parent', () => {
+    // process.ppid is a real pid; any other value means we were reparented.
+    expect(parentReparented(process.ppid + 1)).toBe(true);
+  });
+});
+
+describe('parseWatchdogIntervalMs', () => {
+  it('falls back to the 30s default when unset', () => {
+    expect(parseWatchdogIntervalMs(undefined)).toBe(DEFAULT_PARENT_WATCHDOG_MS);
+  });
+
+  it('falls back to the default for non-numeric, zero, or negative values (never disables)', () => {
+    // The watchdog is load-bearing — no env value may silently turn it off.
+    expect(parseWatchdogIntervalMs('abc')).toBe(DEFAULT_PARENT_WATCHDOG_MS);
+    expect(parseWatchdogIntervalMs('')).toBe(DEFAULT_PARENT_WATCHDOG_MS);
+    expect(parseWatchdogIntervalMs('0')).toBe(DEFAULT_PARENT_WATCHDOG_MS);
+    expect(parseWatchdogIntervalMs('-1')).toBe(DEFAULT_PARENT_WATCHDOG_MS);
+  });
+
+  it('floors tiny positive values so a typo cannot spin the CPU', () => {
+    // Without the floor, setInterval(fn, 5) (or -1) becomes a ~1ms hot poll.
+    expect(parseWatchdogIntervalMs('5')).toBe(100);
+  });
+
+  it('honours a sane positive interval (e.g. the 250ms the integration test uses)', () => {
+    expect(parseWatchdogIntervalMs('250')).toBe(250);
+  });
+});
+
+describe('startParentWatchdog', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('never fires while the parent stays alive', () => {
+    vi.useFakeTimers();
+    const onDead = vi.fn();
+    const handle = startParentWatchdog(1234, 100, onDead, () => false);
+    vi.advanceTimersByTime(1000); // 10 ticks
+    expect(onDead).not.toHaveBeenCalled();
+    clearInterval(handle);
+  });
+
+  it('fires onDead exactly once after the parent is gone', () => {
+    vi.useFakeTimers();
+    const onDead = vi.fn();
+    const handle = startParentWatchdog(1234, 100, onDead, () => true);
+    vi.advanceTimersByTime(1000); // 10 ticks — must not fire repeatedly
+    expect(onDead).toHaveBeenCalledTimes(1);
+    clearInterval(handle);
+  });
+
+  it('returns an unref-able interval handle (never pins the event loop)', () => {
+    vi.useFakeTimers();
+    const handle = startParentWatchdog(1234, 100, () => {}, () => false);
+    expect(typeof (handle as unknown as { unref?: unknown }).unref).toBe('function');
+    clearInterval(handle);
+  });
+});


### PR DESCRIPTION
## Problem

The stdio MCP server had no path to exit when its client disconnected while idle. When an intermediate wrapper (`npx → npm exec → node bin → server`) held the server's stdin write-end open, a dead client never delivered EOF and the leaf lingered in the event loop forever — **~108 MB each**. On the machine where this was found, **155 had accumulated**, reparented to PID 1, for **~18 GB of leaked RSS**.

Root cause: the only existing self-termination was `installStdioErrorGuards()`, which fires on `EPIPE`/`ECONNRESET` — and those only trip *when the server writes*. An idle orphan never writes, so it never exits. The SDK's `StdioServerTransport` binds `stdin.on('data')` but never `'end'`/`'close'`, so stdin EOF doesn't close the transport either.

## Fix

Defense-in-depth self-termination in `main()` — four independent triggers behind one idempotent `shutdown()`:

- **Layer 1** — stdin `'end'`/`'close'` (clean disconnect)
- **Layer 2** — `server.onclose` (SDK transport closed)
- **Layer 3** — `SIGTERM`/`SIGINT`/`SIGHUP` (supervisor signals)
- **Layer 4 (load-bearing)** — parent-liveness watchdog: polls for a reparent away from the pid captured synchronously at startup, catching the orphan case Layers 1–3 miss. `unref()`'d so it never pins the event loop.

The watchdog lives in a side-effect-free module (`src/lifecycle.ts`) so it can be unit-tested without spawning the server. Interval is env-tunable via `AUTOMEM_PARENT_WATCHDOG_MS`; non-finite/zero/negative values fall back to the 30 s default and a 100 ms floor prevents a typo'd value from spinning the CPU — there is intentionally **no "disable" value** (orphan protection must not be silently switchable off).

### Platform note

Layer 4 relies on POSIX orphan reparenting (`process.ppid` changes when the parent dies), so it is a **no-op on Windows**. The JSDoc says so and the spawn-based lifecycle tests `skipIf(win32)` (relevant after the recent #108 Git Bash work).

## Tests

- `tests/server/parent-watchdog.test.ts` — reparent probe, interval parser (default/never-disable/floor/honour), fire-once, unref.
- `tests/server/lifecycle.test.ts` — clean stdin-EOF exit + an orphaned-leaf reproduction (detached `sleep` holds stdin open) that fails without the watchdog.

`npm run build` clean; `npm test` → **18 files / 280 tests passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)