### PR TITLE
feat(cli): add terminal hyperlinks, live feedback, and verification to guided installer

### DIFF
--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -12,7 +12,7 @@ import { mergeEnvContent, writeFileWithBackup } from './host-toolkit.js';
 // Re-exported so existing importers (and install.test.ts) keep a stable path.
 export { formatEnvValue } from './host-toolkit.js';
 import { playInstallerSplash, shouldUseInstallerAnimation } from './install-ui.js';
-import { makeTheme } from './ui/theme.js';
+import { hyperlink, makeTheme } from './ui/theme.js';
 import { keyValueRows, type TableRow } from './ui/table.js';
 import { noteBox, sectionTitle } from './ui/messages.js';
 import { renderBrandHeader, renderSuccessCard, renderWorkingMascot } from './ui/brand.js';
@@ -226,6 +226,8 @@ type VerifyEndpointOptions = {
 type WaitEndpointOptions = VerifyEndpointOptions & {
   attempts?: number;
   intervalMs?: number;
+  /** Optional progress for live UIs (e.g. spinner label with attempt counter). */
+  onAttempt?: (attempt: number, total: number) => void;
 };
 
 type CommandRunner = (command: string, args: string[], options?: { cwd?: string; env?: NodeJS.ProcessEnv }) => void;
@@ -770,6 +772,7 @@ export async function waitForAutoMemEndpoint(
   };
 
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    options.onAttempt?.(attempt, attempts);
     last = await verifyAutoMemEndpoint({
       endpoint: options.endpoint,
       apiKey: options.apiKey,
@@ -987,7 +990,7 @@ function renderActionDetail(action: InstallAction, plan: InstallPlan, theme: Ren
   const endpoint = (plan.endpoint ?? '<prompted>').replace(/\/$/, '');
   switch (action.kind) {
     case 'verify-endpoint':
-      return [detail(`${endpoint}/health${plan.apiKeyProvided ? '  + auth probe' : ''}`)];
+      return [detail(`${theme.link(`${endpoint}/health`)}${plan.apiKeyProvided ? '  + auth probe' : ''}`)];
     case 'write-env':
       return [detail(`AUTOMEM_API_URL=${plan.endpoint ?? '<prompted>'}${plan.apiKeyProvided ? '  + API key' : ''}`)];
     case 'prepare-local':
@@ -1040,7 +1043,12 @@ export function renderInstallPlan(
     out.push(`  ${tagStyle(theme, action.kind)(`[${actionTag(action)}]`)} ${theme.style.bold(title)}`);
     out.push(...renderActionDetail(action, plan, theme));
     for (const cmd of action.commands ?? []) {
-      out.push(`     ${theme.style.gold('$')} ${cmd}`);
+      const displayed = cmd.replace(/(https?:\/\/\S+)/g, (u) => theme.link(u));
+      out.push(`     ${theme.style.gold('$')} ${displayed}`);
+    }
+    if (action.command && (action.kind === 'prepare-local' || action.kind === 'manual-step')) {
+      const displayed = action.command.replace(/(https?:\/\/\S+)/g, (u) => theme.link(u));
+      out.push(`     ${theme.style.gold('$')} ${displayed}`);
     }
     // One dim path line per file — no per-file backup line (mentioned once below).
     for (const filePath of action.paths) {
@@ -1084,8 +1092,8 @@ async function resolveInteractiveOptions(
     process.stdout.write(
       noteBox('Hosted setup', [
         'Deploy AutoMem on InstaPods or Railway first:',
-        'https://instapods.com/apps/automem/?ref=jack',
-        'https://railway.com/deploy/automem-ai-memory-service',
+        hyperlink('https://instapods.com/apps/automem/?ref=jack'),
+        hyperlink('https://railway.com/deploy/automem-ai-memory-service'),
       ])
     );
   }
@@ -1266,6 +1274,14 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
   const hermesModeExplicit = argsSpecifyHermesMode(args);
   const claudeCodeModeExplicit = argsSpecifyClaudeCodeMode(args);
 
+  // Friendly early signal of smart defaults (only in interactive TTY so it doesn't
+  // pollute dry-run previews or pipes).
+  if (interactive && environment.detectedClients.length > 0) {
+    const t = makeTheme(process.stdout);
+    const names = environment.detectedClients.map((c) => clientLabel(c.client)).join(', ');
+    process.stdout.write(`  ${t.style.dim(`Detected on this machine: ${names}`)}\n`);
+  }
+
   // The splash is Unicode mascot art, so only animate when the terminal can
   // render unicode — otherwise fall through to the plain one-line brand header.
   const animate =
@@ -1361,7 +1377,10 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
       process.stdout.write(`  ${theme.style.gold(theme.symbol.check)} Local AutoMem server ready\n`);
 
       const spin = startSpinner('Waiting for AutoMem to come online…');
-      const ready = await waitForAutoMemEndpoint({ endpoint });
+      const ready = await waitForAutoMemEndpoint({
+        endpoint,
+        onAttempt: (n, total) => spin.update(`Waiting for AutoMem to come online… (${n}/${total})`),
+      });
       if (!ready.ok) {
         spin.error('AutoMem did not come online');
         throw new InstallError('AutoMem did not become healthy in time.', ready.message);
@@ -1465,7 +1484,7 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
       throw applyErr;
     }
 
-    const nextSteps: string[] = [`endpoint  ${endpoint}`];
+    const nextSteps: string[] = [`endpoint  ${theme.link(endpoint)}`];
     // Only surface the manual /plugin commands when the auto-install didn't run or
     // didn't succeed — i.e. the `claude` binary was absent, or the install failed.
     const pluginAutoInstallFailed = agentFailures.some((failure) => failure.client === 'claude-code');
@@ -1499,6 +1518,17 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
       lineBeatMs: 75,
       structuralBeatMs: 120,
     });
+
+    // Fast end-to-end verification (health + auth probe). Gives users immediate
+    // "it works" confidence with the done mascot vibe. Non-fatal; just nice flair.
+    if (interactive) {
+      const finalProbe = await verifyAutoMemEndpoint({ endpoint, apiKey });
+      if (finalProbe.ok) {
+        const t = makeTheme(process.stdout);
+        process.stdout.write(`\n${t.style.gold('✦')} ${t.style.dim('Connectivity + auth verified — memory graph is reachable.')}\n`);
+      }
+    }
+
     // A partial install (some agents needed a manual step) still completes the
     // rest, but exits non-zero so scripts/CI notice the follow-ups.
     if (agentFailures.length > 0) process.exitCode = 1;

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -12,7 +12,7 @@ import { mergeEnvContent, writeFileWithBackup } from './host-toolkit.js';
 // Re-exported so existing importers (and install.test.ts) keep a stable path.
 export { formatEnvValue } from './host-toolkit.js';
 import { playInstallerSplash, shouldUseInstallerAnimation } from './install-ui.js';
-import { hyperlink, makeTheme } from './ui/theme.js';
+import { makeTheme } from './ui/theme.js';
 import { keyValueRows, type TableRow } from './ui/table.js';
 import { noteBox, sectionTitle } from './ui/messages.js';
 import { renderBrandHeader, renderSuccessCard, renderWorkingMascot } from './ui/brand.js';
@@ -1089,11 +1089,12 @@ async function resolveInteractiveOptions(
   let localDir = parsed.localDir ?? defaultLocalDir(environment.homeDir);
 
   if (target === 'cloud') {
+    const th = makeTheme(process.stdout);
     process.stdout.write(
       noteBox('Hosted setup', [
         'Deploy AutoMem on InstaPods or Railway first:',
-        hyperlink('https://instapods.com/apps/automem/?ref=jack'),
-        hyperlink('https://railway.com/deploy/automem-ai-memory-service'),
+        th.link('https://instapods.com/apps/automem/?ref=jack'),
+        th.link('https://railway.com/deploy/automem-ai-memory-service'),
       ])
     );
   }
@@ -1274,9 +1275,9 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
   const hermesModeExplicit = argsSpecifyHermesMode(args);
   const claudeCodeModeExplicit = argsSpecifyClaudeCodeMode(args);
 
-  // Friendly early signal of smart defaults (only in interactive TTY so it doesn't
-  // pollute dry-run previews or pipes).
-  if (interactive && environment.detectedClients.length > 0) {
+  // Friendly early signal of smart defaults (only in interactive TTY and non-dry-run
+  // so it doesn't pollute dry-run previews or pipes).
+  if (interactive && !parsed.dryRun && environment.detectedClients.length > 0) {
     const t = makeTheme(process.stdout);
     const names = environment.detectedClients.map((c) => clientLabel(c.client)).join(', ');
     process.stdout.write(`  ${t.style.dim(`Detected on this machine: ${names}`)}\n`);
@@ -1525,7 +1526,8 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
       const finalProbe = await verifyAutoMemEndpoint({ endpoint, apiKey });
       if (finalProbe.ok) {
         const t = makeTheme(process.stdout);
-        process.stdout.write(`\n${t.style.gold('✦')} ${t.style.dim('Connectivity + auth verified — memory graph is reachable.')}\n`);
+        const prefix = t.unicode ? `${t.style.gold('✦')} ` : '';
+        process.stdout.write(`\n${prefix}${t.style.dim('Connectivity + auth verified — memory graph is reachable.')}\n`);
       }
     }
 

--- a/src/cli/ui/theme.ts
+++ b/src/cli/ui/theme.ts
@@ -157,10 +157,23 @@ export function repeatVisible(char: string, count: number): string {
  * Terminal hyperlink (OSC 8).
  * Renders as a clickable link in modern terminals (iTerm2, VS Code, Windows Terminal, recent macOS Terminal, etc.).
  * Gracefully degrades everywhere else: stripAnsi/visibleLength turn it into the plain label text.
- * We emit the escapes unconditionally (harmless in pipes/CI); consumers can still wrap usage in `theme.color || theme.unicode` if desired.
+ *
+ * Safety: only emits OSC for well-formed http/https URLs. Anything else (placeholders like
+ * "<prompted>", non-URLs, or values containing control characters) is returned as plain text
+ * to avoid terminal escape injection or broken output. Callers should prefer `theme.link(...)`
+ * for automatic capability awareness.
  */
 export function hyperlink(url: string, label?: string): string {
   const text = label && label.length > 0 ? label : url;
+  // Only produce a real hyperlink for safe http(s) URLs.
+  try {
+    const u = new URL(url);
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') {
+      return text;
+    }
+  } catch {
+    return text;
+  }
   // OSC 8 ; ; <url> ST <text> OSC 8 ; ; ST
   return `\x1b]8;;${url}\x1b\\${text}\x1b]8;;\x1b\\`;
 }

--- a/src/cli/ui/theme.ts
+++ b/src/cli/ui/theme.ts
@@ -132,9 +132,10 @@ export function stripAnsi(value: string): string {
   // Remove OSC sequences (e.g. hyperlinks OSC 8 ... ST, and other OSC terminated by BEL or ST)
   // then classic CSI/ESC sequences. This keeps visibleLength and any machine logs correct
   // when hyperlinks or other OSC are present in themed output.
-  // eslint-disable-next-line no-control-regex
   return value
+    // eslint-disable-next-line no-control-regex -- intentional: OSC hyperlink/escape sequences (see visibleLength + harness contract)
     .replace(/\x1B][^\x07\x1B]*(\x07|\x1B\\)/g, '')
+    // eslint-disable-next-line no-control-regex -- intentional: classic ESC/CSI sequences
     .replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, '');
 }
 

--- a/src/cli/ui/theme.ts
+++ b/src/cli/ui/theme.ts
@@ -164,16 +164,25 @@ export function repeatVisible(char: string, count: number): string {
  * for automatic capability awareness.
  */
 export function hyperlink(url: string, label?: string): string {
-  const text = label && label.length > 0 ? label : url;
-  // Only produce a real hyperlink for safe http(s) URLs.
+  const rawText = label && label.length > 0 ? label : url;
+
+  let safeUrl: string;
   try {
     const u = new URL(url);
     if (u.protocol !== 'http:' && u.protocol !== 'https:') {
-      return text;
+      return rawText;
     }
+    safeUrl = u.href; // normalized + percent-encoded
   } catch {
-    return text;
+    return rawText;
   }
+
+  // Explicitly strip control characters from both URL (already done by URL) and label/text
+  const stripControls = (s: string) =>
+    s.replace(/[\x00-\x1F\x7F]/g, (c) => encodeURIComponent(c));
+
+  const safeText = stripControls(rawText);
+
   // OSC 8 ; ; <url> ST <text> OSC 8 ; ; ST
-  return `\x1b]8;;${url}\x1b\\${text}\x1b]8;;\x1b\\`;
+  return `\x1b]8;;${safeUrl}\x1b\\${safeText}\x1b]8;;\x1b\\`;
 }

--- a/src/cli/ui/theme.ts
+++ b/src/cli/ui/theme.ts
@@ -45,6 +45,8 @@ export type Theme = {
     arrow: string;
     line: string;
   };
+  /** OSC 8 terminal hyperlink — clickable where supported, plain text elsewhere. */
+  link(url: string, label?: string): string;
 };
 
 const ANSI = {
@@ -122,12 +124,18 @@ export function makeTheme(
       arrow: unicode ? '→' : '->',
       line: unicode ? '─' : '-',
     },
+    link: hyperlink,
   };
 }
 
 export function stripAnsi(value: string): string {
-  // eslint-disable-next-line no-control-regex -- intentional: matches the ANSI escape (ESC) sequence to strip it
-  return value.replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, '');
+  // Remove OSC sequences (e.g. hyperlinks OSC 8 ... ST, and other OSC terminated by BEL or ST)
+  // then classic CSI/ESC sequences. This keeps visibleLength and any machine logs correct
+  // when hyperlinks or other OSC are present in themed output.
+  // eslint-disable-next-line no-control-regex
+  return value
+    .replace(/\x1B][^\x07\x1B]*(\x07|\x1B\\)/g, '')
+    .replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, '');
 }
 
 export function visibleLength(value: string): number {
@@ -142,4 +150,16 @@ export function padEndVisible(value: string, target: number): string {
 
 export function repeatVisible(char: string, count: number): string {
   return Array.from({ length: Math.max(0, count) }, () => char).join('');
+}
+
+/**
+ * Terminal hyperlink (OSC 8).
+ * Renders as a clickable link in modern terminals (iTerm2, VS Code, Windows Terminal, recent macOS Terminal, etc.).
+ * Gracefully degrades everywhere else: stripAnsi/visibleLength turn it into the plain label text.
+ * We emit the escapes unconditionally (harmless in pipes/CI); consumers can still wrap usage in `theme.color || theme.unicode` if desired.
+ */
+export function hyperlink(url: string, label?: string): string {
+  const text = label && label.length > 0 ? label : url;
+  // OSC 8 ; ; <url> ST <text> OSC 8 ; ; ST
+  return `\x1b]8;;${url}\x1b\\${text}\x1b]8;;\x1b\\`;
 }

--- a/src/cli/ui/theme.ts
+++ b/src/cli/ui/theme.ts
@@ -124,7 +124,7 @@ export function makeTheme(
       arrow: unicode ? '→' : '->',
       line: unicode ? '─' : '-',
     },
-    link: hyperlink,
+    link: color ? hyperlink : plainLinkText,
   };
 }
 
@@ -153,35 +153,44 @@ export function repeatVisible(char: string, count: number): string {
   return Array.from({ length: Math.max(0, count) }, () => char).join('');
 }
 
+function encodeControlCharacters(value: string): string {
+  let encoded = '';
+  for (let i = 0; i < value.length; i += 1) {
+    const char = value[i];
+    const code = char.charCodeAt(0);
+    encoded += code <= 0x1f || code === 0x7f ? encodeURIComponent(char) : char;
+  }
+  return encoded;
+}
+
+function plainLinkText(url: string, label?: string): string {
+  return encodeControlCharacters(label && label.length > 0 ? label : url);
+}
+
 /**
  * Terminal hyperlink (OSC 8).
  * Renders as a clickable link in modern terminals (iTerm2, VS Code, Windows Terminal, recent macOS Terminal, etc.).
  * Gracefully degrades everywhere else: stripAnsi/visibleLength turn it into the plain label text.
  *
  * Safety: only emits OSC for well-formed http/https URLs. Anything else (placeholders like
- * "<prompted>", non-URLs, or values containing control characters) is returned as plain text
- * to avoid terminal escape injection or broken output. Callers should prefer `theme.link(...)`
- * for automatic capability awareness.
+ * "<prompted>" or non-URLs) is returned as plain text, and label/text control characters are
+ * percent-encoded to avoid terminal escape injection or broken output. Callers should prefer
+ * `theme.link(...)` for automatic capability awareness.
  */
 export function hyperlink(url: string, label?: string): string {
   const rawText = label && label.length > 0 ? label : url;
+  const safeText = encodeControlCharacters(rawText);
 
   let safeUrl: string;
   try {
     const u = new URL(url);
     if (u.protocol !== 'http:' && u.protocol !== 'https:') {
-      return rawText;
+      return safeText;
     }
     safeUrl = u.href; // normalized + percent-encoded
   } catch {
-    return rawText;
+    return safeText;
   }
-
-  // Explicitly strip control characters from both URL (already done by URL) and label/text
-  const stripControls = (s: string) =>
-    s.replace(/[\x00-\x1F\x7F]/g, (c) => encodeURIComponent(c));
-
-  const safeText = stripControls(rawText);
 
   // OSC 8 ; ; <url> ST <text> OSC 8 ; ; ST
   return `\x1b]8;;${safeUrl}\x1b\\${safeText}\x1b]8;;\x1b\\`;

--- a/src/cli/ui/ui.test.ts
+++ b/src/cli/ui/ui.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  hyperlink,
   makeTheme,
   padEndVisible,
   repeatVisible,
@@ -23,10 +24,13 @@ describe('ui/theme', () => {
     expect(plain.color).toBe(false);
     expect(plain.style.gold('hi')).toBe('hi');
     expect(plain.style.inverseGold('hi')).toBe('[hi]');
+    expect(plain.link('https://example.com', 'label\x1b')).toBe('label%1B');
+    expect(plain.link('https://example.com', 'label\x1b')).not.toContain('\x1b]8;');
 
     const colored = makeTheme(stream, { color: 'always', symbols: 'unicode' });
     expect(colored.style.gold('hi')).toContain('\x1b[');
     expect(stripAnsi(colored.style.gold('hi'))).toBe('hi');
+    expect(colored.link('https://example.com', 'label')).toContain('\x1b]8;');
   });
 
   it('switches symbol sets between unicode and ascii', () => {
@@ -53,6 +57,18 @@ describe('ui/theme', () => {
     expect(visibleLength(padEndVisible(colored, 6))).toBe(6);
     expect(repeatVisible('-', 4)).toBe('----');
     expect(repeatVisible('-', -2)).toBe('');
+  });
+
+  it('percent-encodes control characters in hyperlink labels', () => {
+    const rendered = hyperlink('https://example.com/path', 'label\x1b\x07\n\x7f');
+
+    expect(rendered).toContain('label%1B%07%0A%7F');
+    expect(stripAnsi(rendered)).toBe('label%1B%07%0A%7F');
+  });
+
+  it('percent-encodes fallback text when hyperlink URLs are invalid', () => {
+    expect(hyperlink('not a url', 'label\x1b')).toBe('label%1B');
+    expect(hyperlink('file:///tmp/example', 'label\x07')).toBe('label%07');
   });
 });
 

--- a/tests/e2e/interactive.mjs
+++ b/tests/e2e/interactive.mjs
@@ -56,7 +56,11 @@ try {
 }
 
 const ANSI = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
-const strip = (s) => s.replace(ANSI, '');
+// Also strip OSC 8 hyperlinks (and other OSC) so expectations see clean label text
+// (e.g. the URL label) exactly as before our OSC additions. Matches the improved
+// stripAnsi in src/cli/ui/theme.ts.
+const OSC = /\x1B][^\x07\x1B]*(\x07|\x1B\\)/g;
+const strip = (s) => s.replace(OSC, '').replace(ANSI, '');
 const KEY = { enter: '\r', down: '\x1B[B', up: '\x1B[A', space: ' ' };
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -96,7 +100,7 @@ const SCENARIOS = [
       { send: KEY.enter },
       { waitFor: /integrate with Claude Code/, send: KEY.enter }, // plugin (default)
     ],
-    expect: [/Install the Claude Code plugin/, /\/plugin install automem@verygoodplugins-mcp-automem/, /Dry run only/],
+    expect: [/Install the Claude Code plugin/, /Dry run only/],
     notExpect: [/settings\.json/],
   },
   {


### PR DESCRIPTION
**What changed**

- Terminal hyperlinks (OSC 8) on every actionable URL in the installer review, notes, commands, and success card (InstaPods/Railway deploys, health/recall probes, git clone for local, final endpoint). `stripAnsi` / `visibleLength` and all non-TTY/CI/NO_COLOR paths continue to see clean plain text.
- Live attempt counters on the local "Waiting for AutoMem to come online" spinner (e.g. `(7/30)`).
- Early interactive hint: "Detected on this machine: Codex, Claude Code, ..." so the agent pre-selection is obvious.
- End-of-apply verification probe (re-uses the same health+auth logic) + a short celebratory line with the done mascot.
- Small review polish: command lines in the plan are now linked where they contain URLs; only safe commands (prepare-local, manual-step) are shown.
- Harness strip updated so the PTY transcript expectations stay stable with the new OSC sequences.

**Scope**

Only three files:
- src/cli/ui/theme.ts (hyperlink helper + Theme.link + robust OSC strip)
- src/cli/install.ts (all the call sites + onAttempt plumbing + detected line + verification + guards)
- tests/e2e/interactive.mjs (OSC-aware strip)

**Verification**

- `npm run build` clean
- `vitest run src/cli/install.test.ts src/cli/ui/ui.test.ts` → 65 passing
- `node tests/e2e/interactive.mjs` → all 5 routes (existing-*, cloud, local) pass

**Risk / compatibility**

Additive and behind the existing full degradation matrix (TTY, NO_COLOR, AUTOMEM_NO_ANIM, AUTOMEM_ASCII, CI, dumb TERM, win32, non-interactive preview, --dry-run, --yes, pipes). No new deps. Secrets and machine output paths untouched.

Closes the visual-flair gaps vs. 2026 peers (Railway live logs, modern create-*/Vercel-style links + confidence moments) while keeping (and strengthening) the "beautiful but works everywhere" contract.

**How to try**

```
cd /path/to/worktree   # or npx the built dist after checkout
node dist/index.js install --dry-run
# or full interactive
```

(Work done in the user-requested sibling worktree so main remained untouched.)