### PR TITLE
fix(recall): summary-first budgeted formats + token-aware response budget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,7 +143,7 @@ The server exposes 6 tools to AI assistants. Several are mode-multiplexed — th
 2. **recall_memory** — Three modes:
    - **ID fetch:** `memory_id` → routes to `GET /memory/{id}` and ignores other params.
    - **Tag enumeration:** `tags` + `exhaustive: true` → routes to `GET /memory/by-tag` for paginated exact-match listing. Pair with `limit` (≤200) and `offset`. Returns `has_more`/`limit`/`offset`. Use this for cleanup/audit workflows where ranked recall undercounts.
-   - **Ranked retrieval (default):** hybrid search across vector, keyword, tags, recency, and graph expansion. Supports `query`/`queries`, `embedding`, `limit`, `time_query`, `tags`, `tag_mode`, `tag_match`, `exclude_tags`, expansion options, context hints, and pagination (`offset`, `sort`, `format`).
+   - **Ranked retrieval (default):** hybrid search across vector, keyword, tags, recency, and graph expansion. Supports `query`/`queries`, `embedding`, `limit`, `time_query`, `tags`, `tag_mode`, `tag_match`, `exclude_tags`, expansion options, context hints, and pagination (`offset`, `sort`, `format`). Responses are token-budgeted (default ~18k estimated tokens, override via `AUTOMEM_RECALL_TOKEN_BUDGET`) to stay under MCP client caps: `text`/`items`/`detailed` formats are summary-first (the stored summary replaces the content preview when present), relations collapse to `{id, type, strength, summary}` stubs, and metadata collapses to `metadata_keys`. `format: "json"` and ID fetches keep full per-field passthrough.
 3. **associate_memories** — Create relationships (11 public authorable types only).
 4. **update_memory** — Update existing memory fields (supports `MEMORY_TYPES` enum for `type`).
 5. **delete_memory** — Two modes:
@@ -197,6 +197,12 @@ AUTOMEM_API_KEY=your_api_key_here
 # the 30000 default; the watchdog cannot be disabled (it is the fix for an
 # orphaned-process memory leak — see src/lifecycle.ts).
 AUTOMEM_PARENT_WATCHDOG_MS=30000
+
+# Optional (advanced): recall response budget, in estimated tokens (default
+# 18000). Recall responses tokenize at ~2.5 chars/token; the budget keeps them
+# under MCP client tool-response caps (~25k tokens in Claude Code). Raise it
+# only for hosts with larger caps — see src/recall-memory.ts.
+AUTOMEM_RECALL_TOKEN_BUDGET=18000
 ```
 
 ## Common Tasks

--- a/src/automem-client.test.ts
+++ b/src/automem-client.test.ts
@@ -302,6 +302,78 @@ describe('AutoMemClient', () => {
       );
     });
 
+    it('should normalize relations into a single field and never fabricate related_to', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [
+            {
+              id: 'mem-1',
+              match_type: 'semantic',
+              score: 0.95,
+              relations: [{ memory: { id: 'rel-1' }, type: 'REINFORCES', strength: 0.8 }],
+              memory: { content: 'Recalled content', tags: ['test'] },
+            },
+          ],
+          count: 1,
+        }),
+      } as any);
+
+      const result = await client.recallMemory({ query: 'test query' });
+
+      expect(result.results[0].relations).toHaveLength(1);
+      expect(result.results[0]).not.toHaveProperty('related_to');
+    });
+
+    it('should fall back to related_to when the server sends only related_to', async () => {
+      const related = [{ memory: { id: 'rel-2' }, type: 'RELATES_TO', strength: 0.5 }];
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [
+            {
+              id: 'mem-1',
+              match_type: 'semantic',
+              score: 0.95,
+              related_to: related,
+              memory: { content: 'Recalled content', tags: ['test'] },
+            },
+          ],
+          count: 1,
+        }),
+      } as any);
+
+      const result = await client.recallMemory({ query: 'test query' });
+
+      expect(result.results[0].relations).toEqual(related);
+      expect(result.results[0]).not.toHaveProperty('related_to');
+    });
+
+    it('should map the memory summary when the server provides one', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          results: [
+            {
+              id: 'mem-1',
+              match_type: 'semantic',
+              score: 0.95,
+              memory: {
+                content: 'Recalled content',
+                summary: 'Short standalone summary.',
+                tags: ['test'],
+              },
+            },
+          ],
+          count: 1,
+        }),
+      } as any);
+
+      const result = await client.recallMemory({ query: 'test query' });
+
+      expect(result.results[0].memory.summary).toBe('Short standalone summary.');
+    });
+
     it('should support multiple queries', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/src/automem-client.ts
+++ b/src/automem-client.ts
@@ -54,6 +54,7 @@ function mapStoredMemory(raw: any) {
   return {
     memory_id: raw?.id || raw?.memory_id || '',
     content: raw?.content || '',
+    summary: raw?.summary,
     tags: raw?.tags || [],
     importance: raw?.importance ?? 0,
     created_at: raw?.timestamp || raw?.created_at || '',
@@ -73,7 +74,6 @@ function wrapMemoryAsRecallResult(raw: any): RecallResult['results'][number] {
     final_score: 1,
     score_components: {},
     relations: [],
-    related_to: [],
     memory: memory as any,
   };
 }
@@ -552,12 +552,14 @@ export class AutoMemClient {
         final_score: result.final_score ?? result.score ?? 0,
         score_components: result.score_components || {},
         source: result.source,
-        relations: result.relations || [],
-        related_to: result.related_to || result.relations || [],
+        // Servers may send either key; normalize to one so the formatter never
+        // serializes the same relation list twice.
+        relations: result.relations || result.related_to || [],
         expanded_from_entity: result.expanded_from_entity,
         memory: {
           memory_id: result.id,
           content: result.memory?.content || '',
+          summary: result.memory?.summary,
           tags: result.memory?.tags || [],
           importance: result.memory?.importance ?? 0,
           created_at: result.memory?.timestamp || result.memory?.created_at || '',

--- a/src/index.ts
+++ b/src/index.ts
@@ -769,7 +769,7 @@ const tools: Tool[] = [
           enum: ["text", "items", "detailed", "json"],
           default: "text",
           description:
-            'Output format: text (default, compact preview with timestamps/importance), items (one block per memory), detailed (adds type/confidence to text; metadata in structured payload only), json (raw per-memory fields; whole-response budget still applies). Long content is previewed — fetch a full record via memory_id.',
+            'Output format: text (default), items (one block per memory), detailed (adds type/confidence/metadata keys/relation stubs), json (raw per-memory fields incl. full content/metadata/relations; whole-response token budget still applies). text/items/detailed are summary-first: each memory shows its stored 1-2 sentence summary when available, else a content preview — fetch a full record via memory_id.',
         },
         offset: {
           type: "integer",
@@ -810,7 +810,16 @@ const tools: Tool[] = [
             type: "object",
             properties: {
               memory_id: { type: "string" },
-              content: { type: "string" },
+              summary: {
+                type: "string",
+                description:
+                  "Stored 1-2 sentence summary. In budgeted formats it replaces content when present.",
+              },
+              content: {
+                type: "string",
+                description:
+                  "Memory content (preview in budgeted formats; omitted when summary is shown).",
+              },
               content_truncated: {
                 type: "boolean",
                 description:
@@ -818,7 +827,8 @@ const tools: Tool[] = [
               },
               content_chars: {
                 type: "integer",
-                description: "Original content length when content_truncated is true.",
+                description:
+                  "Original content length when content was previewed or replaced by summary.",
               },
               tags: { type: "array", items: { type: "string" } },
               importance: { type: "number" },

--- a/src/recall-memory.test.ts
+++ b/src/recall-memory.test.ts
@@ -1,12 +1,34 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   buildRecallMemoryResponse,
+  DEFAULT_RECALL_TOKEN_BUDGET,
+  RECALL_CHARS_PER_TOKEN,
   RECALL_CONTENT_PREVIEW_CHARS,
   RECALL_MAX_RELATIONS,
-  RECALL_METADATA_MAX_CHARS,
-  RECALL_RESPONSE_CHAR_BUDGET,
+  RECALL_RELATION_SUMMARY_CHARS,
 } from './recall-memory.js';
 import type { RecallMemoryArgs, RecallResult } from './types.js';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+/** A server-shaped relation record as returned inside /recall results. */
+function makeRelationRecord(i: number, summaryChars = 200): Record<string, any> {
+  return {
+    memory: {
+      id: `rel-mem-${i}`,
+      summary: `r${i} `.padEnd(summaryChars, 's'),
+      tags: ['decision', 'mcp-automem', `entity:topics:rel-${i}`],
+      timestamp: '2026-06-01T00:00:00.000000+00:00',
+      type: 'Decision',
+      confidence: 0.9,
+      importance: 0.85,
+    },
+    strength: 0.8,
+    type: 'REINFORCES',
+  };
+}
 
 function makeRecallResult(overrides: Partial<RecallResult> = {}): RecallResult {
   return {
@@ -231,19 +253,13 @@ describe('buildRecallMemoryResponse', () => {
     expect(response.structuredContent).not.toHaveProperty('truncation');
   });
 
-  it('drops score_components, caps metadata, and slices relations in detailed format', async () => {
+  it('drops score_components and replaces metadata with metadata_keys in detailed format', async () => {
     const bigMetadata: Record<string, string> = {};
     for (let i = 0; i < 40; i += 1) {
       bigMetadata[`key_${i}`] = 'v'.repeat(50);
     }
-    expect(JSON.stringify(bigMetadata).length).toBeGreaterThan(RECALL_METADATA_MAX_CHARS);
-    const relations = Array.from({ length: RECALL_MAX_RELATIONS + 3 }, (_, i) => ({
-      memory_id: `rel-${i}`,
-      type: 'RELATES_TO',
-    }));
     const recallResult = makeRecallResult();
     recallResult.results![0].memory.metadata = bigMetadata;
-    (recallResult.results![0] as any).relations = relations;
     const client = {
       recallMemory: vi.fn().mockResolvedValue(recallResult),
     };
@@ -255,14 +271,102 @@ describe('buildRecallMemoryResponse', () => {
 
     const item = (response.structuredContent.results as any[])[0];
     expect(item).not.toHaveProperty('score_components');
-    expect(item.metadata).toMatchObject({ _truncated: true });
-    expect(item.metadata._keys).toContain('key_0');
+    expect(item).not.toHaveProperty('metadata');
+    expect(item.metadata_keys).toContain('key_0');
+    expect(item.metadata_keys).toHaveLength(40);
+  });
+
+  it('omits metadata_keys when metadata is empty', async () => {
+    const recallResult = makeRecallResult();
+    recallResult.results![0].memory.metadata = {};
+    const client = {
+      recallMemory: vi.fn().mockResolvedValue(recallResult),
+    };
+
+    const response = await buildRecallMemoryResponse(client, {
+      query: 'rich',
+      format: 'detailed',
+    });
+
+    const item = (response.structuredContent.results as any[])[0];
+    expect(item).not.toHaveProperty('metadata');
+    expect(item).not.toHaveProperty('metadata_keys');
+  });
+
+  it('compacts relations to capped stubs and never emits related_to in detailed format', async () => {
+    const relations = Array.from({ length: RECALL_MAX_RELATIONS + 3 }, (_, i) =>
+      makeRelationRecord(i)
+    );
+    const recallResult = makeRecallResult();
+    (recallResult.results![0] as any).relations = relations;
+    const client = {
+      recallMemory: vi.fn().mockResolvedValue(recallResult),
+    };
+
+    const response = await buildRecallMemoryResponse(client, {
+      query: 'rich',
+      format: 'detailed',
+    });
+
+    const item = (response.structuredContent.results as any[])[0];
+    expect(item).not.toHaveProperty('related_to');
     expect(item.relations).toHaveLength(RECALL_MAX_RELATIONS);
     expect(item.relations_total).toBe(RECALL_MAX_RELATIONS + 3);
+    for (const stub of item.relations) {
+      expect(stub).not.toHaveProperty('memory');
+      expect(stub.id).toMatch(/^rel-mem-/);
+      expect(stub.type).toBe('REINFORCES');
+      expect(stub.strength).toBe(0.8);
+      // truncated summary + ellipsis
+      expect(stub.summary.length).toBeLessThanOrEqual(RECALL_RELATION_SUMMARY_CHARS + 1);
+    }
+  });
+
+  it('shows the stored summary instead of content in budgeted formats', async () => {
+    const longContent = 'c'.repeat(2000);
+    const summary = 'Concise standalone summary of the memory.';
+    const recallResult = makeRecallResult();
+    recallResult.results![0].memory.content = longContent;
+    (recallResult.results![0].memory as any).summary = summary;
+    const client = {
+      recallMemory: vi.fn().mockResolvedValue(recallResult),
+    };
+
+    const response = await buildRecallMemoryResponse(client, { query: 'summary first' });
+
+    const item = (response.structuredContent.results as any[])[0];
+    expect(item.summary).toBe(summary);
+    expect(item).not.toHaveProperty('content');
+    expect(item.content_chars).toBe(longContent.length);
+    expect(response.content[0].text).toContain(summary);
+    expect(response.content[0].text).not.toContain('cccccccccc');
+  });
+
+  it('keeps full content, summary, metadata, and raw relation records in json format', async () => {
+    const recallResult = makeRecallResult();
+    const longContent = 'j'.repeat(1200);
+    recallResult.results![0].memory.content = longContent;
+    (recallResult.results![0].memory as any).summary = 'json mode summary';
+    (recallResult.results![0] as any).relations = [makeRelationRecord(1)];
+    const client = {
+      recallMemory: vi.fn().mockResolvedValue(recallResult),
+    };
+
+    const response = await buildRecallMemoryResponse(client, {
+      query: 'raw',
+      format: 'json',
+    });
+
+    const item = (response.structuredContent.results as any[])[0];
+    expect(item.content).toBe(longContent);
+    expect(item.summary).toBe('json mode summary');
+    expect(item.metadata).toEqual({ source: 'test' });
+    expect(item.relations[0].memory.id).toBe('rel-mem-1');
+    expect(item).not.toHaveProperty('related_to');
   });
 
   it('keeps raw per-field passthrough in json format but still applies the global budget', async () => {
-    const bigMetadata = { blob: 'm'.repeat(RECALL_METADATA_MAX_CHARS + 500) };
+    const bigMetadata = { blob: 'm'.repeat(1300) };
     const manyResults = Array.from({ length: 60 }, (_, i) => ({
       id: `mem-${i}`,
       match_type: 'semantic',
@@ -294,7 +398,7 @@ describe('buildRecallMemoryResponse', () => {
     expect(structured.results.length).toBeLessThan(60);
     expect(structured.truncation).toMatchObject({
       applied: true,
-      reason: 'response_char_budget',
+      reason: 'response_token_budget',
     });
     expect(structured.truncation.omitted_results).toBe(60 - structured.results.length);
     expect(JSON.parse(response.content[0].text)).toMatchObject({
@@ -302,7 +406,7 @@ describe('buildRecallMemoryResponse', () => {
     });
   });
 
-  it('drops trailing results past the global char budget in text format', async () => {
+  it('drops trailing results past the global token budget in text format', async () => {
     const manyResults = Array.from({ length: 200 }, (_, i) => ({
       id: `mem-${i}`,
       match_type: 'semantic',
@@ -325,8 +429,92 @@ describe('buildRecallMemoryResponse', () => {
     expect(structured.results.length).toBeLessThan(200);
     expect(structured.results.length).toBeGreaterThan(0);
     expect(structured.truncation.applied).toBe(true);
-    expect(response.content[0].text.length).toBeLessThan(RECALL_RESPONSE_CHAR_BUDGET);
+    expect(response.content[0].text.length).toBeLessThan(
+      DEFAULT_RECALL_TOKEN_BUDGET * RECALL_CHARS_PER_TOKEN
+    );
     expect(response.content[0].text).toContain('Response budget: showing');
+  });
+
+  it('respects the AUTOMEM_RECALL_TOKEN_BUDGET env override', async () => {
+    vi.stubEnv('AUTOMEM_RECALL_TOKEN_BUDGET', '1200');
+    const manyResults = Array.from({ length: 20 }, (_, i) => ({
+      id: `mem-${i}`,
+      match_type: 'semantic',
+      final_score: 0.5,
+      memory: {
+        memory_id: `mem-${i}`,
+        content: 'v'.repeat(RECALL_CONTENT_PREVIEW_CHARS + 100),
+        tags: ['big'],
+        importance: 0.5,
+        created_at: '2026-03-25T00:00:00Z',
+      },
+    }));
+    const client = {
+      recallMemory: vi.fn().mockResolvedValue({ results: manyResults, count: 20 }),
+    };
+
+    const response = await buildRecallMemoryResponse(client, { query: 'big' });
+
+    const structured = response.structuredContent as any;
+    // tiny budget: first result always kept, nearly everything else dropped
+    expect(structured.results.length).toBeLessThan(5);
+    expect(structured.truncation.applied).toBe(true);
+    expect(structured.truncation.omitted_results).toBe(20 - structured.results.length);
+  });
+
+  it('fits a real-world session-start recall (fat relations + enrichment metadata) without truncation', async () => {
+    // Modeled on the live 2026-06-10 failure: 26 ranked results, mixed relation
+    // counts, enrichment metadata, ~400-char contents, 200-char summaries. The
+    // old formatter produced ~65k chars from 16 of these and blew the MCP cap.
+    const relationCounts = [5, 2, 5, 5, 5, 5, 0, 3, 5, 5, 5, 1, 5, 5, 5, 2, 5, 4, 5, 0, 5, 3, 5, 5, 2, 5];
+    const manyResults = relationCounts.map((relCount, i) => ({
+      id: `00000000-0000-4000-8000-${String(i).padStart(12, '0')}`,
+      match_type: 'semantic',
+      match_score: 0.42,
+      relation_score: 0.1,
+      final_score: 0.61,
+      score_components: { semantic: 0.42, recency: 0.1, importance: 0.09 },
+      relations: Array.from({ length: relCount }, (_, r) => makeRelationRecord(r)),
+      memory: {
+        memory_id: `00000000-0000-4000-8000-${String(i).padStart(12, '0')}`,
+        content: `memory ${i} `.padEnd(400, 'x'),
+        summary: `summary ${i} `.padEnd(200, 'y'),
+        tags: ['decision', 'mcp-automem', 'typescript', `entity:topics:thing-${i}`],
+        importance: 0.8,
+        created_at: '2026-05-01T00:00:00.000000+00:00',
+        updated_at: '2026-06-01T00:00:00.000000+00:00',
+        last_accessed: '2026-06-09T00:00:00.000000+00:00',
+        metadata: {
+          enrichment: {
+            forced: false,
+            last_run: '2026-06-01T00:00:00.000000+00:00',
+            patterns_detected: ['decision'],
+            semantic_neighbors: ['a', 'b', 'c'],
+            temporal_links: 2,
+          },
+          entities: ['mcp-automem', 'claude-code'],
+        },
+        type: 'Decision',
+        confidence: 0.9,
+      },
+    }));
+    const client = {
+      recallMemory: vi.fn().mockResolvedValue({ results: manyResults, count: 26 }),
+    };
+
+    const response = await buildRecallMemoryResponse(client, {
+      query: 'session start',
+      format: 'detailed',
+      limit: 30,
+    });
+
+    const structured = response.structuredContent as any;
+    expect(structured.results).toHaveLength(26);
+    expect(structured).not.toHaveProperty('truncation');
+    const totalChars =
+      JSON.stringify(response.structuredContent).length +
+      response.content.reduce((sum, block) => sum + block.text.length, 0);
+    expect(totalChars).toBeLessThanOrEqual(45_000);
   });
 
   it('surfaces updated_at in text output and the structured base item', async () => {

--- a/src/recall-memory.test.ts
+++ b/src/recall-memory.test.ts
@@ -406,6 +406,40 @@ describe('buildRecallMemoryResponse', () => {
     });
   });
 
+  it('budgets json format by actual pretty-printed length, not a 2x minified guess', async () => {
+    vi.stubEnv('AUTOMEM_RECALL_TOKEN_BUDGET', '2000');
+    // Metadata built from many tiny arrays: pretty-printing inflates these ~6x
+    // over minified, so a 2x heuristic badly underestimates the text channel.
+    const inflatedMetadata = { rows: Array.from({ length: 40 }, () => [1]) };
+    const manyResults = Array.from({ length: 40 }, (_, i) => ({
+      id: `mem-${i}`,
+      match_type: 'semantic',
+      final_score: 0.5,
+      score_components: { importance: 0.5 },
+      memory: {
+        memory_id: `mem-${i}`,
+        content: 'small content',
+        tags: ['big'],
+        importance: 0.5,
+        created_at: '2026-03-25T00:00:00Z',
+        metadata: inflatedMetadata,
+      },
+    }));
+    const client = {
+      recallMemory: vi.fn().mockResolvedValue({ results: manyResults, count: 40 }),
+    };
+
+    const response = await buildRecallMemoryResponse(client, {
+      query: 'inflated',
+      format: 'json',
+    });
+
+    const structured = response.structuredContent as any;
+    expect(structured.truncation.applied).toBe(true);
+    // the pretty-printed text channel must respect the token budget
+    expect(response.content[0].text.length).toBeLessThanOrEqual(2000 * RECALL_CHARS_PER_TOKEN);
+  });
+
   it('drops trailing results past the global token budget in text format', async () => {
     const manyResults = Array.from({ length: 200 }, (_, i) => ({
       id: `mem-${i}`,

--- a/src/recall-memory.test.ts
+++ b/src/recall-memory.test.ts
@@ -462,6 +462,32 @@ describe('buildRecallMemoryResponse', () => {
     expect(structured.truncation.omitted_results).toBe(20 - structured.results.length);
   });
 
+  it('falls back to the default budget when AUTOMEM_RECALL_TOKEN_BUDGET is not a clean integer', async () => {
+    vi.stubEnv('AUTOMEM_RECALL_TOKEN_BUDGET', '1200foo');
+    const manyResults = Array.from({ length: 20 }, (_, i) => ({
+      id: `mem-${i}`,
+      match_type: 'semantic',
+      final_score: 0.5,
+      memory: {
+        memory_id: `mem-${i}`,
+        content: 'v'.repeat(RECALL_CONTENT_PREVIEW_CHARS + 100),
+        tags: ['big'],
+        importance: 0.5,
+        created_at: '2026-03-25T00:00:00Z',
+      },
+    }));
+    const client = {
+      recallMemory: vi.fn().mockResolvedValue({ results: manyResults, count: 20 }),
+    };
+
+    const response = await buildRecallMemoryResponse(client, { query: 'big' });
+
+    // strict parsing rejects "1200foo"; the default 18k budget keeps all 20
+    const structured = response.structuredContent as any;
+    expect(structured.results).toHaveLength(20);
+    expect(structured).not.toHaveProperty('truncation');
+  });
+
   it('fits a real-world session-start recall (fat relations + enrichment metadata) without truncation', async () => {
     // Modeled on the live 2026-06-10 failure: 26 ranked results, mixed relation
     // counts, enrichment metadata, ~400-char contents, 200-char summaries. The

--- a/src/recall-memory.ts
+++ b/src/recall-memory.ts
@@ -27,8 +27,9 @@ function estimateTokens(chars: number): number {
 function resolveTokenBudget(): number {
   const raw = process.env.AUTOMEM_RECALL_TOKEN_BUDGET;
   if (raw) {
-    const parsed = Number.parseInt(raw, 10);
-    if (Number.isFinite(parsed) && parsed > 0) {
+    // Strict parse: reject non-numeric suffixes ("1200foo") and fractions.
+    const parsed = Number(raw.trim());
+    if (Number.isInteger(parsed) && parsed > 0) {
       return parsed;
     }
   }

--- a/src/recall-memory.ts
+++ b/src/recall-memory.ts
@@ -2,18 +2,38 @@ import type { AutoMemClient } from './automem-client.js';
 import type { RecallMemoryArgs, RecallResult } from './types.js';
 
 // Response budgeting: recall responses must stay comfortably under MCP client
-// tool-response caps (~25k tokens in Claude Code). Per-memory previews keep
-// individual records bounded; the global budget drops trailing results when a
-// large corpus would still overflow. `format: "json"` keeps raw per-field
-// passthrough (escape hatch) but the global budget still applies. ID fetches
-// (`memory_id`) are never truncated — that is the documented way to retrieve a
-// full record.
-export const RECALL_CONTENT_PREVIEW_CHARS = 700;
-export const RECALL_MAX_RELATIONS = 5;
-export const RECALL_METADATA_MAX_CHARS = 800;
-export const RECALL_RESPONSE_CHAR_BUDGET = 80_000;
+// tool-response caps (~25k tokens in Claude Code). Budgeted formats
+// (text/items/detailed) are summary-first: the server's 1-2 sentence summary
+// replaces the content preview when present, relations collapse to compact
+// stubs, and metadata collapses to its key list. The global budget is measured
+// in estimated tokens — dense recall JSON tokenizes at ~2.5 chars/token
+// (empirical: a 64.8k-char response was rejected by Claude Code's 25k-token
+// cap), so the old 80k-char budget overflowed despite firing. `format: "json"`
+// keeps raw per-field passthrough (escape hatch) but the global budget still
+// applies. ID fetches (`memory_id`) are never truncated — that is the
+// documented way to retrieve a full record.
+export const RECALL_CONTENT_PREVIEW_CHARS = 400;
+export const RECALL_MAX_RELATIONS = 3;
+export const RECALL_RELATION_SUMMARY_CHARS = 100;
+export const RECALL_CHARS_PER_TOKEN = 2.5;
+export const DEFAULT_RECALL_TOKEN_BUDGET = 18_000;
 
-const RESPONSE_ENVELOPE_RESERVE_CHARS = 2_000;
+const RESPONSE_ENVELOPE_RESERVE_TOKENS = 800;
+
+function estimateTokens(chars: number): number {
+  return Math.ceil(chars / RECALL_CHARS_PER_TOKEN);
+}
+
+function resolveTokenBudget(): number {
+  const raw = process.env.AUTOMEM_RECALL_TOKEN_BUDGET;
+  if (raw) {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+  return DEFAULT_RECALL_TOKEN_BUDGET;
+}
 
 type RecallToolContent = {
   type: 'text';
@@ -34,6 +54,7 @@ type PerItemOutput = {
   textBlock: string;
   cost: number;
   contentTruncated: boolean;
+  summaryShown: boolean;
 };
 
 function capContent(
@@ -51,33 +72,42 @@ function capContent(
   };
 }
 
-function capMetadata(metadata: unknown, budgeted: boolean): unknown {
-  if (!budgeted || metadata === null || metadata === undefined || typeof metadata !== 'object') {
-    return metadata;
+function metadataKeyList(metadata: unknown): string[] | undefined {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return undefined;
   }
-  let serialized: string;
-  try {
-    serialized = JSON.stringify(metadata) ?? '';
-  } catch {
-    serialized = '';
-  }
-  if (serialized.length <= RECALL_METADATA_MAX_CHARS) {
-    return metadata;
-  }
+  const keys = Object.keys(metadata as Record<string, unknown>);
+  return keys.length > 0 ? keys : undefined;
+}
+
+// A relation as stored on a recall result embeds a full nested memory record.
+// Budgeted formats keep only what makes the edge meaningful: the target id,
+// edge type/strength, and a short summary of the target.
+function relationStub(rel: Record<string, any>): Record<string, unknown> {
+  const memory = rel?.memory && typeof rel.memory === 'object' ? rel.memory : undefined;
+  const id = memory?.id ?? rel?.id ?? rel?.memory_id;
+  const rawSummary = memory?.summary ?? memory?.content ?? rel?.summary ?? rel?.content;
+  const summary =
+    typeof rawSummary === 'string' && rawSummary.length > 0
+      ? rawSummary.length > RECALL_RELATION_SUMMARY_CHARS
+        ? `${rawSummary.slice(0, RECALL_RELATION_SUMMARY_CHARS)}…`
+        : rawSummary
+      : undefined;
   return {
-    _truncated: true,
-    _chars: serialized.length,
-    _keys: Object.keys(metadata as Record<string, unknown>),
+    ...(id !== undefined ? { id } : {}),
+    ...(rel?.type !== undefined ? { type: rel.type } : {}),
+    ...(typeof rel?.strength === 'number' ? { strength: rel.strength } : {}),
+    ...(summary !== undefined ? { summary } : {}),
   };
 }
 
-function capRelationArray(key: string, value: unknown, budgeted: boolean): Record<string, unknown> {
-  if (!Array.isArray(value) || !budgeted || value.length <= RECALL_MAX_RELATIONS) {
-    return { [key]: value };
+function compactRelations(value: unknown): Record<string, unknown> {
+  if (!Array.isArray(value) || value.length === 0) {
+    return {};
   }
   return {
-    [key]: value.slice(0, RECALL_MAX_RELATIONS),
-    [`${key}_total`]: value.length,
+    relations: value.slice(0, RECALL_MAX_RELATIONS).map(relationStub),
+    ...(value.length > RECALL_MAX_RELATIONS ? { relations_total: value.length } : {}),
   };
 }
 
@@ -86,40 +116,72 @@ function buildStructuredRecallItem(
   isRichFormat: boolean,
   budgeted: boolean,
   keepScoreComponents: boolean
-): { structuredItem: Record<string, unknown>; preview: string; contentTruncated: boolean } {
-  const { preview, truncated, chars } = capContent(item.memory.content, budgeted);
+): {
+  structuredItem: Record<string, unknown>;
+  displayText: string;
+  contentTruncated: boolean;
+  summaryShown: boolean;
+} {
+  const memory = item.memory;
+  const summary =
+    typeof memory.summary === 'string' && memory.summary.trim().length > 0
+      ? memory.summary
+      : undefined;
+  const useSummary = budgeted && summary !== undefined;
+  const { preview, truncated, chars } = capContent(memory.content, budgeted);
+  const contentTruncated = !useSummary && truncated;
+
   const base: Record<string, unknown> = {
-    memory_id: item.memory.memory_id,
-    content: preview,
-    ...(truncated ? { content_truncated: true, content_chars: chars } : {}),
-    tags: item.memory.tags,
-    importance: item.memory.importance,
-    created_at: item.memory.created_at,
-    updated_at: item.memory.updated_at,
+    memory_id: memory.memory_id,
+    ...(useSummary
+      ? {
+          summary,
+          ...(chars > 0 ? { content_chars: chars } : {}),
+        }
+      : {
+          content: preview,
+          ...(truncated ? { content_truncated: true, content_chars: chars } : {}),
+          ...(summary !== undefined ? { summary } : {}),
+        }),
+    tags: memory.tags,
+    importance: memory.importance,
+    created_at: memory.created_at,
+    updated_at: memory.updated_at,
     final_score: item.final_score,
     match_type: item.match_type,
   };
 
+  const displayText = useSummary ? summary : preview;
   if (!isRichFormat) {
-    return { structuredItem: base, preview, contentTruncated: truncated };
+    return { structuredItem: base, displayText, contentTruncated, summaryShown: useSummary };
   }
+
+  const metadataFields = budgeted
+    ? (() => {
+        const keys = metadataKeyList(memory.metadata);
+        return keys ? { metadata_keys: keys } : {};
+      })()
+    : { metadata: memory.metadata };
 
   const structuredItem: Record<string, unknown> = {
     ...base,
-    last_accessed: item.memory.last_accessed,
-    metadata: capMetadata(item.memory.metadata, budgeted),
-    type: item.memory.type,
-    confidence: item.memory.confidence,
-    match_score: item.match_score,
-    relation_score: item.relation_score,
+    last_accessed: memory.last_accessed,
+    ...metadataFields,
+    type: memory.type,
+    confidence: memory.confidence,
+    ...(budgeted
+      ? {}
+      : {
+          match_score: item.match_score,
+          relation_score: item.relation_score,
+          source: item.source,
+        }),
     ...(keepScoreComponents ? { score_components: item.score_components } : {}),
-    source: item.source,
-    ...capRelationArray('relations', item.relations, budgeted),
-    ...capRelationArray('related_to', item.related_to, budgeted),
+    ...(budgeted ? compactRelations(item.relations) : { relations: item.relations }),
     deduped_from: item.deduped_from,
     expanded_from_entity: item.expanded_from_entity,
   };
-  return { structuredItem, preview, contentTruncated: truncated };
+  return { structuredItem, displayText, contentTruncated, summaryShown: useSummary };
 }
 
 function buildStructuredEnvelope(recallResult: RecallResult): Record<string, unknown> {
@@ -234,39 +296,37 @@ export async function buildRecallMemoryResponse(
   }
 
   const perItem: PerItemOutput[] = results.map((item, index) => {
-    const { structuredItem, preview, contentTruncated } = buildStructuredRecallItem(
-      item,
-      isRichFormat,
-      budgeted,
-      keepScoreComponents
-    );
+    const { structuredItem, displayText, contentTruncated, summaryShown } =
+      buildStructuredRecallItem(item, isRichFormat, budgeted, keepScoreComponents);
     let textBlock = '';
     if (format === 'items') {
-      textBlock = `[${item.memory.memory_id}] ${preview}`;
+      textBlock = `[${item.memory.memory_id}] ${displayText}`;
     } else if (format === 'detailed') {
-      textBlock = renderDetailedBlock(item, preview);
+      textBlock = renderDetailedBlock(item, displayText);
     } else if (format !== 'json') {
-      textBlock = renderTextBlock(item, preview, index);
+      textBlock = renderTextBlock(item, displayText, index);
     }
     const structuredLength = JSON.stringify(structuredItem)?.length ?? 0;
     // json doubles the structured payload into the text channel (pretty-printed).
     const cost =
       format === 'json' ? structuredLength * 2 : structuredLength + textBlock.length;
-    return { structuredItem, textBlock, cost, contentTruncated };
+    return { structuredItem, textBlock, cost, contentTruncated, summaryShown };
   });
 
   // Global budget: always keep the first result; keep the rest while in budget.
+  const tokenBudget = resolveTokenBudget();
   const kept: PerItemOutput[] = [];
-  let runningTotal = RESPONSE_ENVELOPE_RESERVE_CHARS;
+  let runningTokens = RESPONSE_ENVELOPE_RESERVE_TOKENS;
   if (isIdFetch) {
     kept.push(...perItem);
   } else {
     for (const entry of perItem) {
-      if (kept.length > 0 && runningTotal + entry.cost > RECALL_RESPONSE_CHAR_BUDGET) {
+      const entryTokens = estimateTokens(entry.cost);
+      if (kept.length > 0 && runningTokens + entryTokens > tokenBudget) {
         break;
       }
       kept.push(entry);
-      runningTotal += entry.cost;
+      runningTokens += entryTokens;
     }
   }
   const omitted = perItem.length - kept.length;
@@ -279,7 +339,7 @@ export async function buildRecallMemoryResponse(
           truncation: {
             applied: true,
             omitted_results: omitted,
-            reason: 'response_char_budget',
+            reason: 'response_token_budget',
           },
         }
       : {}),
@@ -316,15 +376,16 @@ export async function buildRecallMemoryResponse(
   const notesSuffix = notes.length > 0 ? ` (${notes.join('; ')})` : '';
 
   const anyContentTruncated = kept.some((entry) => entry.contentTruncated);
+  const anySummaryShown = kept.some((entry) => entry.summaryShown);
   const trailerParts: string[] = [];
   if (omitted > 0) {
     trailerParts.push(
       `Response budget: showing ${kept.length} of ${perItem.length} results; ${omitted} omitted.`
     );
   }
-  if (anyContentTruncated) {
+  if (anyContentTruncated || anySummaryShown) {
     trailerParts.push(
-      'Some content previews truncated — fetch full records with recall_memory({ memory_id: "<id>" }).'
+      'Content shown as summaries/previews — fetch full records with recall_memory({ memory_id: "<id>" }).'
     );
   }
   const trailer = trailerParts.length > 0 ? `\n\n[${trailerParts.join(' ')}]` : '';

--- a/src/recall-memory.ts
+++ b/src/recall-memory.ts
@@ -308,9 +308,12 @@ export async function buildRecallMemoryResponse(
       textBlock = renderTextBlock(item, displayText, index);
     }
     const structuredLength = JSON.stringify(structuredItem)?.length ?? 0;
-    // json doubles the structured payload into the text channel (pretty-printed).
+    // json repeats the structured payload in the text channel pretty-printed;
+    // measure that length directly (nesting can inflate it well past 2x).
     const cost =
-      format === 'json' ? structuredLength * 2 : structuredLength + textBlock.length;
+      format === 'json'
+        ? structuredLength + (JSON.stringify(structuredItem, null, 2)?.length ?? 0)
+        : structuredLength + textBlock.length;
     return { structuredItem, textBlock, cost, contentTruncated, summaryShown };
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,6 +61,8 @@ export interface MemoryRecord {
 export interface StoredMemory {
   memory_id: string;
   content: string;
+  /** Server-generated 1-2 sentence summary (enrichment); absent until enriched. */
+  summary?: string;
   tags: string[];
   importance: number;
   created_at: string;
@@ -80,7 +82,6 @@ export interface RecallResult {
     score_components: Record<string, number>;
     source?: string;
     relations?: Array<Record<string, any>>;
-    related_to?: Array<Record<string, any>>;
     memory: StoredMemory & Record<string, any>;
     deduped_from?: string[];
     expanded_from_entity?: string;

--- a/tests/helpers/host-smoke.ts
+++ b/tests/helpers/host-smoke.ts
@@ -76,6 +76,7 @@ export async function startFakeAutoMemApi(): Promise<FakeAutoMemApi> {
             score_components: {},
             memory: {
               content: `remembered host smoke detail (${kind})`,
+              summary: `host smoke summary (${kind})`,
               tags,
               importance: 0.8,
               timestamp: '2026-06-06T00:00:00.000Z',


### PR DESCRIPTION
## Problem

`recall_memory` responses with `format: "detailed"` (the prescribed session-start format) exceed Claude Code's MCP tool-response cap (~25k tokens) on real corpora. Live repro on 2026-06-10: two session-start recalls came back at ~64.8k chars and were rejected — **even though the existing 80k-char budget had already fired** and dropped 10 of 26 results.

Byte analysis of the failed response: 67% was relation data, and half of that was a byte-identical `related_to` duplicate fabricated by our own client mapping (`related_to: result.related_to || result.relations || []`) and then serialized alongside `relations`.

## Changes

1. **De-duplicate relations** — normalize to a single `relations` field in the client; `related_to` removed from types and structured output (~34% instant reduction on relation-bearing corpora).
2. **Compact relation stubs** in budgeted formats (`text`/`items`/`detailed`): `{id, type, strength, summary≤100ch}`, capped at 3 with `relations_total`. `json` and ID fetches keep full records.
3. **Metadata → `metadata_keys`** in budgeted formats (observed blobs are mostly enrichment bookkeeping); full metadata via `json`/ID fetch.
4. **Token-aware global budget** — replaces the mis-calibrated 80k-char cap (≈31k tokens at the empirical ~2.5 chars/token for dense recall JSON). Default 18k estimated tokens, override via `AUTOMEM_RECALL_TOKEN_BUDGET`.
5. **Summary-first display** — budgeted formats show the stored 1–2 sentence `summary` when the server provides one, falling back to a content preview (now 400 chars, was 700). Server-side exposure of `summary` on the semantic path is tracked in verygoodplugins/automem#180; this PR degrades gracefully until that ships.

## Live verification (production corpus)

| Recall | Before | After |
|---|---|---|
| Preferences (tag-only, limit 20, detailed) | 64,100 chars — **rejected by client cap** | 25,981 chars (~10.4k tokens), all 18 kept, summaries 18/18 |
| Task context (semantic, limit 30, detailed) | 64,814 chars — **rejected by client cap** | 42,423 chars (~17k tokens), 21 of 26 kept |

## Tests

- TDD: 11 new/updated tests in `src/recall-memory.test.ts` + `src/automem-client.test.ts`, including a regression test modeled on the live failure profile (26 results, mixed fat relations, enrichment metadata → must fit ≤45k chars with zero truncation).
- Full suite: 471 tests across 29 files green; `npm run build` green.
- Fake AutoMem API fixture now serves `summary` so host smoke tests exercise the new mapping.

## Risk notes

- Budgeted format output shape changes (`metadata` → `metadata_keys`, relation stubs, possible `summary` instead of `content`). These formats are an internal contract with this repo's own policy templates; `json` and ID-fetch passthrough are unchanged as the full-fidelity escape hatches.
- `truncation.reason` renamed `response_char_budget` → `response_token_budget`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)