### PR TITLE
fix(build): avoid shell chmod in postbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "prebuild": "tsx scripts/sync-memory-policy.ts && node scripts/sync-template-versions.mjs",
     "build": "tsc",
-    "postbuild": "node scripts/build-openclaw-plugin-package.mjs && chmod +x dist/index.js",
+    "postbuild": "node scripts/build-openclaw-plugin-package.mjs",
     "sync-versions": "node scripts/sync-template-versions.mjs",
     "docs:hermes": "node scripts/build-hermes-demos.mjs",
     "probe:claude-stop-context": "node scripts/probe-claude-stop-additional-context.mjs",

--- a/scripts/build-openclaw-plugin-package.mjs
+++ b/scripts/build-openclaw-plugin-package.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -53,5 +53,7 @@ for (const filename of runtimeFiles) {
   mkdirSync(dirname(targetPath), { recursive: true });
   cpSync(join(DIST_ROOT, filename), targetPath);
 }
+
+chmodSync(join(DIST_ROOT, 'index.js'), 0o755);
 
 console.log(`✓ staged lean OpenClaw plugin package in ${join('dist', 'openclaw-plugin-package')}`);

--- a/scripts/build-openclaw-plugin-package.mjs
+++ b/scripts/build-openclaw-plugin-package.mjs
@@ -54,6 +54,10 @@ for (const filename of runtimeFiles) {
   cpSync(join(DIST_ROOT, filename), targetPath);
 }
 
-chmodSync(join(DIST_ROOT, 'index.js'), 0o755);
+try {
+  chmodSync(join(DIST_ROOT, 'index.js'), 0o755);
+} catch (error) {
+  if (process.platform !== 'win32') throw error;
+}
 
 console.log(`✓ staged lean OpenClaw plugin package in ${join('dist', 'openclaw-plugin-package')}`);

--- a/tests/cli/smoke.test.ts
+++ b/tests/cli/smoke.test.ts
@@ -491,6 +491,21 @@ describe('Template Generation', () => {
     ).toEqual([]);
   });
 
+  it('postbuild should not depend on a shell chmod command', () => {
+    const repoRoot = path.resolve(__dirname, '../..');
+    const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, 'package.json'), 'utf8'));
+    const postbuild = pkg.scripts?.postbuild ?? '';
+
+    expect(postbuild).toBe('node scripts/build-openclaw-plugin-package.mjs');
+    expect(postbuild).not.toMatch(/\bchmod\b/);
+
+    const openclawBuildScript = fs.readFileSync(
+      path.join(repoRoot, 'scripts/build-openclaw-plugin-package.mjs'),
+      'utf8'
+    );
+    expect(openclawBuildScript).toContain("chmodSync(join(DIST_ROOT, 'index.js'), 0o755)");
+  });
+
   it('cursor project template should include operational memory workflow (3.0.0 playbook)', () => {
     const cursorTemplate = fs.readFileSync(
       path.resolve(__dirname, '../../templates/cursor/automem.mdc.template'),


### PR DESCRIPTION
## Summary
- Removes the shell `chmod +x` from the npm `postbuild` script so Windows/npm lifecycle shells do not need a Unix chmod binary.
- Moves the executable-bit update into `scripts/build-openclaw-plugin-package.mjs` via Node `chmodSync`.
- Adds a smoke regression test for the postbuild contract.

Supersedes #114 with the same fix adapted onto current `main` and without a manual changelog edit.

## Breaking changes
None.

## Validation
- `npm run build`
- `npm audit --audit-level=high`
- `env -u AUTOMEM_ENDPOINT -u AUTOMEM_API_URL -u AUTOMEM_API_KEY npm test`