### PR TITLE
fix: close remaining AUTOMEM_ENDPOINT migration gaps

### DIFF
--- a/plugins/automem/.mcp.json
+++ b/plugins/automem/.mcp.json
@@ -2,10 +2,7 @@
   "mcpServers": {
     "memory": {
       "command": "npx",
-      "args": ["-y", "@verygoodplugins/mcp-automem"],
-      "env": {
-        "AUTOMEM_API_URL": "${AUTOMEM_API_URL:-${AUTOMEM_ENDPOINT:-http://127.0.0.1:8001}}"
-      }
+      "args": ["-y", "@verygoodplugins/mcp-automem"]
     }
   }
 }

--- a/src/cli/hermes-config.test.ts
+++ b/src/cli/hermes-config.test.ts
@@ -310,6 +310,46 @@ describe('hermes-config', () => {
       expect(creds.apiKey).toBe('sk-env');
     });
 
+    it('recovers a legacy AUTOMEM_ENDPOINT from the config entry when AUTOMEM_API_URL is absent', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'config.yaml'),
+        [
+          'mcp_servers:',
+          '  automem:',
+          '    env:',
+          '      AUTOMEM_ENDPOINT: https://legacy.automem.test',
+          '      AUTOMEM_API_KEY: sk-legacy',
+          '',
+        ].join('\n'),
+      );
+      const creds = readExistingHermesCredentials(paths(tmpDir));
+      expect(creds.endpoint).toBe('https://legacy.automem.test');
+      expect(creds.apiKey).toBe('sk-legacy');
+    });
+
+    it('recovers a legacy AUTOMEM_ENDPOINT from .env when AUTOMEM_API_URL is absent', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, '.env'),
+        'AUTOMEM_ENDPOINT=https://legacy-env.automem.test\nAUTOMEM_API_KEY=sk-env\n',
+      );
+      const creds = readExistingHermesCredentials(paths(tmpDir));
+      expect(creds.endpoint).toBe('https://legacy-env.automem.test');
+      expect(creds.apiKey).toBe('sk-env');
+    });
+
+    it('prefers AUTOMEM_API_URL over the legacy AUTOMEM_ENDPOINT in the same source', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, '.env'),
+        [
+          'AUTOMEM_ENDPOINT=https://legacy-env.automem.test',
+          'AUTOMEM_API_URL=https://env.automem.test',
+          '',
+        ].join('\n'),
+      );
+      const creds = readExistingHermesCredentials(paths(tmpDir));
+      expect(creds.endpoint).toBe('https://env.automem.test');
+    });
+
     it('prefers the config entry over .env when both are present', () => {
       fs.writeFileSync(
         path.join(tmpDir, 'config.yaml'),

--- a/src/cli/hermes-config.ts
+++ b/src/cli/hermes-config.ts
@@ -145,7 +145,10 @@ function readCredentialsFromConfig(configPath: string): HermesCredentials {
   const env = entry && isRecord(entry.env) ? (entry.env as Record<string, unknown>) : null;
   if (!env) return {};
   return {
-    endpoint: normalizeCred(env.AUTOMEM_API_URL),
+    // The runtime provider still honors the deprecated AUTOMEM_ENDPOINT, so a
+    // hand-migrated config must survive a setup re-run instead of being reset
+    // to the default endpoint.
+    endpoint: normalizeCred(env.AUTOMEM_API_URL) ?? normalizeCred(env.AUTOMEM_ENDPOINT),
     apiKey: normalizeCred(env.AUTOMEM_API_KEY),
   };
 }
@@ -153,15 +156,17 @@ function readCredentialsFromConfig(configPath: string): HermesCredentials {
 function readCredentialsFromEnvFile(envPath: string): HermesCredentials {
   if (!fs.existsSync(envPath)) return {};
   let endpoint: string | undefined;
+  let legacyEndpoint: string | undefined;
   let apiKey: string | undefined;
   for (const line of fs.readFileSync(envPath, 'utf8').split(/\r?\n/)) {
     const match = line.match(/^\s*([A-Za-z0-9_]+)\s*=\s*(.*)$/);
     if (!match) continue;
     const value = normalizeCred(unquoteEnvValue(match[2]));
     if (match[1] === 'AUTOMEM_API_URL') endpoint = value;
+    else if (match[1] === 'AUTOMEM_ENDPOINT') legacyEndpoint = value;
     else if (match[1] === 'AUTOMEM_API_KEY') apiKey = value;
   }
-  return { endpoint, apiKey };
+  return { endpoint: endpoint ?? legacyEndpoint, apiKey };
 }
 
 /**

--- a/src/cli/hermes.ts
+++ b/src/cli/hermes.ts
@@ -194,11 +194,13 @@ export async function applyHermesSetup(cliOptions: HermesSetupOptions): Promise<
   // switch --mode) without flags or env vars does not clobber a remote
   // endpoint/key with the local default. Explicit flags and env still win.
   const existing = readExistingHermesCredentials(paths);
+  // `||` not `??`: an empty-string env var must fall through to the next
+  // source, matching the server's own resolution in src/index.ts.
   const endpoint =
-    cliOptions.endpoint ??
-    process.env.AUTOMEM_API_URL ??
-    process.env.AUTOMEM_ENDPOINT ??
-    existing.endpoint ??
+    cliOptions.endpoint ||
+    process.env.AUTOMEM_API_URL ||
+    process.env.AUTOMEM_ENDPOINT ||
+    existing.endpoint ||
     DEFAULT_AUTOMEM_API_URL;
   const apiKey = cliOptions.apiKey ?? readAutoMemApiKeyFromEnv() ?? existing.apiKey;
   const rulesPath = cliOptions.rulesPath ?? paths.agentsPath;

--- a/src/cli/queue.ts
+++ b/src/cli/queue.ts
@@ -58,12 +58,14 @@ function ensureObject(value: unknown): Record<string, unknown> {
 type AutoMemConfig = { endpoint: string; apiKey?: string };
 
 function resolveAutoMemConfig(): AutoMemConfig {
-  const envEndpoint = process.env.AUTOMEM_API_URL ?? process.env.AUTOMEM_ENDPOINT;
+  // `||` not `??`: an empty-string env var must fall through to the next
+  // source, matching the server's own resolution in src/index.ts.
+  const envEndpoint = process.env.AUTOMEM_API_URL || process.env.AUTOMEM_ENDPOINT;
   const envApiKey = readAutoMemApiKeyFromEnv();
 
   if (envEndpoint || envApiKey) {
     return {
-      endpoint: envEndpoint ?? 'http://127.0.0.1:8001',
+      endpoint: envEndpoint || 'http://127.0.0.1:8001',
       apiKey: envApiKey,
     };
   }
@@ -79,10 +81,10 @@ function resolveAutoMemConfig(): AutoMemConfig {
     for (const server of Object.values(servers)) {
       const env = server?.env ?? {};
       const keyFromServerEnv = readAutoMemApiKeyFromEnv(env);
-      const serverEndpoint = env.AUTOMEM_API_URL ?? env.AUTOMEM_ENDPOINT;
+      const serverEndpoint = env.AUTOMEM_API_URL || env.AUTOMEM_ENDPOINT;
       if (serverEndpoint || keyFromServerEnv) {
         return {
-          endpoint: serverEndpoint ?? 'http://127.0.0.1:8001',
+          endpoint: serverEndpoint || 'http://127.0.0.1:8001',
           apiKey: keyFromServerEnv,
         };
       }

--- a/src/cli/setup.test.ts
+++ b/src/cli/setup.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { runConfig } from './setup.js';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { runConfig, runSetup } from './setup.js';
 
 describe('runConfig — API key handling in printed snippets', () => {
   const REAL_KEY = 'sk-super-secret-runconfig';
@@ -45,5 +48,44 @@ describe('runConfig — API key handling in printed snippets', () => {
     // The JSON dump is the single surface that deliberately includes the key,
     // so a developer can paste a working config. The Hermes/Claude snippets do not.
     expect(out).toContain(REAL_KEY);
+  });
+});
+
+describe('runSetup — deprecated AUTOMEM_ENDPOINT alias migration', () => {
+  let tmpDir: string;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'automem-setup-test-'));
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('keeps a pre-existing AUTOMEM_ENDPOINT line in sync with the new endpoint', async () => {
+    const envPath = path.join(tmpDir, '.env');
+    fs.writeFileSync(envPath, 'AUTOMEM_ENDPOINT=https://old.example.test\nKEEP_ME=1\n');
+
+    await runSetup(['--env', envPath, '--endpoint', 'https://new.example.test', '--yes']);
+
+    const envText = fs.readFileSync(envPath, 'utf8');
+    expect(envText).toContain('AUTOMEM_API_URL=https://new.example.test');
+    // The stale legacy value must not survive — it would silently resurface
+    // if AUTOMEM_API_URL were ever removed.
+    expect(envText).not.toContain('https://old.example.test');
+    expect(envText).toContain('KEEP_ME=1');
+  });
+
+  it('does not introduce the deprecated alias into a fresh .env', async () => {
+    const envPath = path.join(tmpDir, '.env');
+
+    await runSetup(['--env', envPath, '--endpoint', 'https://new.example.test', '--yes']);
+
+    const envText = fs.readFileSync(envPath, 'utf8');
+    expect(envText).toContain('AUTOMEM_API_URL=https://new.example.test');
+    expect(envText).not.toContain('AUTOMEM_ENDPOINT');
   });
 });

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -168,12 +168,14 @@ export async function runSetup(args: string[] = []): Promise<void> {
   const envPath = path.resolve(options.envPath ?? '.env');
 
   const existingValues = loadEnvValues(envPath);
+  // `||` not `??`: an empty value (e.g. a blank AUTOMEM_API_URL= line) must
+  // fall through to the next source, matching the server's own resolution.
   const defaultEndpoint = options.endpoint
-    ?? existingValues[ENV_API_URL_KEY]
-    ?? existingValues[LEGACY_ENV_ENDPOINT_KEY]
-    ?? process.env[ENV_API_URL_KEY]
-    ?? process.env[LEGACY_ENV_ENDPOINT_KEY]
-    ?? DEFAULT_AUTOMEM_API_URL;
+    || existingValues[ENV_API_URL_KEY]
+    || existingValues[LEGACY_ENV_ENDPOINT_KEY]
+    || process.env[ENV_API_URL_KEY]
+    || process.env[LEGACY_ENV_ENDPOINT_KEY]
+    || DEFAULT_AUTOMEM_API_URL;
 
   const defaultApiKey = options.apiKey
     ?? existingValues[ENV_API_KEY]
@@ -215,12 +217,23 @@ export async function runSetup(args: string[] = []): Promise<void> {
   const updates: Record<string, string> = {
     [ENV_API_URL_KEY]: endpoint,
   };
+  // Keep a pre-existing deprecated alias in sync — a stale divergent value
+  // would silently resurface if AUTOMEM_API_URL were ever removed.
+  const hasLegacyLine = existingValues[LEGACY_ENV_ENDPOINT_KEY] !== undefined;
+  if (hasLegacyLine) {
+    updates[LEGACY_ENV_ENDPOINT_KEY] = endpoint;
+  }
   if (apiKey && apiKey !== '<required>' && apiKey !== '<unchanged>') {
     updates[ENV_API_KEY] = apiKey;
   }
 
   mergeEnvFile(envPath, updates);
   console.log(`\n✅ Saved AutoMem settings to ${envPath}`);
+  if (hasLegacyLine) {
+    console.log(
+      `ℹ️  ${LEGACY_ENV_ENDPOINT_KEY} is deprecated; it was updated to match ${ENV_API_URL_KEY}. You can remove the old line.`
+    );
+  }
 
   console.log(buildSummaryInstructions(endpoint, Boolean(apiKey)));
   console.log('Claude Desktop snippet:\n');
@@ -246,8 +259,8 @@ export async function runSetup(args: string[] = []): Promise<void> {
 export async function runConfig(args: string[] = []): Promise<void> {
   const options = parseConfigArgs(args);
   const endpoint = process.env[ENV_API_URL_KEY]
-    ?? process.env[LEGACY_ENV_ENDPOINT_KEY]
-    ?? DEFAULT_AUTOMEM_API_URL;
+    || process.env[LEGACY_ENV_ENDPOINT_KEY]
+    || DEFAULT_AUTOMEM_API_URL;
   const apiKey = process.env[ENV_API_KEY] ?? '${AUTOMEM_API_KEY}';
 
   if (options.format === 'json') {

--- a/src/cli/uninstall.test.ts
+++ b/src/cli/uninstall.test.ts
@@ -45,6 +45,7 @@ describe('uninstall hermes', () => {
       path.join(tmpDir, '.env'),
       [
         'AUTOMEM_API_URL=https://automem.example.test',
+        'AUTOMEM_ENDPOINT=https://legacy.example.test',
         'AUTOMEM_API_KEY=sk-test',
         'AUTOMEM_API_TOKEN=token-test',
         'AUTOMEM_HERMES_PROVIDER_TOOLS=true',

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -322,6 +322,7 @@ async function uninstallHermes(options: UninstallOptions): Promise<void> {
     path.join(paths.home, '.env'),
     [
       'AUTOMEM_API_URL',
+      'AUTOMEM_ENDPOINT',
       'AUTOMEM_API_KEY',
       'AUTOMEM_API_TOKEN',
       'AUTOMEM_HERMES_PROVIDER_TOOLS',

--- a/tests/cli/smoke.test.ts
+++ b/tests/cli/smoke.test.ts
@@ -107,6 +107,37 @@ describe('CLI Smoke Tests', () => {
       expect(stdout).toContain('http://legacy-host:8765');
     });
 
+    it('prefers AUTOMEM_API_URL over AUTOMEM_ENDPOINT when both are set', () => {
+      const cleanEnv: NodeJS.ProcessEnv = { ...process.env };
+      cleanEnv.AUTOMEM_API_URL = 'http://new-host:1111';
+      cleanEnv.AUTOMEM_ENDPOINT = 'http://legacy-host:8765';
+
+      const stdout = execFileSync(process.execPath, [CLI_PATH, 'config', '--format=json'], {
+        encoding: 'utf8',
+        timeout: 10000,
+        env: cleanEnv,
+        cwd: tempDir,
+      });
+
+      expect(stdout).toContain('http://new-host:1111');
+      expect(stdout).not.toContain('http://legacy-host:8765');
+    });
+
+    it('treats an empty AUTOMEM_API_URL as unset so the legacy alias still applies', () => {
+      const cleanEnv: NodeJS.ProcessEnv = { ...process.env };
+      cleanEnv.AUTOMEM_API_URL = '';
+      cleanEnv.AUTOMEM_ENDPOINT = 'http://legacy-host:8765';
+
+      const stdout = execFileSync(process.execPath, [CLI_PATH, 'config', '--format=json'], {
+        encoding: 'utf8',
+        timeout: 10000,
+        env: cleanEnv,
+        cwd: tempDir,
+      });
+
+      expect(stdout).toContain('http://legacy-host:8765');
+    });
+
     it('should include Claude Code setup', () => {
       const output = runCliExpectSuccess(['config']);
       expect(output).toMatch(/claude mcp add/i);

--- a/tests/installer/plugin-mcp-config.test.ts
+++ b/tests/installer/plugin-mcp-config.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Regression guard for the plugin's MCP server config.
+ *
+ * Claude Code's .mcp.json env expansion supports only single-level `${VAR}`
+ * and `${VAR:-default}` (https://code.claude.com/docs/en/mcp.md). A nested
+ * default like `${AUTOMEM_API_URL:-${AUTOMEM_ENDPOINT:-…}}` is undocumented
+ * and parses to a mangled value, so it must never ship.
+ *
+ * The plugin also must not set AUTOMEM_API_URL itself: stdio MCP servers
+ * inherit the parent environment, and the server resolves
+ * AUTOMEM_API_URL → AUTOMEM_ENDPOINT (deprecated) → default in code
+ * (src/index.ts). A config-level default would shadow a legacy user's
+ * AUTOMEM_ENDPOINT and silently redirect them to the default endpoint.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+const SHIPPED_MCP_CONFIGS = [
+  'plugins/automem/.mcp.json',
+  'templates/claude_desktop_config.json',
+  'templates/cursor_mcp.json',
+  'templates/antigravity/mcp_config.json',
+];
+
+const NESTED_EXPANSION = /\$\{[^}]*\$\{/;
+
+describe('shipped MCP server configs', () => {
+  it.each(SHIPPED_MCP_CONFIGS)('%s has no nested ${} expansion', (relPath) => {
+    const raw = fs.readFileSync(path.join(REPO_ROOT, relPath), 'utf8');
+    expect(raw).not.toMatch(NESTED_EXPANSION);
+  });
+
+  it('plugin .mcp.json leaves endpoint resolution to the server', () => {
+    const raw = fs.readFileSync(path.join(REPO_ROOT, 'plugins/automem/.mcp.json'), 'utf8');
+    const parsed = JSON.parse(raw) as {
+      mcpServers: Record<string, { env?: Record<string, string> }>;
+    };
+    const memory = parsed.mcpServers.memory;
+    expect(memory).toBeDefined();
+    expect(memory.env?.AUTOMEM_API_URL).toBeUndefined();
+    expect(memory.env?.AUTOMEM_ENDPOINT).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Audit of the `AUTOMEM_ENDPOINT` → `AUTOMEM_API_URL` rename (#110) found five gaps where legacy-name users could silently break:

- **Plugin `.mcp.json`**: the nested `${AUTOMEM_API_URL:-${AUTOMEM_ENDPOINT:-…}}` expansion is undocumented in Claude Code (only single-level `${VAR:-default}` is supported) and risks passing a mangled URL. The env block is removed entirely — stdio MCP servers inherit the parent environment and `src/index.ts` already resolves `AUTOMEM_API_URL || AUTOMEM_ENDPOINT || default` in code. Note: flattening to `${AUTOMEM_API_URL:-default}` instead would have **broken** legacy users by shadowing their `AUTOMEM_ENDPOINT` with the localhost default.
- **Hermes setup re-run**: credential recovery only read `AUTOMEM_API_URL` from existing `config.yaml`/`.env`, silently resetting a hand-migrated legacy config to `http://127.0.0.1:8001`. Both readers now fall back to `AUTOMEM_ENDPOINT` (the Python provider honors it at runtime, so recovery must too).
- **Hermes uninstall**: `AUTOMEM_ENDPOINT` was missing from the `.env` key-removal list.
- **Empty-string semantics**: `queue`/`hermes`/`setup` used `??` where the server uses `||`, so `AUTOMEM_API_URL=""` blocked the legacy fallback in some paths but not others. Normalized on `||`.
- **Setup migration**: a pre-existing `AUTOMEM_ENDPOINT=` line in `.env` kept its stale value after setup wrote the new key; it is now kept in sync with a deprecation note.

## Tests

- New regression guard `tests/installer/plugin-mcp-config.test.ts`: no nested `${}` expansion in any shipped `.mcp.json`; plugin leaves endpoint resolution to the server.
- New: both-vars-set precedence and empty-string fallback (CLI smoke), legacy credential recovery (hermes-config), legacy key uninstall cleanup.
- Full suite: 429/429 passing locally after `npm run build`.

## Risk

Low. Runtime resolution paths are unchanged for anyone with either var set normally; the changes only affect edge cases that previously misbehaved (empty strings, legacy-only Hermes configs, plugin env expansion). The plugin change relies on environment inheritance, which is how the published CLI installer path already works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)