### PR TITLE
refactor(cli): extract shared host-toolkit helpers

### DIFF
--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -1,91 +1,24 @@
 import fs from 'fs';
 import path from 'path';
-import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
+import {
+  CommonOptions,
+  detectProjectName,
+  log,
+  parseCommonFlags,
+  replaceTemplateVars,
+  writeFileWithBackup,
+} from './host-toolkit.js';
 
-interface CodexSetupOptions {
+interface CodexSetupOptions extends CommonOptions {
   rulesPath?: string; // default: ./AGENTS.md
-  projectName?: string;
-  dryRun?: boolean;
-  quiet?: boolean;
 }
 
 const TEMPLATE_ROOT = path.resolve(
   fileURLToPath(new URL('../../templates/codex', import.meta.url))
 );
 
-function log(message: string, quiet?: boolean) {
-  if (!quiet) console.log(message);
-}
-
-function detectProjectName(): string {
-  // 1) package.json name
-  if (fs.existsSync('package.json')) {
-    try {
-      const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-      if (pkg.name) return String(pkg.name).replace(/^@.*?\//, '');
-    } catch {
-      // Ignore JSON parse errors; fall back to other name sources
-    }
-  }
-  // 2) git remote
-  try {
-    const remote = execSync('git remote get-url origin 2>/dev/null', { encoding: 'utf8' }).trim();
-    if (remote) {
-      const match = remote.match(/\/([^/]+?)(\.git)?$/);
-      if (match) return match[1];
-    }
-  } catch {
-    // Ignore missing/invalid git remotes; fall back to directory name
-  }
-  // 3) directory
-  return path.basename(process.cwd());
-}
-
-function replaceTemplateVars(content: string, vars: Record<string, string>): string {
-  let result = content;
-  for (const [k, v] of Object.entries(vars)) {
-    result = result.replace(new RegExp(`{{${k}}}`, 'g'), v);
-  }
-  return result;
-}
-
-function backupPath(filePath: string): string {
-  let candidate = `${filePath}.bak`;
-  let i = 1;
-  while (fs.existsSync(candidate)) {
-    candidate = `${filePath}.bak.${i++}`;
-  }
-  return candidate;
-}
-
-function writeFileWithBackup(targetPath: string, content: string, options: CodexSetupOptions) {
-  if (options.dryRun) {
-    log(`[DRY RUN] Would write: ${targetPath}`, options.quiet);
-    return;
-  }
-  const dir = path.dirname(targetPath);
-  fs.mkdirSync(dir, { recursive: true });
-
-  const existed = fs.existsSync(targetPath);
-  if (existed) {
-    const current = fs.readFileSync(targetPath, 'utf8');
-    if (current === content) {
-      log(`✓ Unchanged: ${path.basename(targetPath)}`, options.quiet);
-      return;
-    }
-    const backup = backupPath(targetPath);
-    fs.copyFileSync(targetPath, backup);
-    log(`📦 Backup created: ${backup}`, options.quiet);
-  }
-  fs.writeFileSync(targetPath, content, 'utf8');
-  log(`✅ ${existed ? 'Updated' : 'Created'}: ${path.basename(targetPath)}`, options.quiet);
-}
-
-function upsertRulesWithMarkers(
-  existing: string | null,
-  block: string
-): string {
+function upsertRulesWithMarkers(existing: string | null, block: string): string {
   const start = '<!-- BEGIN AUTOMEM CODEX RULES -->';
   const end = '<!-- END AUTOMEM CODEX RULES -->';
   if (!existing) {
@@ -94,12 +27,10 @@ function upsertRulesWithMarkers(
   const startIdx = existing.indexOf(start);
   const endIdx = existing.indexOf(end);
   if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
-    // Replace existing block
     const before = existing.slice(0, startIdx);
     const after = existing.slice(endIdx + end.length);
     return `${before}${block}${after}`;
   }
-  // Append with spacing
   const sep = existing.endsWith('\n') ? '\n' : '\n\n';
   return `${existing}${sep}${block}\n`;
 }
@@ -115,16 +46,13 @@ export async function applyCodexSetup(cliOptions: CodexSetupOptions): Promise<vo
   log(`\n🔧 Setting up Codex AutoMem rules for: ${projectName}`, cliOptions.quiet);
   log(`📄 Target rules file: ${rulesPath}\n`, cliOptions.quiet);
 
-  // Load and process template
   const templateContent = fs.readFileSync(path.join(TEMPLATE_ROOT, 'memory-rules.md'), 'utf8');
   const processed = replaceTemplateVars(templateContent, vars);
 
-  // Merge/append into AGENTS.md using markers
   const existingContent = fs.existsSync(rulesPath) ? fs.readFileSync(rulesPath, 'utf8') : null;
   const finalContent = upsertRulesWithMarkers(existingContent, processed);
   writeFileWithBackup(rulesPath, finalContent, cliOptions);
 
-  // Show configuration hint
   log('\n📊 Configuration Status:', cliOptions.quiet);
   log('  ✅ Project rules installed (AGENTS.md)', cliOptions.quiet);
   log('  ℹ️ Ensure Codex MCP config includes the memory server:', cliOptions.quiet);
@@ -137,35 +65,11 @@ export async function applyCodexSetup(cliOptions: CodexSetupOptions): Promise<vo
 }
 
 function parseArgs(args: string[]): CodexSetupOptions {
-  const options: CodexSetupOptions = {};
-  for (let i = 0; i < args.length; i += 1) {
-    const arg = args[i];
-    switch (arg) {
-      case '--rules':
-        if (i + 1 >= args.length) {
-          console.error('Error: --rules requires a path');
-          process.exit(1);
-        }
-        options.rulesPath = args[++i];
-        break;
-      case '--name':
-        if (i + 1 >= args.length) {
-          console.error('Error: --name requires a value');
-          process.exit(1);
-        }
-        options.projectName = args[++i];
-        break;
-      case '--dry-run':
-        options.dryRun = true;
-        break;
-      case '--quiet':
-        options.quiet = true;
-        break;
-      default:
-        break;
-    }
-  }
-  return options;
+  let rulesPath: string | undefined;
+  const common = parseCommonFlags(args, {
+    '--rules': { kind: 'value', set: (v) => (rulesPath = v) },
+  });
+  return { ...common, rulesPath };
 }
 
 export async function runCodexSetup(args: string[] = []): Promise<void> {

--- a/src/cli/host-toolkit.test.ts
+++ b/src/cli/host-toolkit.test.ts
@@ -107,6 +107,14 @@ describe('host-toolkit', () => {
     it('leaves untouched variables in place', () => {
       expect(replaceTemplateVars('{{A}} {{B}}', { A: 'a' })).toBe('a {{B}}');
     });
+
+    it('treats replacement values as literal strings', () => {
+      expect(replaceTemplateVars('value={{A}}', { A: '$& $$ $1' })).toBe('value=$& $$ $1');
+    });
+
+    it('escapes variable names before building the matcher', () => {
+      expect(replaceTemplateVars('{{A.B}} {{ACB}}', { 'A.B': 'x' })).toBe('x {{ACB}}');
+    });
   });
 
   describe('detectProjectName', () => {
@@ -170,6 +178,11 @@ describe('host-toolkit', () => {
     it('silently ignores unknown flags (matches existing handler behavior)', () => {
       const opts = parseCommonFlags(['--unknown', '--dry-run']);
       expect(opts.dryRun).toBe(true);
+    });
+
+    it('ignores unknown flags that match inherited object properties', () => {
+      expect(() => parseCommonFlags(['toString', '--dry-run'])).not.toThrow();
+      expect(parseCommonFlags(['toString', '--dry-run']).dryRun).toBe(true);
     });
   });
 });

--- a/src/cli/host-toolkit.test.ts
+++ b/src/cli/host-toolkit.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  backupPath,
+  detectProjectName,
+  parseCommonFlags,
+  readJsonFile,
+  replaceTemplateVars,
+  writeFileWithBackup,
+} from './host-toolkit.js';
+
+describe('host-toolkit', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'host-toolkit-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  describe('backupPath', () => {
+    it('returns .bak when nothing collides', () => {
+      const filePath = path.join(tmpDir, 'config.json');
+      expect(backupPath(filePath)).toBe(`${filePath}.bak`);
+    });
+
+    it('increments counter when .bak already exists', () => {
+      const filePath = path.join(tmpDir, 'config.json');
+      fs.writeFileSync(`${filePath}.bak`, 'existing');
+      expect(backupPath(filePath)).toBe(`${filePath}.bak.1`);
+    });
+
+    it('skips multiple existing backups', () => {
+      const filePath = path.join(tmpDir, 'config.json');
+      fs.writeFileSync(`${filePath}.bak`, 'a');
+      fs.writeFileSync(`${filePath}.bak.1`, 'b');
+      fs.writeFileSync(`${filePath}.bak.2`, 'c');
+      expect(backupPath(filePath)).toBe(`${filePath}.bak.3`);
+    });
+  });
+
+  describe('writeFileWithBackup', () => {
+    it('creates a new file when none exists', () => {
+      const target = path.join(tmpDir, 'new.txt');
+      const result = writeFileWithBackup(target, 'hello', { quiet: true });
+      expect(result.status).toBe('created');
+      expect(fs.readFileSync(target, 'utf8')).toBe('hello');
+    });
+
+    it('updates an existing file and writes a backup', () => {
+      const target = path.join(tmpDir, 'existing.txt');
+      fs.writeFileSync(target, 'old');
+      const result = writeFileWithBackup(target, 'new', { quiet: true });
+      expect(result.status).toBe('updated');
+      expect(fs.readFileSync(target, 'utf8')).toBe('new');
+      expect(fs.readFileSync(`${target}.bak`, 'utf8')).toBe('old');
+    });
+
+    it('returns unchanged when content matches', () => {
+      const target = path.join(tmpDir, 'same.txt');
+      fs.writeFileSync(target, 'same');
+      const result = writeFileWithBackup(target, 'same', { quiet: true });
+      expect(result.status).toBe('unchanged');
+      expect(fs.existsSync(`${target}.bak`)).toBe(false);
+    });
+
+    it('writes nothing in dry-run mode', () => {
+      const target = path.join(tmpDir, 'dry.txt');
+      const result = writeFileWithBackup(target, 'hello', { dryRun: true, quiet: true });
+      expect(result.status).toBe('dry-run');
+      expect(fs.existsSync(target)).toBe(false);
+    });
+  });
+
+  describe('readJsonFile', () => {
+    it('returns parsed JSON', () => {
+      const target = path.join(tmpDir, 'data.json');
+      fs.writeFileSync(target, JSON.stringify({ a: 1 }));
+      expect(readJsonFile<{ a: number }>(target)).toEqual({ a: 1 });
+    });
+
+    it('returns null when file does not exist', () => {
+      expect(readJsonFile(path.join(tmpDir, 'missing.json'))).toBeNull();
+    });
+
+    it('returns null on malformed JSON', () => {
+      const target = path.join(tmpDir, 'bad.json');
+      fs.writeFileSync(target, '{ not json');
+      expect(readJsonFile(target)).toBeNull();
+    });
+  });
+
+  describe('replaceTemplateVars', () => {
+    it('replaces single variable', () => {
+      expect(replaceTemplateVars('hello {{NAME}}', { NAME: 'world' })).toBe('hello world');
+    });
+
+    it('replaces all occurrences', () => {
+      expect(replaceTemplateVars('{{X}} and {{X}}', { X: '1' })).toBe('1 and 1');
+    });
+
+    it('leaves untouched variables in place', () => {
+      expect(replaceTemplateVars('{{A}} {{B}}', { A: 'a' })).toBe('a {{B}}');
+    });
+  });
+
+  describe('detectProjectName', () => {
+    it('reads name from package.json and strips scope', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'package.json'),
+        JSON.stringify({ name: '@scope/my-pkg' }),
+      );
+      expect(detectProjectName(tmpDir)).toBe('my-pkg');
+    });
+
+    it('falls back to directory basename when no package.json', () => {
+      expect(detectProjectName(tmpDir)).toBe(path.basename(tmpDir));
+    });
+
+    it('ignores malformed package.json and uses directory', () => {
+      fs.writeFileSync(path.join(tmpDir, 'package.json'), '{ broken');
+      expect(detectProjectName(tmpDir)).toBe(path.basename(tmpDir));
+    });
+  });
+
+  describe('parseCommonFlags', () => {
+    it('parses common flags', () => {
+      const opts = parseCommonFlags(['--dir', '/tmp', '--name', 'p', '--dry-run', '--quiet', '-y']);
+      expect(opts).toEqual({
+        targetDir: '/tmp',
+        projectName: 'p',
+        dryRun: true,
+        quiet: true,
+        yes: true,
+      });
+    });
+
+    it('handles extra value flag', () => {
+      let rulesPath: string | undefined;
+      const opts = parseCommonFlags(['--rules', '/x.md', '--quiet'], {
+        '--rules': { kind: 'value', set: (v) => (rulesPath = v) },
+      });
+      expect(rulesPath).toBe('/x.md');
+      expect(opts.quiet).toBe(true);
+    });
+
+    it('handles extra boolean flag', () => {
+      let cleanAll = false;
+      parseCommonFlags(['--clean-all', '--quiet'], {
+        '--clean-all': { kind: 'boolean', set: () => (cleanAll = true) },
+      });
+      expect(cleanAll).toBe(true);
+    });
+
+    it('exits when a required value is missing', () => {
+      const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+        throw new Error('process.exit');
+      });
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      expect(() => parseCommonFlags(['--dir'])).toThrow('process.exit');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(errSpy).toHaveBeenCalled();
+    });
+
+    it('silently ignores unknown flags (matches existing handler behavior)', () => {
+      const opts = parseCommonFlags(['--unknown', '--dry-run']);
+      expect(opts.dryRun).toBe(true);
+    });
+  });
+});

--- a/src/cli/host-toolkit.ts
+++ b/src/cli/host-toolkit.ts
@@ -72,7 +72,8 @@ export function readJsonFile<T = unknown>(filePath: string): T | null {
 export function replaceTemplateVars(content: string, vars: Record<string, string>): string {
   let result = content;
   for (const [key, value] of Object.entries(vars)) {
-    result = result.replace(new RegExp(`{{${key}}}`, 'g'), value);
+    const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    result = result.replace(new RegExp(`{{${escapedKey}}}`, 'g'), () => value);
   }
   return result;
 }
@@ -155,7 +156,7 @@ export function parseCommonFlags(
         options.yes = true;
         break;
       default: {
-        const handler = extra[arg];
+        const handler = Object.prototype.hasOwnProperty.call(extra, arg) ? extra[arg] : undefined;
         if (!handler) break;
         if (handler.kind === 'boolean') {
           handler.set();

--- a/src/cli/host-toolkit.ts
+++ b/src/cli/host-toolkit.ts
@@ -1,0 +1,172 @@
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+export interface CommonOptions {
+  dryRun?: boolean;
+  quiet?: boolean;
+  targetDir?: string;
+  projectName?: string;
+  yes?: boolean;
+}
+
+export function log(message: string, quiet?: boolean): void {
+  if (!quiet) {
+    console.log(message);
+  }
+}
+
+export function backupPath(filePath: string): string {
+  let candidate = `${filePath}.bak`;
+  let counter = 1;
+  while (fs.existsSync(candidate)) {
+    candidate = `${filePath}.bak.${counter}`;
+    counter += 1;
+  }
+  return candidate;
+}
+
+export interface WriteResult {
+  status: 'created' | 'updated' | 'unchanged' | 'dry-run';
+}
+
+export function writeFileWithBackup(
+  targetPath: string,
+  content: string,
+  opts: Pick<CommonOptions, 'dryRun' | 'quiet'>,
+): WriteResult {
+  if (opts.dryRun) {
+    log(`[DRY RUN] Would write: ${targetPath}`, opts.quiet);
+    return { status: 'dry-run' };
+  }
+
+  const dir = path.dirname(targetPath);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const existed = fs.existsSync(targetPath);
+  if (existed) {
+    const current = fs.readFileSync(targetPath, 'utf8');
+    if (current === content) {
+      log(`✓ Unchanged: ${path.basename(targetPath)}`, opts.quiet);
+      return { status: 'unchanged' };
+    }
+    const backup = backupPath(targetPath);
+    fs.copyFileSync(targetPath, backup);
+    log(`📦 Backup created: ${backup}`, opts.quiet);
+  }
+
+  fs.writeFileSync(targetPath, content, 'utf8');
+  log(`✅ ${existed ? 'Updated' : 'Created'}: ${path.basename(targetPath)}`, opts.quiet);
+  return { status: existed ? 'updated' : 'created' };
+}
+
+export function readJsonFile<T = unknown>(filePath: string): T | null {
+  try {
+    if (!fs.existsSync(filePath)) return null;
+    return JSON.parse(fs.readFileSync(filePath, 'utf8')) as T;
+  } catch {
+    return null;
+  }
+}
+
+export function replaceTemplateVars(content: string, vars: Record<string, string>): string {
+  let result = content;
+  for (const [key, value] of Object.entries(vars)) {
+    result = result.replace(new RegExp(`{{${key}}}`, 'g'), value);
+  }
+  return result;
+}
+
+export function detectProjectName(cwd: string = process.cwd()): string {
+  // 1) package.json name
+  const pkgPath = path.join(cwd, 'package.json');
+  if (fs.existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+      if (pkg.name) return String(pkg.name).replace(/^@.*?\//, '');
+    } catch {
+      // Fall through
+    }
+  }
+  // 2) git remote
+  try {
+    const remote = execSync('git remote get-url origin 2>/dev/null', {
+      cwd,
+      encoding: 'utf8',
+    }).trim();
+    if (remote) {
+      const match = remote.match(/\/([^/]+?)(\.git)?$/);
+      if (match) return match[1];
+    }
+  } catch {
+    // Fall through
+  }
+  // 3) directory name
+  return path.basename(cwd);
+}
+
+export type ExtraFlag =
+  | { kind: 'value'; set: (value: string) => void }
+  | { kind: 'boolean'; set: () => void };
+
+/**
+ * Shared parser for the flags every host handler uses:
+ *   --dir <path>, --name <value>, --dry-run, --quiet, --yes / -y
+ *
+ * Pass `extra` to register host-specific flags. Examples:
+ *   { '--rules': { kind: 'value', set: (v) => (rulesPath = v) } }
+ *   { '--clean-all': { kind: 'boolean', set: () => (cleanAll = true) } }
+ *
+ * Unknown flags are silently ignored, matching the existing handlers.
+ */
+export function parseCommonFlags(
+  args: string[],
+  extra: Record<string, ExtraFlag> = {},
+): CommonOptions {
+  const options: CommonOptions = {};
+
+  const requireValue = (flag: string, i: number): string => {
+    if (i + 1 >= args.length) {
+      console.error(`Error: ${flag} requires a value`);
+      process.exit(1);
+    }
+    return args[i + 1];
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    switch (arg) {
+      case '--dir':
+        options.targetDir = requireValue('--dir', i);
+        i += 1;
+        break;
+      case '--name':
+        options.projectName = requireValue('--name', i);
+        i += 1;
+        break;
+      case '--dry-run':
+        options.dryRun = true;
+        break;
+      case '--quiet':
+        options.quiet = true;
+        break;
+      case '--yes':
+      case '-y':
+        options.yes = true;
+        break;
+      default: {
+        const handler = extra[arg];
+        if (!handler) break;
+        if (handler.kind === 'boolean') {
+          handler.set();
+        } else {
+          const value = requireValue(arg, i);
+          handler.set(value);
+          i += 1;
+        }
+      }
+    }
+  }
+
+  return options;
+}


### PR DESCRIPTION
## What

Extracts the shared CLI helper module `src/cli/host-toolkit.ts` (path/backup/file-write utilities) and slims `src/cli/codex.ts` to consume them, with full test coverage in `src/cli/host-toolkit.test.ts`.

## Why — first step of a 4-branch untangle

Four unrelated concerns had been stacked in one linear history on tangled branches (host-toolkit → hermes → installer → codex hooks). This PR is **step 1 of 4**, isolating the shared base that every other concern imports (`codex.ts`, `hermes.ts`, `hermes-config.ts`, `install.ts`, `claude-code.ts`, `uninstall.ts`). It must land first so the follow-up branches (Hermes, then the guided installer, then codex hooks) each build in isolation.

Cherry-picked from `52dc84f` onto current `main` so it carries the `#137` watchdog and other post-fork progress untouched.

## Verification

- `npm run build` ✅
- `npm test` ✅ — 301/301 tests pass (19 files)
- `git diff --stat main..` shows only the 3 host-toolkit files — no cross-concern leakage
- Watchdog still wired (`startParentWatchdog` + `./lifecycle.js` import intact in `src/index.ts`)

## Follow-ups (separate PRs, in order)

1. **This PR** — `refactor/host-toolkit`
2. `feat/hermes-agent` (Hermes Agent integration)
3. `feat/installer` (guided installer — unblocks `curl … install.sh | sh`)
4. `feat/codex-hooks` (codex hooks + templates)