### PR TITLE
fix(associate): explain batch rejection from a pre-0.16.0 service

### DIFF
--- a/src/automem-client.test.ts
+++ b/src/automem-client.test.ts
@@ -924,6 +924,47 @@ describe('AutoMemClient', () => {
       });
     });
 
+    it('should explain a pre-0.16.0 service rejecting batch mode', async () => {
+      // An older service ignores `associations` and validates the payload as a single
+      // association, so it reports the very fields the client did send in every item.
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        json: async () => ({
+          code: 400,
+          message: "'memory1_id' and 'memory2_id' are required",
+          status: 'error',
+        }),
+      } as any);
+
+      const promise = client.associateMemories({
+        associations: [
+          { memory1_id: 'mem-1', memory2_id: 'mem-2', type: 'RELATES_TO', strength: 0.9 },
+        ],
+      } as any);
+
+      await expect(promise).rejects.toThrow(/requires AutoMem 0\.16\.0 or newer/);
+      await expect(promise).rejects.toThrow(/one per call/);
+      // The service's own wording is preserved so the failure stays greppable.
+      await expect(promise).rejects.toThrow(/'memory1_id' and 'memory2_id' are required/);
+    });
+
+    it('should not rewrite unrelated batch association failures', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: async () => ({ message: 'Unauthorized' }),
+      } as any);
+
+      await expect(
+        client.associateMemories({
+          associations: [
+            { memory1_id: 'mem-1', memory2_id: 'mem-2', type: 'RELATES_TO', strength: 0.9 },
+          ],
+        } as any)
+      ).rejects.toThrow(/Unauthorized/);
+    });
+
     it('should return partial batch association results for 207 responses', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,

--- a/src/automem-client.ts
+++ b/src/automem-client.ts
@@ -78,6 +78,29 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+/**
+ * AutoMem services older than 0.16.0 have no `associations` branch in POST /associate,
+ * so a valid batch request falls through to single-association validation and comes back
+ * as `'memory1_id' and 'memory2_id' are required` — naming the exact fields the client
+ * did send, inside every item. That reads as a malformed client request rather than an
+ * outdated service, so restate it as the version mismatch it is.
+ */
+function explainBatchAssociateRejection(error: unknown, itemCount: number): unknown {
+  const status = (error as { status?: number } | null | undefined)?.status;
+  const message = errorMessage(error);
+  const isSingleModeValidation = status === 400 && /memory1_id|memory2_id/.test(message);
+  if (!isSingleModeValidation) return error;
+
+  const explained = new Error(
+    `associate_memories: the AutoMem service rejected batch mode with "${message}". ` +
+      'Batch `associations` requires AutoMem 0.16.0 or newer; older services ignore the ' +
+      'array and validate the payload as a single association. Upgrade the AutoMem service, ' +
+      `or send the ${itemCount} association(s) one per call.`
+  ) as Error & { status?: number };
+  explained.status = status;
+  return explained;
+}
+
 function mapStoredMemory(raw: any) {
   return {
     memory_id: raw?.id || raw?.memory_id || '',
@@ -761,7 +784,12 @@ export class AutoMemClient {
       const associations = args.associations.map((association, index) =>
         sanitizeAssociationInput(association, `associations[${index}]`)
       );
-      const response = await this.makeRequest('POST', 'associate', { associations });
+      let response;
+      try {
+        response = await this.makeRequest('POST', 'associate', { associations });
+      } catch (error) {
+        throw explainBatchAssociateRejection(error, associations.length);
+      }
       const createdCount =
         typeof response.created_count === 'number'
           ? response.created_count


### PR DESCRIPTION
When the connected AutoMem service predates batch association support, `associate_memories` fails with an error that points at the one thing that is not wrong.

## What happens

An AutoMem service older than 0.16.0 has no `associations` branch in `POST /associate`, so a valid batch request falls through to single-association validation and comes back as:

```json
{"code":400,"message":"'memory1_id' and 'memory2_id' are required","status":"error"}
```

The client did send `memory1_id` and `memory2_id` — in every item of the array. The tool schema documents batch mode, `associateMemories` implements it correctly, and the payload on the wire is right. But the error names those exact fields, so it reads as a malformed client request.

I hit this as an agent and concluded the MCP had a schema/handler bug. It took reading the server source, diffing the deployed commit, and probing the live endpoint to establish that the client was fine and the *service* was three months stale. That is a lot of work to get back to "upgrade your server."

## The change

In the batch branch only, recognise the single-mode validation signature (HTTP 400 mentioning `memory1_id`/`memory2_id` — which cannot legitimately occur for a batch request, since each item is validated client-side before the call) and restate it:

> associate_memories: the AutoMem service rejected batch mode with "'memory1_id' and 'memory2_id' are required". Batch `associations` requires AutoMem 0.16.0 or newer; older services ignore the array and validate the payload as a single association. Upgrade the AutoMem service, or send the N association(s) one per call.

The service’s original wording is preserved inside the message so the failure stays greppable, and `status` is carried through.

This is diagnostics only — no behaviour change on the success path, and no change to what is sent. Unrelated failures (auth, network, per-item validation from a service that *does* support batch) pass through untouched.

## Tests

Two added:
- a pre-0.16.0 rejection produces the explanatory message and keeps the original text
- a 401 is **not** rewritten (guards against over-matching)

Full file: 63/63 passing, `tsc --noEmit` clean.

Related: verygoodplugins/automem#223, a separate bug found during the same investigation.