### PR TITLE
feat: add OpenCode client support

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -141,6 +141,7 @@ Now that your AutoMem service is running, install and configure the MCP client t
 - [Cursor IDE](#cursor-ide) - AI-powered code editor
 - [Claude Code](#claude-code) - Terminal coding assistant with automation hooks
 - [OpenAI Codex](#openai-codex) - CLI, IDE, and cloud agent
+- [OpenCode](#opencode) - Open-source terminal coding agent
 - [Hermes Agent](#hermes-agent) - Nous Research terminal agent with MCP and native memory provider support
 - [Google Antigravity](#google-antigravity) - Desktop editor with MCP Store and raw config
 - [OpenClaw](#openclaw) - Personal AI assistant with multi-platform messaging (WhatsApp, Telegram, Slack, Discord, etc.)
@@ -751,6 +752,41 @@ codex "What were the key decisions made in this project last week?"
 - Launch tasks from [chatgpt.com/codex](https://chatgpt.com/codex/)
 - Codex has access to stored memories across environments
 - Memories sync between CLI, IDE, and cloud agent
+
+## OpenCode
+
+[OpenCode](https://opencode.ai) is an open-source terminal coding agent with MCP and plugin support. AutoMem gives it persistent memory across sessions.
+
+### 1. Install OpenCode
+
+```bash
+curl -fsSL https://opencode.ai/install | bash
+```
+
+### 2. Run the setup command
+
+```bash
+cd ~/Projects/my-app
+npx @verygoodplugins/mcp-automem opencode --endpoint http://127.0.0.1:8001
+```
+
+This does two things:
+
+- Adds the `memory` MCP server to `~/.config/opencode/opencode.json` (creating the file if needed, backing it up if not). Pass `--api-key <key>` if your instance requires auth, or `--config <path>` for a non-default location.
+- Installs memory-first rules into the project's `AGENTS.md` (read natively by OpenCode), so the agent proactively recalls and stores context.
+
+Preview everything first with `--dry-run`.
+
+**Manual alternative:** copy `templates/opencode/opencode.json` into your config and fill in the placeholders.
+
+### 3. Verify Installation
+
+```bash
+opencode mcp list
+# expect: ✓ memory connected
+```
+
+Then ask OpenCode: `Check the health of the AutoMem service` — you should see connection status for FalkorDB and Qdrant.
 
 ### Memory Best Practices for Codex
 

--- a/scripts/sync-memory-policy.ts
+++ b/scripts/sync-memory-policy.ts
@@ -12,6 +12,7 @@ import {
   renderCursorProjectRule,
   renderHermesMemoryRules,
   renderHermesProviderPolicyPython,
+  renderOpenCodeMemoryRules,
 } from '../src/memory-policy/shared.js';
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
@@ -48,6 +49,10 @@ const files: Array<[string, string]> = [
   [
     'templates/codex/memory-rules.md',
     renderCodexMemoryRules({ projectName: '{{PROJECT_NAME}}', templateVersion }),
+  ],
+  [
+    'templates/opencode/memory-rules.md',
+    renderOpenCodeMemoryRules({ projectName: '{{PROJECT_NAME}}', templateVersion }),
   ],
   [
     'templates/cursor/automem.mdc.template',

--- a/src/cli/opencode.test.ts
+++ b/src/cli/opencode.test.ts
@@ -1,0 +1,137 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { applyOpenCodeSetup, mergeOpenCodeConfig } from './opencode.js';
+
+const MEMORY_SERVER = {
+  type: 'local',
+  command: ['npx', '-y', '@verygoodplugins/mcp-automem'],
+  enabled: true,
+  environment: { AUTOMEM_API_URL: 'http://127.0.0.1:8001' },
+};
+
+describe('mergeOpenCodeConfig', () => {
+  it('creates a fresh config with schema when none exists', () => {
+    const merged = JSON.parse(mergeOpenCodeConfig(null, MEMORY_SERVER));
+    expect(merged.$schema).toBe('https://opencode.ai/config.json');
+    expect(merged.mcp.memory).toEqual(MEMORY_SERVER);
+  });
+
+  it('preserves unrelated keys and other MCP servers', () => {
+    const existing = JSON.stringify({
+      $schema: 'https://opencode.ai/config.json',
+      plugin: ['./plugins/my-plugin.js'],
+      mcp: { other: { type: 'remote', url: 'https://example.com' } },
+    });
+    const merged = JSON.parse(mergeOpenCodeConfig(existing, MEMORY_SERVER));
+    expect(merged.plugin).toEqual(['./plugins/my-plugin.js']);
+    expect(merged.mcp.other).toEqual({ type: 'remote', url: 'https://example.com' });
+    expect(merged.mcp.memory).toEqual(MEMORY_SERVER);
+  });
+
+  it('replaces an existing mcp.memory entry', () => {
+    const existing = JSON.stringify({
+      mcp: { memory: { type: 'local', command: ['stale'], enabled: false } },
+    });
+    const merged = JSON.parse(mergeOpenCodeConfig(existing, MEMORY_SERVER));
+    expect(merged.mcp.memory).toEqual(MEMORY_SERVER);
+  });
+
+  it('throws on unparseable or non-object existing config', () => {
+    expect(() => mergeOpenCodeConfig('{not json', MEMORY_SERVER)).toThrow();
+    expect(() => mergeOpenCodeConfig('[1,2]', MEMORY_SERVER)).toThrow();
+  });
+
+  it('treats an empty file as a fresh config', () => {
+    const merged = JSON.parse(mergeOpenCodeConfig('', MEMORY_SERVER));
+    expect(merged.mcp.memory).toEqual(MEMORY_SERVER);
+  });
+});
+
+describe('applyOpenCodeSetup', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'automem-opencode-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function paths() {
+    return {
+      configPath: path.join(tmpDir, 'opencode.json'),
+      rulesPath: path.join(tmpDir, 'AGENTS.md'),
+    };
+  }
+
+  it('writes config and rules into empty targets', async () => {
+    const { configPath, rulesPath } = paths();
+    await applyOpenCodeSetup({
+      configPath,
+      rulesPath,
+      projectName: 'test-project',
+      endpoint: 'http://127.0.0.1:8001',
+      quiet: true,
+    });
+
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config.mcp.memory.command).toEqual(['npx', '-y', '@verygoodplugins/mcp-automem']);
+    expect(config.mcp.memory.environment.AUTOMEM_API_URL).toBe('http://127.0.0.1:8001');
+    expect(config.mcp.memory.environment.AUTOMEM_API_KEY).toBeUndefined();
+
+    const rules = fs.readFileSync(rulesPath, 'utf8');
+    expect(rules).toContain('<!-- BEGIN AUTOMEM OPENCODE RULES -->');
+    expect(rules).toContain('<!-- END AUTOMEM OPENCODE RULES -->');
+    expect(rules).toContain('test-project');
+    expect(rules).not.toContain('{{PROJECT_NAME}}');
+  });
+
+  it('is idempotent: re-run replaces the marked block instead of appending', async () => {
+    const { configPath, rulesPath } = paths();
+    const options = {
+      configPath,
+      rulesPath,
+      projectName: 'test-project',
+      endpoint: 'http://127.0.0.1:8001',
+      quiet: true,
+    };
+    await applyOpenCodeSetup(options);
+    fs.writeFileSync(rulesPath, `# My rules\n\n${fs.readFileSync(rulesPath, 'utf8')}`, 'utf8');
+    await applyOpenCodeSetup(options);
+
+    const rules = fs.readFileSync(rulesPath, 'utf8');
+    expect(rules.match(/BEGIN AUTOMEM OPENCODE RULES/g)?.length).toBe(1);
+    expect(rules.startsWith('# My rules'));
+  });
+
+  it('includes the API key in environment only when provided', async () => {
+    const { configPath, rulesPath } = paths();
+    await applyOpenCodeSetup({
+      configPath,
+      rulesPath,
+      projectName: 'test-project',
+      endpoint: 'http://127.0.0.1:8001',
+      apiKey: 'secret-key',
+      quiet: true,
+    });
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    expect(config.mcp.memory.environment.AUTOMEM_API_KEY).toBe('secret-key');
+  });
+
+  it('dry-run writes nothing', async () => {
+    const { configPath, rulesPath } = paths();
+    await applyOpenCodeSetup({
+      configPath,
+      rulesPath,
+      projectName: 'test-project',
+      endpoint: 'http://127.0.0.1:8001',
+      dryRun: true,
+      quiet: true,
+    });
+    expect(fs.existsSync(configPath)).toBe(false);
+    expect(fs.existsSync(rulesPath)).toBe(false);
+  });
+});

--- a/src/cli/opencode.ts
+++ b/src/cli/opencode.ts
@@ -1,0 +1,158 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  CommonOptions,
+  detectProjectName,
+  log,
+  parseCommonFlags,
+  replaceTemplateVars,
+  writeFileWithBackup,
+} from './host-toolkit.js';
+import { DEFAULT_AUTOMEM_API_URL } from './templates.js';
+
+interface OpenCodeSetupOptions extends CommonOptions {
+  configPath?: string; // default: ~/.config/opencode/opencode.json
+  rulesPath?: string; // default: ./AGENTS.md
+  endpoint?: string;
+  apiKey?: string;
+}
+
+const TEMPLATE_ROOT = path.resolve(
+  fileURLToPath(new URL('../../templates/opencode', import.meta.url))
+);
+
+export function defaultOpenCodeConfigPath(homeDir: string = os.homedir()): string {
+  return path.join(homeDir, '.config', 'opencode', 'opencode.json');
+}
+
+function upsertRulesWithMarkers(existing: string | null, block: string): string {
+  const start = '<!-- BEGIN AUTOMEM OPENCODE RULES -->';
+  const end = '<!-- END AUTOMEM OPENCODE RULES -->';
+  if (!existing) {
+    return `${block}\n`;
+  }
+  const startIdx = existing.indexOf(start);
+  const endIdx = existing.indexOf(end);
+  if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+    const before = existing.slice(0, startIdx);
+    const after = existing.slice(endIdx + end.length);
+    return `${before}${block}${after}`;
+  }
+  const sep = existing.endsWith('\n') ? '\n' : '\n\n';
+  return `${existing}${sep}${block}\n`;
+}
+
+// Merge the `mcp.memory` server block into an existing opencode.json without
+// touching any other key. An unparseable existing config aborts (never clobber
+// a file we cannot round-trip); an existing `mcp.memory` entry is replaced.
+export function mergeOpenCodeConfig(
+  existingRaw: string | null,
+  memoryServer: Record<string, unknown>
+): string {
+  let config: Record<string, unknown> = {};
+  if (existingRaw !== null && existingRaw.trim() !== '') {
+    const parsed = JSON.parse(existingRaw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('existing opencode.json is not a JSON object');
+    }
+    config = parsed as Record<string, unknown>;
+  }
+  if (!('$schema' in config)) {
+    config.$schema = 'https://opencode.ai/config.json';
+  }
+  const mcp =
+    config.mcp && typeof config.mcp === 'object' && !Array.isArray(config.mcp)
+      ? (config.mcp as Record<string, unknown>)
+      : {};
+  mcp.memory = memoryServer;
+  config.mcp = mcp;
+  return `${JSON.stringify(config, null, 2)}\n`;
+}
+
+export async function applyOpenCodeSetup(cliOptions: OpenCodeSetupOptions): Promise<void> {
+  const projectName = cliOptions.projectName ?? detectProjectName();
+  const configPath = cliOptions.configPath ?? defaultOpenCodeConfigPath();
+  const rulesPath = cliOptions.rulesPath ?? path.join(process.cwd(), 'AGENTS.md');
+
+  const endpoint =
+    cliOptions.endpoint ||
+    process.env.AUTOMEM_API_URL ||
+    process.env.AUTOMEM_ENDPOINT ||
+    DEFAULT_AUTOMEM_API_URL;
+  const apiKey = cliOptions.apiKey ?? process.env.AUTOMEM_API_KEY ?? '';
+
+  log(`\n🔧 Setting up OpenCode AutoMem integration for: ${projectName}`, cliOptions.quiet);
+  log(`📄 Config: ${configPath}`, cliOptions.quiet);
+  log(`📄 Rules:  ${rulesPath}\n`, cliOptions.quiet);
+
+  // 1. MCP server block in opencode.json
+  const environment: Record<string, string> = { AUTOMEM_API_URL: endpoint };
+  if (apiKey) {
+    environment.AUTOMEM_API_KEY = apiKey;
+  }
+  const memoryServer = {
+    type: 'local',
+    command: ['npx', '-y', '@verygoodplugins/mcp-automem'],
+    enabled: true,
+    environment,
+  };
+
+  const existingConfig = fs.existsSync(configPath) ? fs.readFileSync(configPath, 'utf8') : null;
+  let mergedConfig: string;
+  try {
+    mergedConfig = mergeOpenCodeConfig(existingConfig, memoryServer);
+  } catch (error) {
+    console.error(
+      `Error: could not parse ${configPath} — fix or remove it and re-run. (${String(error)})`
+    );
+    process.exit(1);
+  }
+  // The config may carry an API key: back up + restrict like other secret-bearing files.
+  writeFileWithBackup(configPath, mergedConfig, {
+    dryRun: cliOptions.dryRun,
+    quiet: cliOptions.quiet,
+    secret: Boolean(apiKey),
+  });
+
+  // 2. Memory policy rules in AGENTS.md (OpenCode reads project AGENTS.md natively)
+  const templateContent = fs.readFileSync(path.join(TEMPLATE_ROOT, 'memory-rules.md'), 'utf8');
+  const processed = replaceTemplateVars(templateContent, { PROJECT_NAME: projectName });
+  const existingRules = fs.existsSync(rulesPath) ? fs.readFileSync(rulesPath, 'utf8') : null;
+  const finalRules = upsertRulesWithMarkers(existingRules, processed);
+  writeFileWithBackup(rulesPath, finalRules, cliOptions);
+
+  log('\n📊 Configuration Status:', cliOptions.quiet);
+  log('  ✅ MCP server `memory` configured (opencode.json)', cliOptions.quiet);
+  log('  ✅ Memory rules installed (AGENTS.md)', cliOptions.quiet);
+  if (!apiKey) {
+    log(
+      '  ℹ️ No AUTOMEM_API_KEY found — set it in the config `environment` block if your instance requires auth.',
+      cliOptions.quiet
+    );
+  }
+
+  log('\n✨ OpenCode AutoMem setup complete! Next steps:', cliOptions.quiet);
+  log('  1. Restart OpenCode to reload MCP servers', cliOptions.quiet);
+  log('  2. Verify with: opencode mcp list  (expect: ✓ memory connected)', cliOptions.quiet);
+}
+
+function parseArgs(args: string[]): OpenCodeSetupOptions {
+  let configPath: string | undefined;
+  let rulesPath: string | undefined;
+  let endpoint: string | undefined;
+  let apiKey: string | undefined;
+  const common = parseCommonFlags(args, {
+    '--config': { kind: 'value', set: (v) => (configPath = v) },
+    '--rules': { kind: 'value', set: (v) => (rulesPath = v) },
+    '--endpoint': { kind: 'value', set: (v) => (endpoint = v) },
+    '--api-key': { kind: 'value', set: (v) => (apiKey = v) },
+  });
+  return { ...common, configPath, rulesPath, endpoint, apiKey };
+}
+
+export async function runOpenCodeSetup(args: string[] = []): Promise<void> {
+  const options = parseArgs(args);
+  await applyOpenCodeSetup(options);
+}

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -9,11 +9,13 @@ import {
   removeMcpServerEntry,
   resolveHermesPaths,
 } from './hermes-config.js';
+import { defaultOpenCodeConfigPath } from './opencode.js';
 
 interface UninstallOptions {
-  platform: 'cursor' | 'claude-code' | 'codex' | 'hermes';
+  platform: 'cursor' | 'claude-code' | 'codex' | 'hermes' | 'opencode';
   projectDir?: string;
   rulesPath?: string;
+  configPath?: string;
   cleanAll?: boolean;
   dryRun?: boolean;
   yes?: boolean;
@@ -385,6 +387,83 @@ async function uninstallCodex(options: UninstallOptions): Promise<void> {
   log('\n✅ Codex AutoMem configuration removed', options.quiet);
 }
 
+async function uninstallOpenCode(options: UninstallOptions): Promise<void> {
+  // Symmetric with the `opencode` setup command: strip the marked AutoMem block
+  // from AGENTS.md and remove the `mcp.memory` entry from opencode.json.
+  const projectDir = options.projectDir ?? process.cwd();
+  const rulesFile = options.rulesPath ?? path.join(projectDir, 'AGENTS.md');
+  const configFile = options.configPath ?? defaultOpenCodeConfigPath();
+
+  log('\n🗑️  Uninstalling OpenCode AutoMem...', options.quiet);
+
+  // 1. Rules block
+  if (!fs.existsSync(rulesFile)) {
+    log(`ℹ️  No rules file at ${rulesFile}`, options.quiet);
+  } else {
+    const start = '<!-- BEGIN AUTOMEM OPENCODE RULES -->';
+    const end = '<!-- END AUTOMEM OPENCODE RULES -->';
+    const raw = fs.readFileSync(rulesFile, 'utf8');
+    const startIdx = raw.indexOf(start);
+    const endIdx = raw.indexOf(end);
+
+    if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
+      log(`ℹ️  No AutoMem rule block in ${rulesFile}`, options.quiet);
+    } else if (options.dryRun) {
+      log(`[DRY RUN] Would strip AutoMem block from: ${rulesFile}`, options.quiet);
+    } else {
+      const before = raw.slice(0, startIdx).replace(/\s+$/, '');
+      const after = raw.slice(endIdx + end.length).replace(/^\s+/, '');
+      const joined = before && after ? `${before}\n\n${after}` : `${before}${after}`;
+      const next = `${joined.replace(/\n+$/, '')}\n`;
+      const backupPath = `${rulesFile}.backup.${Date.now()}`;
+      fs.copyFileSync(rulesFile, backupPath);
+      fs.writeFileSync(rulesFile, next, 'utf8');
+      log(`🗑️  Stripped AutoMem block from ${rulesFile}`, options.quiet);
+      log(`   Backup: ${backupPath}`, options.quiet);
+    }
+  }
+
+  // 2. MCP server entry
+  if (!fs.existsSync(configFile)) {
+    log(`ℹ️  No OpenCode config at ${configFile}`, options.quiet);
+  } else {
+    let config: Record<string, unknown> | null = null;
+    try {
+      const parsed = JSON.parse(fs.readFileSync(configFile, 'utf8'));
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        config = parsed as Record<string, unknown>;
+      }
+    } catch {
+      // fall through to the warning below
+    }
+    if (!config) {
+      log(`⚠️  Could not parse ${configFile} — remove the mcp.memory entry manually`, options.quiet);
+    } else {
+      const mcp =
+        config.mcp && typeof config.mcp === 'object' && !Array.isArray(config.mcp)
+          ? (config.mcp as Record<string, unknown>)
+          : null;
+      if (!mcp || !('memory' in mcp)) {
+        log(`ℹ️  No mcp.memory entry in ${configFile}`, options.quiet);
+      } else if (options.dryRun) {
+        log(`[DRY RUN] Would remove mcp.memory from: ${configFile}`, options.quiet);
+      } else {
+        delete mcp.memory;
+        if (Object.keys(mcp).length === 0) {
+          delete config.mcp;
+        }
+        const backupPath = `${configFile}.backup.${Date.now()}`;
+        fs.copyFileSync(configFile, backupPath);
+        fs.writeFileSync(configFile, `${JSON.stringify(config, null, 2)}\n`, 'utf8');
+        log(`🗑️  Removed mcp.memory from ${configFile}`, options.quiet);
+        log(`   Backup: ${backupPath}`, options.quiet);
+      }
+    }
+  }
+
+  log('\n✅ OpenCode AutoMem configuration removed', options.quiet);
+}
+
 async function uninstallClaudeCode(options: UninstallOptions): Promise<void> {
   const claudeDir = path.join(os.homedir(), '.claude');
   const settingsPath = path.join(claudeDir, 'settings.json');
@@ -519,6 +598,8 @@ export async function runUninstall(options: UninstallOptions): Promise<void> {
     await uninstallClaudeCode(options);
   } else if (options.platform === 'codex') {
     await uninstallCodex(options);
+  } else if (options.platform === 'opencode') {
+    await uninstallOpenCode(options);
   } else if (options.platform === 'hermes') {
     await uninstallHermes(options);
   }
@@ -544,10 +625,10 @@ export async function runUninstall(options: UninstallOptions): Promise<void> {
 }
 
 export function parseUninstallArgs(args: string[]): UninstallOptions | null {
-  const allowed = ['cursor', 'claude-code', 'codex', 'hermes'] as const;
+  const allowed = ['cursor', 'claude-code', 'codex', 'opencode', 'hermes'] as const;
   if (args.length === 0 || !allowed.includes(args[0] as typeof allowed[number])) {
-    console.error('❌ Error: Platform required (cursor, claude-code, codex, or hermes)');
-    console.error('Usage: mcp-automem uninstall <cursor|claude-code|codex|hermes> [options]');
+    console.error('❌ Error: Platform required (cursor, claude-code, codex, opencode, or hermes)');
+    console.error('Usage: mcp-automem uninstall <cursor|claude-code|codex|opencode|hermes> [options]');
     return null;
   }
 
@@ -572,6 +653,14 @@ export function parseUninstallArgs(args: string[]): UninstallOptions | null {
           return null;
         }
         options.rulesPath = args[i + 1];
+        i += 1;
+        break;
+      case '--config':
+        if (i + 1 >= args.length) {
+          console.error('Error: --config requires a path value');
+          return null;
+        }
+        options.configPath = args[i + 1];
         i += 1;
         break;
       case '--clean-all':

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { runInstallCommand } from "./cli/install.js";
 import { runClaudeCodeSetup } from "./cli/claude-code.js";
 import { runCursorSetup } from "./cli/cursor.js";
 import { runCodexSetup } from "./cli/codex.js";
+import { runOpenCodeSetup } from "./cli/opencode.js";
 import { runOpenClawSetup } from "./cli/openclaw.js";
 import { runHermesSetup } from "./cli/hermes.js";
 import { runMigrateCommand } from "./cli/migrate.js";
@@ -50,6 +51,7 @@ const KNOWN_COMMANDS = new Set([
   "claude-code",
   "cursor",
   "codex",
+  "opencode",
   "openclaw",
   "hermes",
   "migrate",
@@ -189,6 +191,7 @@ COMMANDS:
   claude-code        Set up AutoMem for Claude Code
   cursor             Set up AutoMem for Cursor
   codex              Set up AutoMem for Codex
+  opencode           Set up AutoMem for OpenCode
   openclaw           Set up AutoMem for OpenClaw
   hermes             Set up AutoMem for Hermes Agent
   migrate            Migrate existing projects to AutoMem
@@ -274,12 +277,27 @@ RECALL:
 
 CODEX SETUP:
   npx @verygoodplugins/mcp-automem codex [options]
-  
+
   Options:
     --name <name>         Project name (auto-detected if not provided)
     --rules <path>        Target rules file (default: ./AGENTS.md)
     --dry-run             Show what would be changed
     --quiet               Suppress output
+
+OPENCODE SETUP:
+  npx @verygoodplugins/mcp-automem opencode [options]
+
+  Options:
+    --name <name>         Project name (auto-detected if not provided)
+    --config <path>       OpenCode config file (default: ~/.config/opencode/opencode.json)
+    --rules <path>        Target rules file (default: ./AGENTS.md)
+    --endpoint <url>      AutoMem endpoint (default: $AUTOMEM_API_URL or http://127.0.0.1:8001)
+    --api-key <key>       AutoMem API key (optional)
+    --dry-run             Show what would be changed
+    --quiet               Suppress output
+
+  Configures the memory MCP server in opencode.json and installs memory rules
+  into AGENTS.md (read natively by OpenCode). Verify with: opencode mcp list
 
 HERMES SETUP:
   npx @verygoodplugins/mcp-automem hermes [options]
@@ -363,6 +381,11 @@ if (command === "cursor") {
 
 if (command === "codex") {
   await runCodexSetup(process.argv.slice(3));
+  process.exit(0);
+}
+
+if (command === "opencode") {
+  await runOpenCodeSetup(process.argv.slice(3));
   process.exit(0);
 }
 

--- a/src/memory-policy/shared.ts
+++ b/src/memory-policy/shared.ts
@@ -547,6 +547,36 @@ export function renderCodexMemoryRules(params: ToolRuleRenderOptions): string {
   ].join('\n');
 }
 
+export function renderOpenCodeMemoryRules(params: ToolRuleRenderOptions): string {
+  // OpenCode exposes MCP tools as <server>_<tool> (server key `memory` → `memory_*`).
+  const toolPrefix = params.toolPrefix ?? 'memory_';
+  return [
+    '<!-- BEGIN AUTOMEM OPENCODE RULES -->',
+    `<!-- automem-template-version: ${params.templateVersion} -->`,
+    '',
+    `## Memory - AutoMem (persistent context for ${params.projectName})`,
+    '',
+    `AutoMem is wired as the \`memory\` MCP server (see \`~/.config/opencode/opencode.json\`). Tools are \`${toolPrefix}*\`. Use this layer proactively for continuity across turns.`,
+    '',
+    renderToolBehaviorSection(),
+    '',
+    renderRecallRulesSection({ projectName: params.projectName, toolPrefix }),
+    '',
+    renderStorageRulesSection(toolPrefix, params.projectName),
+    '',
+    '## Guidelines',
+    '',
+    '- Weave recalled context naturally; do not announce memory operations.',
+    '- Prefer high-signal memories: decisions, root causes, reusable patterns, and explicit preferences.',
+    '- Avoid wall-of-text memories; keep them atomic and focused.',
+    '',
+    renderMemoryVsCurrentState(),
+    '',
+    '<!-- END AUTOMEM OPENCODE RULES -->',
+    '',
+  ].join('\n');
+}
+
 export type CursorProjectRuleOptions = ToolRuleRenderOptions & {
   mcpServerName: string;
   mcpToolPrefix: string;

--- a/templates/opencode/memory-rules.md
+++ b/templates/opencode/memory-rules.md
@@ -1,0 +1,140 @@
+<!-- BEGIN AUTOMEM OPENCODE RULES -->
+<!-- automem-template-version: 0.15.0 -->
+
+## Memory - AutoMem (persistent context for {{PROJECT_NAME}})
+
+AutoMem is wired as the `memory` MCP server (see `~/.config/opencode/opencode.json`). Tools are `memory_*`. Use this layer proactively for continuity across turns.
+
+## Tool's real behavior (validated against production corpus)
+
+- **Tags are a hard gate** - memories without matching tags are excluded before scoring. Use tags for stable categories like `preference` and `bugfix`; do not guess topic tags.
+- **One good query beats `queries[]` + `auto_decompose`** for focused tasks. Use `queries[]` only for genuinely multi-topic questions.
+- **`limit` caps at 50.** Routine recall should use enough budget to be useful.
+- **Default `text` format shows content previews with created/updated timestamps and importance.** `detailed` adds type/confidence/metadata summary. Responses are budget-capped; fetch a full record with `recall_memory({ memory_id })`.
+- **`store_memory` can silently fail.** Verify important stores by recalling a distinctive phrase; retry once if missing.
+- **Bare tag convention** - use `automem`, not `project/automem`; no `lang/` prefixes, platform tags, or date-stamped tags. `entity:*:*` tags are server-injected.
+
+### Slug-collision rule
+
+Drop the project tag gate when the slug collides with common topic words: `api`, `app`, `test`, `video`. Use semantic query alone in that case.
+
+## Session start — two-phase recall
+
+Standardized defaults: preferences limit 20, task-context limit 30, 90-day task window.
+
+Preferences and task context are independent recalls - issue them in parallel in a single message.
+
+Preferences first:
+
+```javascript
+memory_recall_memory({
+  tags: ["preference"],
+  limit: 20,
+  sort: "updated_desc"
+})
+```
+
+Task context: one semantic query built from proper nouns, products, files, error strings, tools, and specific topics in the user message.
+
+```javascript
+memory_recall_memory({
+  query: "<proper nouns, product names, people, tools, specific topics from the user's message>",
+  tags: ["{{PROJECT_NAME}}"],        // drop if slug collides with a common word
+  time_query: "last 90 days",
+  limit: 30,
+  language: "<typescript|python|go|rust|...>" // optional ranker
+})
+```
+
+Skip task-context recall for pure syntax questions, trivial edits, one-off calculations, direct factual queries about current files, or casual openings.
+
+Debug context, only when actively investigating a concrete symptom:
+
+```javascript
+memory_recall_memory({
+  query: "<error symptom or exact message>",
+  limit: 20
+})
+```
+
+No tag gate on debug recall - bugfix/solution tagging is incomplete and a hard gate hides cross-corpus fixes.
+
+Don't re-recall mid-conversation unless the topic genuinely shifts, a new proper noun enters, or active debugging starts.
+
+### When recall misses
+
+Escalate only when the task-context recall comes back too broad or empty:
+
+- **Too broad** - add a tag gate (a stable category like `preference`/`bugfix`, or the unambiguous project slug) and tighten the query to the real nouns.
+- **Empty** - drop the time window first (the topic may be dormant-but-important), then broaden the query.
+- **Sparse under a tag gate** - drop the gate and rely on the semantic query alone; older memories use `project/<slug>` prefixes, so gated queries can miss historical content.
+- **Need graph traversal** - use `expand_relations: true`; add `expand_respect_tags: true` when traversal must stay inside the tag gate, or leave it false/drop tags when broader graph context is useful.
+
+## Storage Discipline
+
+Store only durable decisions, corrections, explicit preferences, bug-fix root causes, and articulated reusable patterns. Never store secrets, credentials, tokens, PII, session summaries, progress reports, confirmations, speculative context, or attentiveness notes.
+
+```javascript
+memory_store_memory({
+  content: "Brief title. Context + reasoning. Outcome.",
+  type: "Decision",
+  tags: ["<category>", "{{PROJECT_NAME}}", "<language>"], // bare strings; NO platform tag, NO [YYYY-MM]
+  importance: 0.85,
+  confidence: 0.9
+})
+```
+
+Use content of 150-300 chars when possible; put file paths, metrics, exit codes, and other structured details in `metadata`. For facts with a shelf life, use `t_valid` and `t_invalid` instead of date tags.
+
+### Three mid-conversation triggers (and only three)
+
+1. **User correction or override.** Listen for: "actually", "no, I prefer", "not X, Y", "that's wrong", "stop doing X", "never do X", "I told you before", "we decided X already". Store as `Preference`, importance 0.9, confidence 0.95, tag `correction`, then associate `INVALIDATED_BY` the prior memory.
+2. **Decision stabilizes after at least one round of discussion.** Listen for: "let's go with X", "yeah that's the plan", "ship it", "do it that way", "final answer", "okay let's do that". Store as `Decision`, importance 0.85-0.9, then associate `PREFERS_OVER` alternatives if they came up.
+3. **Pattern articulated - not inferred.** Listen for: "I always do X", "every time", "this is how I usually", "my thing is". Store as `Pattern`, importance 0.8, then associate concrete examples with `EXEMPLIFIES`.
+
+### The atomic ritual - every store runs all four steps
+
+```javascript
+const related = await memory_recall_memory({ query: "<what is being corrected / decided / named>", limit: 5 })
+const stored = await memory_store_memory({
+  content: "Brief title. Context + reasoning. Outcome.",
+  type: "Preference",
+  tags: ["correction", "{{PROJECT_NAME}}"],
+  importance: 0.9,
+  confidence: 0.95
+})
+await memory_recall_memory({ query: "<distinctive phrase from content>", limit: 3 })
+if (related?.results?.length) {
+  await memory_associate_memories({ memory1_id: related.results[0].id, memory2_id: stored.memory_id, type: "INVALIDATED_BY", strength: 0.9 })
+}
+```
+
+Step 4 is where the graph gets built. Skipping it is the main reason AutoMem degrades into a flat bag of notes.
+
+### Mandatory association pairings
+
+| Trigger | Store as | Then associate |
+|---|---|---|
+| User correction | `Preference`, 0.9 / 0.95 | Old memory -> `INVALIDATED_BY` |
+| Architectural decision | `Decision`, 0.9 / 0.9 | Alternatives -> `PREFERS_OVER` |
+| Bug fix | `Insight`, 0.75 / 0.85, tags `bugfix` + `solution` | Bug report -> `LEADS_TO` |
+| Pattern discovered | `Pattern`, 0.8 | Concrete examples -> `EXEMPLIFIES` |
+| Knowledge evolved | `update_memory` old + store new | Old -> `EVOLVED_INTO` |
+| Deprecated info | `update_memory` old with deprecated metadata | Old <- `INVALIDATED_BY` |
+
+Prefer memory_update_memory over a duplicate store when a fact changes in place.
+Valid relation types for memory_associate_memories: RELATES_TO, LEADS_TO, OCCURRED_BEFORE, PREFERS_OVER, EXEMPLIFIES, CONTRADICTS, REINFORCES, INVALIDATED_BY, EVOLVED_INTO, DERIVED_FROM, PART_OF.
+
+## Guidelines
+
+- Weave recalled context naturally; do not announce memory operations.
+- Prefer high-signal memories: decisions, root causes, reusable patterns, and explicit preferences.
+- Avoid wall-of-text memories; keep them atomic and focused.
+
+## Memory vs current state
+
+Recalled context is a prior, not ground truth. If a memory disagrees with the current repo state, the user's latest instruction, or a freshly read file - **current evidence wins**. Update or invalidate stale memory instead of acting on it.
+
+If recall fails or returns nothing, continue without memory and do not mention the failure to the user. Weave recalled context naturally.
+
+<!-- END AUTOMEM OPENCODE RULES -->

--- a/templates/opencode/opencode.json
+++ b/templates/opencode/opencode.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "memory": {
+      "type": "local",
+      "command": ["npx", "-y", "@verygoodplugins/mcp-automem"],
+      "enabled": true,
+      "environment": {
+        "AUTOMEM_API_URL": "{{AUTOMEM_API_URL}}",
+        "AUTOMEM_API_KEY": "{{AUTOMEM_API_KEY}}"
+      }
+    }
+  }
+}

--- a/tests/helpers/host-specs.ts
+++ b/tests/helpers/host-specs.ts
@@ -1,5 +1,5 @@
 export interface HostSmokeSpec {
-  host: 'hermes' | 'codex' | 'claude-code' | 'cursor';
+  host: 'hermes' | 'codex' | 'claude-code' | 'cursor' | 'opencode';
   configPath: string;
   installCommand: string[];
   expectedToolNames: string[];
@@ -38,6 +38,14 @@ export const HOST_SMOKE_SPECS: HostSmokeSpec[] = [
     configPath: '~/.cursor/mcp.json',
     installCommand: ['mcp-automem', 'cursor'],
     expectedToolNames: RAW_AUTOMEM_TOOLS.map((name) => `mcp_memory_${name}`).sort(),
+    realHostSmoke: 'config-and-mcp-contract',
+  },
+  {
+    host: 'opencode',
+    configPath: '~/.config/opencode/opencode.json',
+    installCommand: ['mcp-automem', 'opencode'],
+    expectedToolNames: RAW_AUTOMEM_TOOLS.map((name) => `memory_${name}`).sort(),
+    validationCommand: ['opencode', 'mcp', 'list'],
     realHostSmoke: 'config-and-mcp-contract',
   },
   {

--- a/tests/host-smoke/host-specs.test.ts
+++ b/tests/host-smoke/host-specs.test.ts
@@ -3,12 +3,13 @@ import { HOST_SMOKE_SPECS } from '../helpers/host-specs.js';
 import { duplicateCounts } from '../helpers/host-smoke.js';
 
 describe('host smoke specs', () => {
-  it('defines reusable host specs for Hermes, Codex, and Claude Code', () => {
+  it('defines reusable host specs for Hermes, Codex, Claude Code, and OpenCode', () => {
     expect(HOST_SMOKE_SPECS.map((spec) => spec.host).sort()).toEqual([
       'claude-code',
       'codex',
       'cursor',
       'hermes',
+      'opencode',
     ]);
   });
 


### PR DESCRIPTION
Adds OpenCode as a supported client, closely mirroring the existing codex/cursor patterns.
- opencode setup command: merges mcp.memory into ~/.config/opencode/opencode.json (backup-first, refuses unparseable files; --config, --rules, --endpoint, --api-key, --dry-run) and upserts a marked rules block into the project's AGENTS.md (OpenCode reads it natively).
- templates/opencode/memory-rules.md is generated from src/memory-policy/shared.ts via the existing sync script — same policy text as codex, with OpenCode's memory_* tool naming and config path.
- uninstall opencode strips the rules block and removes mcp.memory; round-trip verified in a sandbox (XDG_CONFIG_HOME isolation).
- Host smoke spec entry, 9 unit tests (suite: 640 passing), INSTALLATION.md section.
- Verified against a real OpenCode session: opencode mcp list reports memory connected, and recall works end-to-end.