### PR TITLE
ci: exclude racy release-asset links from lychee link check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
       - name: Check links in documentation
         uses: lycheeverse/lychee-action@v2
         with:
+          # Release-asset "latest download" URLs (e.g. the .mcpb button in README)
+          # 404 transiently on a release: this link check runs concurrently with the
+          # release workflow, which uploads the asset ~1 min after creating the
+          # release. Exclude them — the build-extension job validates the asset.
           args: >-
             --verbose
             --no-progress
@@ -24,6 +28,7 @@ jobs:
             --exclude '127.0.0.1'
             --exclude 'x.com/i/communities'
             --exclude 'github.com/.*/compare/.*\.\.\..*'
+            --exclude 'github.com/.*/releases/latest/download/.*'
             README.md
             INSTALLATION.md
             CHANGELOG.md


### PR DESCRIPTION
## What

Excludes release-asset "latest download" URLs from the `Check Links`
(lychee) job.

## Why

The v0.15.0 release succeeded end to end — npm published with provenance,
tag + GitHub release created, `.mcpb` asset uploaded — but the **CI** run on
the release-merge commit went red. The `Check Links` job hit:

```
[404] https://github.com/verygoodplugins/mcp-automem/releases/latest/download/mcp-automem.mcpb
```

This is a race, not a broken doc. The README "Download (.mcpb)" button
([README.md:117](https://github.com/verygoodplugins/mcp-automem/blob/main/README.md))
points at `releases/latest/download/…`. On a release merge, CI runs
concurrently with the release workflow, which creates the GitHub release
~1 minute **before** the `build-extension` job uploads the `.mcpb` asset.
Lychee checked the URL inside that window → 404 → CI failure on a perfectly
good release.

## Fix

Add `--exclude 'github.com/.*/releases/latest/download/.*'`, mirroring the
existing exclusion for racy `compare/...` links. The asset is still
validated where it's produced — the `build-extension` job fails loudly if
the `.mcpb` can't be built.

## Notes

- `.mcpb` support is unaffected — it's still built and shipped each release.
- The v0.15.0 CI run was already re-run to green (the asset is live now);
  this only prevents recurrence on future releases.
