### PR TITLE
fix: Sanitize terminal hyperlinks in plain output

### DIFF
--- a/src/cli/ui/theme.ts
+++ b/src/cli/ui/theme.ts
@@ -124,7 +124,7 @@ export function makeTheme(
       arrow: unicode ? '→' : '->',
       line: unicode ? '─' : '-',
     },
-    link: hyperlink,
+    link: color ? hyperlink : plainLinkText,
   };
 }
 
@@ -153,35 +153,44 @@ export function repeatVisible(char: string, count: number): string {
   return Array.from({ length: Math.max(0, count) }, () => char).join('');
 }
 
+function encodeControlCharacters(value: string): string {
+  let encoded = '';
+  for (let i = 0; i < value.length; i += 1) {
+    const char = value[i];
+    const code = char.charCodeAt(0);
+    encoded += code <= 0x1f || code === 0x7f ? encodeURIComponent(char) : char;
+  }
+  return encoded;
+}
+
+function plainLinkText(url: string, label?: string): string {
+  return encodeControlCharacters(label && label.length > 0 ? label : url);
+}
+
 /**
  * Terminal hyperlink (OSC 8).
  * Renders as a clickable link in modern terminals (iTerm2, VS Code, Windows Terminal, recent macOS Terminal, etc.).
  * Gracefully degrades everywhere else: stripAnsi/visibleLength turn it into the plain label text.
  *
  * Safety: only emits OSC for well-formed http/https URLs. Anything else (placeholders like
- * "<prompted>", non-URLs, or values containing control characters) is returned as plain text
- * to avoid terminal escape injection or broken output. Callers should prefer `theme.link(...)`
- * for automatic capability awareness.
+ * "<prompted>" or non-URLs) is returned as plain text, and label/text control characters are
+ * percent-encoded to avoid terminal escape injection or broken output. Callers should prefer
+ * `theme.link(...)` for automatic capability awareness.
  */
 export function hyperlink(url: string, label?: string): string {
   const rawText = label && label.length > 0 ? label : url;
+  const safeText = encodeControlCharacters(rawText);
 
   let safeUrl: string;
   try {
     const u = new URL(url);
     if (u.protocol !== 'http:' && u.protocol !== 'https:') {
-      return rawText;
+      return safeText;
     }
     safeUrl = u.href; // normalized + percent-encoded
   } catch {
-    return rawText;
+    return safeText;
   }
-
-  // Explicitly strip control characters from both URL (already done by URL) and label/text
-  const stripControls = (s: string) =>
-    s.replace(/[\x00-\x1F\x7F]/g, (c) => encodeURIComponent(c));
-
-  const safeText = stripControls(rawText);
 
   // OSC 8 ; ; <url> ST <text> OSC 8 ; ; ST
   return `\x1b]8;;${safeUrl}\x1b\\${safeText}\x1b]8;;\x1b\\`;

--- a/src/cli/ui/ui.test.ts
+++ b/src/cli/ui/ui.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  hyperlink,
   makeTheme,
   padEndVisible,
   repeatVisible,
@@ -23,10 +24,13 @@ describe('ui/theme', () => {
     expect(plain.color).toBe(false);
     expect(plain.style.gold('hi')).toBe('hi');
     expect(plain.style.inverseGold('hi')).toBe('[hi]');
+    expect(plain.link('https://example.com', 'label\x1b')).toBe('label%1B');
+    expect(plain.link('https://example.com', 'label\x1b')).not.toContain('\x1b]8;');
 
     const colored = makeTheme(stream, { color: 'always', symbols: 'unicode' });
     expect(colored.style.gold('hi')).toContain('\x1b[');
     expect(stripAnsi(colored.style.gold('hi'))).toBe('hi');
+    expect(colored.link('https://example.com', 'label')).toContain('\x1b]8;');
   });
 
   it('switches symbol sets between unicode and ascii', () => {
@@ -53,6 +57,18 @@ describe('ui/theme', () => {
     expect(visibleLength(padEndVisible(colored, 6))).toBe(6);
     expect(repeatVisible('-', 4)).toBe('----');
     expect(repeatVisible('-', -2)).toBe('');
+  });
+
+  it('percent-encodes control characters in hyperlink labels', () => {
+    const rendered = hyperlink('https://example.com/path', 'label\x1b\x07\n\x7f');
+
+    expect(rendered).toContain('label%1B%07%0A%7F');
+    expect(stripAnsi(rendered)).toBe('label%1B%07%0A%7F');
+  });
+
+  it('percent-encodes fallback text when hyperlink URLs are invalid', () => {
+    expect(hyperlink('not a url', 'label\x1b')).toBe('label%1B');
+    expect(hyperlink('file:///tmp/example', 'label\x07')).toBe('label%07');
   });
 });
 


### PR DESCRIPTION
## Summary
- Replaces the `no-control-regex`-triggering hyperlink label sanitizer with shared char-code control-character encoding.
- Keeps `theme.link` plain for no-color/non-TTY output so CI and redirected stdout do not receive OSC 8 control sequences.
- Adds regression coverage for plain/color hyperlink behavior plus invalid and non-http URL fallback text.

## Verification
- `npm run lint` exits 0 with `156` existing warnings and no errors.
- `npm test -- src/cli/ui/ui.test.ts --reporter=dot` passes `1` file / `25` tests.
- `git diff --check`

## Review
- Independent review found missing regression coverage; fixed.
- Independent review found plain-mode OSC 8 leakage; fixed.
- Independent review found invalid/non-http URL fallback still returned raw control text; fixed.
- Final re-review returned no findings.

Stacked on top of `feat/installer-visual-flair` because that feature branch already has PR #157 open.