### PR TITLE
test(installer): fail CI on skipped website-bootstrap; lock credential + uninstall contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The production curl|sh entrypoint lives in the website repo (served at
+      # automem.ai/install.sh). Check it out so the e2e website-bootstrap scenario
+      # exercises the REAL launcher, not a stale copy. Public repo → default token.
+      - name: Check out automem-website (for the curl|sh install bootstrap)
+        uses: actions/checkout@v4
+        with:
+          repository: verygoodplugins/automem-website
+          path: automem-website
+
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
@@ -59,6 +68,12 @@ jobs:
       # scenarios against an in-process mock — no docker, no node-pty, no network).
       # Gates the risky write/abort/idempotency paths the unit tests don't reach.
       - name: E2E install scenarios
+        env:
+          # Point the harness at the real production install.sh and REQUIRE it, so the
+          # website-bootstrap (curl | sh) scenario can never be silently skipped again.
+          # A missing/renamed checkout now fails the build instead of going green-untested.
+          AUTOMEM_INSTALL_SH: ${{ github.workspace }}/automem-website/public/install.sh
+          AUTOMEM_REQUIRE_INSTALL_SH: "1"
         run: npm run test:e2e
 
   hooks-windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,15 +34,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # The production curl|sh entrypoint lives in the website repo (served at
-      # automem.ai/install.sh). Check it out so the e2e website-bootstrap scenario
-      # exercises the REAL launcher, not a stale copy. Public repo → default token.
-      - name: Check out automem-website (for the curl|sh install bootstrap)
-        uses: actions/checkout@v4
-        with:
-          repository: verygoodplugins/automem-website
-          path: automem-website
-
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
@@ -67,6 +58,16 @@ jobs:
       # Headless installer e2e matrix (builds+packs a tarball, runs install/uninstall
       # scenarios against an in-process mock — no docker, no node-pty, no network).
       # Gates the risky write/abort/idempotency paths the unit tests don't reach.
+      # Check out the production curl|sh entrypoint (served at automem.ai/install.sh)
+      # immediately before the e2e step — NOT at the top — so this external checkout
+      # never contaminates lint/build/test scope (`eslint .` / `vitest run` would
+      # otherwise traverse automem-website/ and fail on its source).
+      - name: Check out automem-website (for the curl|sh install bootstrap)
+        uses: actions/checkout@v4
+        with:
+          repository: verygoodplugins/automem-website
+          path: automem-website
+
       - name: E2E install scenarios
         env:
           # Point the harness at the real production install.sh and REQUIRE it, so the

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -67,6 +67,24 @@ describe('guided install helpers', () => {
     });
   });
 
+  it('reads AUTOMEM_API_KEY from the environment when no --api-key flag is given (the curl|sh path)', () => {
+    // Regression guard for the website install path. public/install.sh deliberately
+    // does NOT map AUTOMEM_API_KEY to a --api-key CLI flag — that would leak the token
+    // via process args (`ps`) and the stage-4 `npx … $*` echo. The token instead flows
+    // through the environment, which parseInstallArgs reads here. install-surface.test.mjs
+    // asserts the complementary half (install.sh contains no --api-key). Together they lock
+    // the contract: credentials reach the installer via env, never argv.
+    expect(parseInstallArgs([], { AUTOMEM_API_KEY: 'env-secret' }).apiKey).toBe('env-secret');
+    // Legacy fallback to AUTOMEM_API_TOKEN when AUTOMEM_API_KEY is absent.
+    expect(parseInstallArgs([], { AUTOMEM_API_TOKEN: 'tok-secret' }).apiKey).toBe('tok-secret');
+    // No key anywhere → undefined (an unauthenticated install, e.g. local self-host).
+    expect(parseInstallArgs([], {}).apiKey).toBeUndefined();
+    // An explicit --api-key flag still wins over the environment.
+    expect(
+      parseInstallArgs(['--api-key', 'flag-key'], { AUTOMEM_API_KEY: 'env-secret' }).apiKey
+    ).toBe('flag-key');
+  });
+
   it('rejects unknown install targets and clients', () => {
     expect(() => parseInstallArgs(['--target', 'serverless'])).toThrow(/invalid install target/i);
     expect(() => parseInstallArgs(['--clients', 'codex,nope'])).toThrow(/invalid AutoMem client/i);

--- a/src/cli/uninstall.test.ts
+++ b/src/cli/uninstall.test.ts
@@ -6,6 +6,95 @@ import { parse as parseYaml } from 'yaml';
 import { removeManagedHookEntries } from './claude-code.js';
 import { parseUninstallArgs, runUninstall } from './uninstall.js';
 
+describe('uninstall --clean-all preserves foreign Claude Desktop mcpServers', () => {
+  // Guards the highest-blast-radius path: --clean-all edits the user's shared
+  // claude_desktop_config.json. The code deletes only the `memory`/`automem`
+  // keys (never an overwrite), but nothing asserted that a *foreign* server
+  // survives. This locks that — a regression to a blanket overwrite fails here.
+  let home: string;
+
+  beforeEach(() => {
+    home = fs.mkdtempSync(path.join(os.tmpdir(), 'automem-uninstall-claude-desktop-'));
+    vi.spyOn(os, 'homedir').mockReturnValue(home);
+    vi.spyOn(os, 'platform').mockReturnValue('darwin');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  function seedConfig(extra: Record<string, unknown> = {}): string {
+    const cfgDir = path.join(home, 'Library', 'Application Support', 'Claude');
+    fs.mkdirSync(cfgDir, { recursive: true });
+    const cfgPath = path.join(cfgDir, 'claude_desktop_config.json');
+    fs.writeFileSync(
+      cfgPath,
+      JSON.stringify(
+        {
+          mcpServers: {
+            memory: { command: 'npx', args: ['-y', '@verygoodplugins/mcp-automem'] },
+            automem: { command: 'npx', args: ['-y', '@verygoodplugins/mcp-automem'] },
+            filesystem: { command: 'npx', args: ['-y', '@modelcontextprotocol/server-filesystem'] },
+          },
+          globalShortcut: 'Cmd+Shift+Space',
+          ...extra,
+        },
+        null,
+        2,
+      ),
+    );
+    return cfgPath;
+  }
+
+  it('removes only memory/automem, keeps a foreign server + unrelated keys, and backs up', async () => {
+    const cfgPath = seedConfig();
+
+    // projectDir:home isolates the platform uninstall (codex strips a cwd-relative
+    // AGENTS.md) to the temp dir so the test never touches the real working tree.
+    await runUninstall({
+      platform: 'codex',
+      projectDir: home,
+      cleanAll: true,
+      yes: true,
+      dryRun: false,
+      quiet: true,
+    });
+
+    const after = JSON.parse(fs.readFileSync(cfgPath, 'utf8'));
+    expect(after.mcpServers).not.toHaveProperty('memory');
+    expect(after.mcpServers).not.toHaveProperty('automem');
+    expect(after.mcpServers).toHaveProperty('filesystem');
+    expect(after.globalShortcut).toBe('Cmd+Shift+Space');
+
+    const cfgDir = path.dirname(cfgPath);
+    const backups = fs
+      .readdirSync(cfgDir)
+      .filter((f) => f.startsWith('claude_desktop_config.json.backup.'));
+    expect(backups).toHaveLength(1);
+  });
+
+  it('dry-run leaves the config byte-for-byte unchanged', async () => {
+    const cfgPath = seedConfig();
+    const before = fs.readFileSync(cfgPath, 'utf8');
+
+    await runUninstall({
+      platform: 'codex',
+      projectDir: home,
+      cleanAll: true,
+      yes: true,
+      dryRun: true,
+      quiet: true,
+    });
+
+    expect(fs.readFileSync(cfgPath, 'utf8')).toBe(before);
+    const backups = fs
+      .readdirSync(path.dirname(cfgPath))
+      .filter((f) => f.includes('.backup.'));
+    expect(backups).toHaveLength(0);
+  });
+});
+
 describe('uninstall hermes', () => {
   let tmpDir: string;
 

--- a/tests/e2e/harness.mjs
+++ b/tests/e2e/harness.mjs
@@ -881,7 +881,22 @@ async function main() {
   // The website-bootstrap scenario needs the SIBLING automem-website install.sh.
   // When that checkout isn't present, skip just that scenario (don't fail the run) —
   // the rest of the matrix exercises the packed tarball directly.
+  //
+  // EXCEPTION: when AUTOMEM_REQUIRE_INSTALL_SH is set (CI does this after checking
+  // out automem-website), a missing install.sh is a HARD failure instead of a silent
+  // skip. The production `curl | sh` entrypoint must never be green-but-untested —
+  // if the website checkout path ever breaks, CI fails loudly here.
   if (!existsSync(INSTALL_SH)) {
+    const required =
+      process.env.AUTOMEM_REQUIRE_INSTALL_SH && process.env.AUTOMEM_REQUIRE_INSTALL_SH !== '0';
+    if (required) {
+      console.error(
+        `FATAL: AUTOMEM_REQUIRE_INSTALL_SH is set but install.sh was not found at ${INSTALL_SH}. ` +
+          `The website-bootstrap (curl | sh) scenario would be silently skipped. Check out ` +
+          `automem-website and point AUTOMEM_INSTALL_SH at its public/install.sh.`,
+      );
+      process.exit(2);
+    }
     const before = selected.length;
     selected = selected.filter((s) => s.name !== 'website-bootstrap-install-sh');
     if (selected.length !== before) {


### PR DESCRIPTION
## What & why

The installer e2e harness silently skipped the production `curl | sh` entrypoint
(`website-bootstrap-install-sh`) whenever `automem-website` wasn't checked out — and CI
never checked it out. So the most-exposed install path was **green-but-untested**. This
wires it into CI and adds regression guards for two paths that were previously verified
only by hand.

## Changes
- **CI gate** (`ci.yml`): check out the public `automem-website` repo and run the e2e step
  with `AUTOMEM_INSTALL_SH` + `AUTOMEM_REQUIRE_INSTALL_SH=1`.
- **Fail-on-skip** (`tests/e2e/harness.mjs`): when `AUTOMEM_REQUIRE_INSTALL_SH` is set, a
  missing `install.sh` is a hard failure instead of a silent skip. Default local behavior
  (graceful skip) is unchanged.
- **Credential env-path contract** (`src/cli/install.test.ts`): assert `AUTOMEM_API_KEY`
  reaches the installer via the environment with **no** `--api-key` flag (the `curl|sh`
  mechanism — `install.sh` deliberately keeps the token out of argv to avoid leaking it via
  `ps`/the stage-4 echo), plus the `AUTOMEM_API_TOKEN` fallback and flag-overrides-env.
- **Uninstall safety** (`src/cli/uninstall.test.ts`): assert `--clean-all` removes only the
  `memory`/`automem` servers, preserves a foreign `mcpServers` entry + unrelated top-level
  keys, and writes a backup; plus a dry-run no-op. Uses `projectDir`-isolated `runUninstall`.

## Tests / risk
- **Tests + CI only — no change to shipped runtime code.**
- Full suite: **637 passing**; focused: `install.test` 50, `uninstall.test` 20.
- Conventional type `test:` → no release-please version bump.
