### PR TITLE
docs: reconcile README integrations and guard coverage in CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ https://github.com/user-attachments/assets/fd79112b-5158-4320-a054-8c18ab1ea314
 
 <p align="center"><sub><b>The guided installer</b> — <code>npx @verygoodplugins/mcp-automem install</code> walks you through local, hosted, or existing-endpoint setup.</sub></p>
 
-Works with **Claude Desktop**, **Cursor IDE**, **Claude Code**, **GitHub Copilot (coding agent)**, **ChatGPT**, **ElevenLabs**, **OpenAI Codex**, **Google Antigravity** - any MCP-compatible AI platform.
+Works with **Claude Desktop**, **Cursor IDE**, **Claude Code**, **GitHub Copilot (coding agent)**, **ChatGPT**, **ElevenLabs**, **OpenAI Codex**, **OpenClaw**, **Hermes**, **Google Antigravity** - any MCP-compatible AI platform.
 
 ## The Problem We Solve
 
@@ -42,7 +42,7 @@ AutoMem MCP connects your AI to persistent memory powered by **[AutoMem](https:/
 ### 🧠 Persistent Memory Across Sessions
 
 - AI remembers decisions, patterns, and context **forever**
-- Works across **all MCP platforms** - Claude Desktop, Cursor, Claude Code, OpenAI Codex, Google Antigravity
+- Works across **all MCP platforms** - Claude Desktop, Cursor, Claude Code, OpenAI Codex, OpenClaw, Hermes, Google Antigravity
 - **Cross-device sync** - same memory on Mac, Windows, Linux
 
 ### 🏆 Graph-Vector Architecture
@@ -60,6 +60,8 @@ AutoMem MCP connects your AI to persistent memory powered by **[AutoMem](https:/
 | **Claude Code**    | ✅ Full | 30 seconds |
 | **GitHub Copilot** | ✅ Full | 2 minutes  |
 | **OpenAI Codex**   | ✅ Full | 30 seconds |
+| **OpenClaw**       | ✅ Full | 30 seconds |
+| **Hermes Agent**   | ✅ Full | 30 seconds |
 | **Google Antigravity** | ✅ Full | 30 seconds |
 | **Any MCP client** | ✅ Full | 30 seconds |
 
@@ -179,7 +181,7 @@ On Windows, the hook payload assumes a POSIX shell environment such as Git Bash,
 npx @verygoodplugins/mcp-automem cursor
 ```
 
-**Other platforms** — Claude Desktop (one-click `.mcpb` above, plus the [Personal Preferences template](templates/CLAUDE_DESKTOP_INSTRUCTIONS.md)), [OpenAI Codex](INSTALLATION.md#openai-codex), [Hermes Agent](INSTALLATION.md#hermes-agent), [Google Antigravity](INSTALLATION.md#google-antigravity), and [GitHub Copilot](INSTALLATION.md#github-copilot-coding-agent-githubcom):
+**Other platforms** — Claude Desktop (one-click `.mcpb` above, plus the [Personal Preferences template](templates/CLAUDE_DESKTOP_INSTRUCTIONS.md)), [OpenAI Codex](INSTALLATION.md#openai-codex), [Hermes Agent](INSTALLATION.md#hermes-agent), [OpenClaw](INSTALLATION.md#openclaw), [Google Antigravity](INSTALLATION.md#google-antigravity), and [GitHub Copilot](INSTALLATION.md#github-copilot-coding-agent-githubcom):
 
 👉 **[Full Installation Guide](INSTALLATION.md)** for every platform's setup and verification steps
 

--- a/tests/docs/integration-coverage.test.ts
+++ b/tests/docs/integration-coverage.test.ts
@@ -1,0 +1,93 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { AGENT_CLIENTS, type AgentClient } from '../../src/cli/install.js';
+
+/**
+ * Documentation drift guard.
+ *
+ * "Which integrations we support" has a single source of truth in code:
+ * `AGENT_CLIENTS` in src/cli/install.ts — the agents the guided installer
+ * configures. The README historically hand-maintained several separate
+ * integration lists that drifted out of sync (e.g. Hermes and OpenClaw were
+ * shipped and installer-supported, but missing from the compatibility table).
+ *
+ * This test fails CI when an installer-supported client is not reflected in
+ * the README compatibility table or the INSTALLATION guide, so adding an
+ * integration without documenting it can no longer be merged.
+ *
+ * Scope is deliberately the deterministic, code-derived `AGENT_CLIENTS` set
+ * and the structured compatibility table. The looser headline prose — which
+ * also markets non-installer platforms like ChatGPT and ElevenLabs — is not
+ * gated here; folding every surface into one generated block is the planned
+ * source-of-truth follow-up.
+ */
+
+const repoFile = (rel: string): string =>
+  readFileSync(fileURLToPath(new URL(`../../${rel}`, import.meta.url)), 'utf8');
+
+// The display name each installer client is documented under. Typing this as
+// Record<AgentClient, string> forces every new AGENT_CLIENTS entry to declare a
+// docs name here (compile error otherwise), which in turn makes the assertions
+// below require the new integration to be documented before it can ship.
+const DISPLAY_NAMES: Record<AgentClient, string> = {
+  codex: 'Codex',
+  'claude-code': 'Claude Code',
+  cursor: 'Cursor',
+  openclaw: 'OpenClaw',
+  hermes: 'Hermes',
+};
+
+/** Extract a markdown section: its heading line through (excluding) the next heading. */
+function section(markdown: string, headingContains: string): string {
+  const lines = markdown.split('\n');
+  const start = lines.findIndex(
+    (line) => /^#{2,4}\s/.test(line) && line.includes(headingContains),
+  );
+  if (start === -1) return '';
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^#{2,4}\s/.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start, end).join('\n');
+}
+
+describe('integration docs coverage', () => {
+  const readme = repoFile('README.md');
+  const installation = repoFile('INSTALLATION.md');
+  const compatibilityTable = section(readme, 'Works Everywhere You Code');
+
+  it('locates the README compatibility table', () => {
+    // Guards against a heading rename silently disabling the row checks below.
+    expect(
+      compatibilityTable,
+      'Could not find the README "Works Everywhere You Code" compatibility table',
+    ).not.toBe('');
+  });
+
+  it.each(AGENT_CLIENTS)(
+    'lists installer client "%s" in the README compatibility table',
+    (client) => {
+      const name = DISPLAY_NAMES[client];
+      expect(
+        compatibilityTable.includes(name),
+        `README compatibility table is missing "${name}" (AGENT_CLIENTS includes '${client}'). ` +
+          'Add a row for it in README.md.',
+      ).toBe(true);
+    },
+  );
+
+  it.each(AGENT_CLIENTS)(
+    'documents installer client "%s" in INSTALLATION.md',
+    (client) => {
+      const name = DISPLAY_NAMES[client];
+      expect(
+        installation.includes(name),
+        `INSTALLATION.md does not mention "${name}" (AGENT_CLIENTS includes '${client}').`,
+      ).toBe(true);
+    },
+  );
+});


### PR DESCRIPTION
## What

Fixes the stale/inconsistent README integration lists **and** adds a CI
guard so this class of drift can't be merged again.

## Why

"Which integrations we support" has a single source of truth in code —
`AGENT_CLIENTS` in [src/cli/install.ts](src/cli/install.ts) (`codex`,
`claude-code`, `cursor`, `openclaw`, `hermes`) — but the README
hand-maintained **four separate lists** that drifted apart:

- the compatibility table was missing **OpenClaw** and **Hermes**
- the headline, the feature bullet, and the platform links each listed a
  different subset

`INSTALLATION.md` already had full sections for all five, so the drift was
README-only.

## Changes

- **`tests/docs/integration-coverage.test.ts`** — reads `AGENT_CLIENTS` and
  asserts every installer client appears in the README compatibility table
  and in `INSTALLATION.md`. Typed `Record<AgentClient, …>` display map, so a
  new client won't compile until it's documented. Lives in the already-
  required `test` job.
- **`README.md`** — add OpenClaw + Hermes to the compatibility table and
  reconcile the three prose lists so all four surfaces agree.

Before the README fix the guard failed on exactly `hermes` and `openclaw`
(2 failed / 9 passed); after, 11/11.

## Scope / follow-up

Deliberately gates the deterministic, code-derived client set against the
structured table — not the looser headline prose (which also markets
non-installer platforms like ChatGPT/ElevenLabs). Folding every surface
into one generated block from a single registry is the planned
source-of-truth follow-up we discussed.

## Verification

- `npm test` → 648 passed (40 files)
- `npm run typecheck` clean · `eslint` clean
