### PR TITLE
test: sandbox setup smoke test so it stops clobbering the real .env

### DIFF
--- a/tests/cli/smoke.test.ts
+++ b/tests/cli/smoke.test.ts
@@ -158,7 +158,17 @@ describe('CLI Smoke Tests', () => {
 
   describe('setup command', () => {
     it('should show config with --yes flag (non-interactive)', () => {
-      const result = runCli(['setup', '--yes', '--endpoint', 'http://test:8001']);
+      // Sandbox cwd + HOME so `setup` writes its .env into the temp workspace,
+      // not the developer's real project-root .env (setup resolves .env against cwd).
+      const cwd = path.join(tempDir, 'setup-cwd');
+      const homeDir = path.join(tempDir, 'setup-home');
+      fs.mkdirSync(cwd, { recursive: true });
+      fs.mkdirSync(homeDir, { recursive: true });
+
+      const result = runCli(['setup', '--yes', '--endpoint', 'http://test:8001'], {
+        cwd,
+        env: { HOME: homeDir },
+      });
       expect((result.stdout + result.stderr).length).toBeGreaterThan(0);
     });
   });


### PR DESCRIPTION
## What

The `setup --yes` smoke test ran with the default cwd (repo root), so the `setup` command resolved `.env` against the project root and **overwrote the developer's real `AUTOMEM_API_URL`** with the test endpoint (`http://test:8001`) on every `npm test` run. This is a pre-existing footgun on `main` — it bit the branch-untangle work 3× during validation.

This PR sandboxes the test with a temp `cwd` + `HOME` (matching the existing `claude-code` and `install` smoke tests) so `setup` writes its `.env` into a throwaway workspace. The real project-root `.env` and the in-test endpoint now coexist: the suite uses `http://test:8001` inside the sandbox while the developer's `.env` stays intact.

## Verification

- `npm run build && npm test` → **280 passing**, no behavior change (test still asserts `setup` produces output).
- Restored `.env` to the real Railway URL, ran the full suite, and confirmed `.env` is **byte-identical** afterward (SHA-256 match) — proving both that the `setup` test no longer trampled it and that no *other* test writes the repo `.env`.

## Scope — what this does NOT do

This fixes the `.env`-clobbering bug only. It does **not** wire the test suite to a Docker AutoMem backend — the suite still exercises a mock (`localhost:9999`, the intentional ECONNREFUSED-by-design health check) and a fake endpoint (`http://test:8001`). Whether integration/e2e tests should run against a local Docker instance is an open follow-up (see PR discussion / linked issue).

## Suggested merge order

Independent of the 4-branch installer untangle (it fixes a pre-existing `main` bug). Recommend merging **first** — then the recut `feat/*` branches inherit the fix and local `npm test` runs stop re-clobbering `.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)