### PR TITLE
feat: add Grok Build AutoMem installer client

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,7 +318,15 @@ When adding or changing a client host integration, test the real host boundary i
 - Assert tool names are unique across the final provider payload, not just within AutoMem tools.
 - Add uninstall coverage for every file, config key, plugin directory, and environment key the installer writes.
 - Redact secrets and isolate env vars; never let a real `AUTOMEM_API_KEY` leak into temp config or snapshots.
-- Keep `tests/helpers/host-specs.ts` updated as the executable host integration contract for Hermes, Claude Code, Codex, Cursor, Grok, and future platforms.
+- Keep `tests/helpers/host-specs.ts` updated as the executable host integration contract for Hermes, Claude Code, Codex, Cursor, Copilot, Grok, and future platforms. Each spec's `host` is the MCP *registration surface* (Copilot has two: CLI and VS Code); `client` ties it back to the installer client in `src/cli/clients.ts`.
+
+### Adding a host
+
+`src/cli/clients.ts` is the client registry — `AGENT_CLIENTS` plus the exclusion lists that record where a client is deliberately unsupported. Uninstall platforms and the CLI's known-commands set are derived from it, so those cannot drift.
+
+`tests/docs/host-parity.test.ts` enforces the rest: every client needs an uninstall path, a host smoke spec, a dispatch branch, and — if it ships a rules template — a renderer registered in `scripts/sync-memory-policy.ts`. When a gap is knowingly accepted, add it to the exclusion list in that test (or in `clients.ts`) with a reason. Do not delete the assertion.
+
+Known debt tracked this way: OpenClaw has no uninstall path (`UNINSTALL_UNSUPPORTED_CLIENTS`), and Copilot's memory rules are still hand-written rather than generated (`HAND_WRITTEN_RULES`) — the drift that caused #186.
 
 Documentation changes are part of the integration contract. Any new host mode or uninstall behavior should be reflected in `INSTALLATION.md` and covered by a smoke/doc assertion.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,7 +318,7 @@ When adding or changing a client host integration, test the real host boundary i
 - Assert tool names are unique across the final provider payload, not just within AutoMem tools.
 - Add uninstall coverage for every file, config key, plugin directory, and environment key the installer writes.
 - Redact secrets and isolate env vars; never let a real `AUTOMEM_API_KEY` leak into temp config or snapshots.
-- Keep `tests/helpers/host-specs.ts` updated as the executable host integration contract for Hermes, Claude Code, Codex, Cursor, and future platforms.
+- Keep `tests/helpers/host-specs.ts` updated as the executable host integration contract for Hermes, Claude Code, Codex, Cursor, Grok, and future platforms.
 
 Documentation changes are part of the integration contract. Any new host mode or uninstall behavior should be reflected in `INSTALLATION.md` and covered by a smoke/doc assertion.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,7 +266,7 @@ AUTOMEM_RECALL_TOKEN_BUDGET=18000
 **Modify memory policy / recall rules:**
 1. Edit the shared policy source in `src/memory-policy/shared.ts`
 2. Run `npx tsx scripts/sync-memory-policy.ts` (or `npm run build`, which runs it during `prebuild`)
-3. Do not hand-edit generated policy artifacts: `templates/claude-code/hooks/automem-session-start.sh`, `templates/claude-code/hooks/automem-stop-nudge.sh`, `templates/claude-code/hooks/automem-track-store.sh`, `plugins/automem/scripts/session-start.sh`, `plugins/automem/scripts/stop-nudge.sh`, `plugins/automem/scripts/track-store.sh`, `templates/codex/memory-rules.md`, `templates/cursor/automem.mdc.template`, `templates/CLAUDE_DESKTOP_INSTRUCTIONS.md`, `templates/CLAUDE_MD_MEMORY_RULES.md`, `templates/hermes/memory-rules.md`, or `templates/hermes/provider/automem_policy.py`
+3. Do not hand-edit generated policy artifacts: `templates/claude-code/hooks/automem-session-start.sh`, `templates/claude-code/hooks/automem-stop-nudge.sh`, `templates/claude-code/hooks/automem-track-store.sh`, `plugins/automem/scripts/session-start.sh`, `plugins/automem/scripts/stop-nudge.sh`, `plugins/automem/scripts/track-store.sh`, `templates/codex/memory-rules.md`, `templates/cursor/automem.mdc.template`, `templates/CLAUDE_DESKTOP_INSTRUCTIONS.md`, `templates/CLAUDE_MD_MEMORY_RULES.md`, `templates/hermes/memory-rules.md`, `templates/grok/memory-rules.md`, or `templates/hermes/provider/automem_policy.py`
 4. Update `src/memory-policy.test.ts` when the shared policy contract changes
 
 **Modify non-policy hook behavior:**

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -79,7 +79,7 @@ the plan.
 > plan and stops without writing — re-run with `--yes` to apply.
 
 **Removing AutoMem:** uninstall is per-agent —
-`npx @verygoodplugins/mcp-automem uninstall <cursor|claude-code|codex|hermes>`
+`npx @verygoodplugins/mcp-automem uninstall <cursor|claude-code|codex|hermes|grok>`
 (add `--clean-all` to also drop the MCP server config). OpenClaw owns its own
 plugin lifecycle, so remove the AutoMem plugin from OpenClaw directly with
 `openclaw plugins uninstall automem` rather than the `uninstall` command above.
@@ -144,6 +144,7 @@ Now that your AutoMem service is running, install and configure the MCP client t
 - [GitHub Copilot CLI and VS Code](#github-copilot-cli-and-vs-code) - Terminal and editor with hooks and memory rules
 - [OpenAI Codex](#openai-codex) - CLI, IDE, and cloud agent
 - [Hermes Agent](#hermes-agent) - Nous Research terminal agent with MCP and native memory provider support
+- [Grok Build](#grok-build) - xAI Grok CLI with native `~/.grok/config.toml` MCP registration
 - [Google Antigravity](#google-antigravity) - Desktop editor with MCP Store and raw config
 - [OpenClaw](#openclaw) - Personal AI assistant with multi-platform messaging (WhatsApp, Telegram, Slack, Discord, etc.)
 
@@ -1024,6 +1025,59 @@ Then check the Hermes logs for AutoMem prefetch diagnostics. The debug path repo
 
 ---
 
+## Grok Build
+
+Grok Build (xAI CLI) loads MCP from `~/.grok/config.toml`, then Claude/Cursor compat sources. **Native config is required for AutoMem.** If AutoMem is only present via Claude/Cursor imports, Grok can start `npx @verygoodplugins/mcp-automem` without `AUTOMEM_*` env — the server then defaults to `http://127.0.0.1:8001` and every session fails with `Mcp error: -32603: fetch failed`. Edits in the `/mcps` UI are session-scoped unless written to `config.toml`.
+
+### Install
+
+```bash
+# Guided installer (detects ~/.grok and offers Grok in the agent list)
+npx @verygoodplugins/mcp-automem install --clients grok \
+  --endpoint https://your-automem.example --api-key "$AUTOMEM_API_KEY"
+
+# Or standalone
+npx @verygoodplugins/mcp-automem grok \
+  --endpoint https://your-automem.example --api-key "$AUTOMEM_API_KEY"
+```
+
+This writes:
+
+- `~/.grok/config.toml` → `[mcp_servers.memory]` with `npx -y @verygoodplugins/mcp-automem` and `AUTOMEM_API_URL` / `AUTOMEM_API_KEY` / `AUTOMEM_PROCESS_TAG=grok:memory`
+- `~/.grok/AGENTS.md` → marked AutoMem rules block (Grok injects this every session)
+
+Override the Grok home with `$GROK_HOME` or `--dir`.
+
+### Verify
+
+```bash
+grok mcp list
+# → memory: npx -y @verygoodplugins/mcp-automem
+
+# Start a *new* Grok session (existing sessions keep the old MCP child), then recall
+```
+
+Tools appear as `memory__recall_memory`, `memory__store_memory`, etc. Discover with `search_tool`, then call with `use_tool`.
+
+### Uninstall
+
+```bash
+npx @verygoodplugins/mcp-automem uninstall grok
+npx @verygoodplugins/mcp-automem uninstall grok --dry-run
+```
+
+Removes AutoMem-owned `mcp_servers.memory` and strips the `<!-- BEGIN AUTOMEM GROK RULES -->` block from `~/.grok/AGENTS.md` (or `--rules <path>`). Non-AutoMem `memory` servers are left alone.
+
+### Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `fetch failed` / `ECONNREFUSED 127.0.0.1:8001` | No native MCP env; compat import dropped `AUTOMEM_*` | Run `mcp-automem grok` so `config.toml` wins over Claude/Cursor |
+| Works after `/mcps` SSE tweak, fails next session | UI change was session-only | Persist with `grok mcp add` / `mcp-automem grok`, not the modal alone |
+| `grok mcp list` empty but tools still appear | Compat-only load | Add native `[mcp_servers.memory]` so env is explicit |
+
+---
+
 ## Google Antigravity
 
 Google Antigravity supports MCP servers through its built-in MCP Store and a raw config file. AutoMem fits Antigravity's local stdio MCP flow directly, so the primary path is to add the `memory` server to Antigravity's custom MCP server config.
@@ -1510,6 +1564,9 @@ npx @verygoodplugins/mcp-automem uninstall claude-code
 
 # Uninstall Hermes setup
 npx @verygoodplugins/mcp-automem uninstall hermes
+
+# Uninstall Grok Build setup
+npx @verygoodplugins/mcp-automem uninstall grok
 
 # Also clean Claude Desktop config
 npx @verygoodplugins/mcp-automem uninstall cursor --clean-all

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1048,6 +1048,15 @@ This writes:
 
 Override the Grok home with `$GROK_HOME` or `--dir`.
 
+Only the `[mcp_servers.memory]` table is touched — the rest of `config.toml` keeps its
+comments, multi-line strings, and formatting. Every write backs the file up first, and
+`--dry-run` reports whether the entry would be added, updated, or left unchanged without
+writing anything. To wire it up by hand instead, copy
+[`templates/grok/config.toml`](templates/grok/config.toml).
+
+> If `disabled_mcp_servers` in `config.toml` contains `"memory"`, Grok ignores the server
+> entry entirely. The installer warns when it sees this; remove the name from that list.
+
 ### Verify
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ https://github.com/user-attachments/assets/fd79112b-5158-4320-a054-8c18ab1ea314
 
 <p align="center"><sub><b>The guided installer</b> — <code>npx @verygoodplugins/mcp-automem install</code> walks you through local, hosted, or existing-endpoint setup.</sub></p>
 
-Works with **Claude Desktop**, **Cursor IDE**, **Claude Code**, **GitHub Copilot (coding agent)**, **ChatGPT**, **ElevenLabs**, **OpenAI Codex**, **OpenClaw**, **Hermes**, **Google Antigravity** - any MCP-compatible AI platform.
+Works with **Claude Desktop**, **Cursor IDE**, **Claude Code**, **GitHub Copilot (coding agent)**, **ChatGPT**, **ElevenLabs**, **OpenAI Codex**, **OpenClaw**, **Hermes**, **Grok Build**, **Google Antigravity** - any MCP-compatible AI platform.
 
 ## The Problem We Solve
 
@@ -42,7 +42,7 @@ AutoMem MCP connects your AI to persistent memory powered by **[AutoMem](https:/
 ### 🧠 Persistent Memory Across Sessions
 
 - AI remembers decisions, patterns, and context **forever**
-- Works across **all MCP platforms** - Claude Desktop, Cursor, Claude Code, OpenAI Codex, OpenClaw, Hermes, Google Antigravity
+- Works across **all MCP platforms** - Claude Desktop, Cursor, Claude Code, OpenAI Codex, OpenClaw, Hermes, Grok Build, Google Antigravity
 - **Cross-device sync** - same memory on Mac, Windows, Linux
 
 ### 🏆 Graph-Vector Architecture
@@ -62,6 +62,7 @@ AutoMem MCP connects your AI to persistent memory powered by **[AutoMem](https:/
 | **OpenAI Codex**   | ✅ Full | 30 seconds |
 | **OpenClaw**       | ✅ Full | 30 seconds |
 | **Hermes Agent**   | ✅ Full | 30 seconds |
+| **Grok Build**     | ✅ Full | 30 seconds |
 | **Google Antigravity** | ✅ Full | 30 seconds |
 | **Any MCP client** | ✅ Full | 30 seconds |
 
@@ -181,7 +182,7 @@ On Windows, the hook payload assumes a POSIX shell environment such as Git Bash,
 npx @verygoodplugins/mcp-automem cursor
 ```
 
-**Other platforms** — Claude Desktop (one-click `.mcpb` above, plus the [Personal Preferences template](templates/CLAUDE_DESKTOP_INSTRUCTIONS.md)), [OpenAI Codex](INSTALLATION.md#openai-codex), [Hermes Agent](INSTALLATION.md#hermes-agent), [OpenClaw](INSTALLATION.md#openclaw), [Google Antigravity](INSTALLATION.md#google-antigravity), and [GitHub Copilot](INSTALLATION.md#github-copilot-coding-agent-githubcom):
+**Other platforms** — Claude Desktop (one-click `.mcpb` above, plus the [Personal Preferences template](templates/CLAUDE_DESKTOP_INSTRUCTIONS.md)), [OpenAI Codex](INSTALLATION.md#openai-codex), [Hermes Agent](INSTALLATION.md#hermes-agent), [Grok Build](INSTALLATION.md#grok-build), [OpenClaw](INSTALLATION.md#openclaw), [Google Antigravity](INSTALLATION.md#google-antigravity), and [GitHub Copilot](INSTALLATION.md#github-copilot-coding-agent-githubcom):
 
 👉 **[Full Installation Guide](INSTALLATION.md)** for every platform's setup and verification steps
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.2",
         "node-fetch": "^3.3.2",
+        "smol-toml": "^1.7.0",
         "yaml": "^2.9.0"
       },
       "bin": {
@@ -5034,6 +5035,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/smol-toml": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.7.0.tgz",
+      "integrity": "sha512-aqVvWoyO21L23mb+drl4RmMXbf6N7FdHjAhTRA9ZBL7apWBgfWC16KjrASI+1p9GAroljyMHj6fK67i0UiTNvQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.2",
     "node-fetch": "^3.3.2",
+    "smol-toml": "^1.7.0",
     "yaml": "^2.9.0"
   },
   "devDependencies": {

--- a/scripts/sync-memory-policy.ts
+++ b/scripts/sync-memory-policy.ts
@@ -10,6 +10,7 @@ import {
   renderClaudeMdMemoryRules,
   renderCodexMemoryRules,
   renderCursorProjectRule,
+  renderGrokMemoryRules,
   renderHermesMemoryRules,
   renderHermesProviderPolicyPython,
 } from '../src/memory-policy/shared.js';
@@ -72,6 +73,10 @@ const files: Array<[string, string]> = [
     }),
   ],
   ['templates/hermes/provider/automem_policy.py', renderHermesProviderPolicyPython()],
+  [
+    'templates/grok/memory-rules.md',
+    renderGrokMemoryRules({ projectName: '{{PROJECT_NAME}}', templateVersion }),
+  ],
 ];
 
 const changed = files.reduce((count, [relativePath, content]) => {

--- a/src/cli/clients.ts
+++ b/src/cli/clients.ts
@@ -1,0 +1,60 @@
+/**
+ * The set of agent clients the guided installer can configure, plus the drift-control
+ * lists that describe where a client is deliberately *not* supported.
+ *
+ * This lives apart from install.ts so uninstall.ts, src/index.ts, and the parity tests
+ * can name clients without importing the installer (and, transitively, every host
+ * module and the cloud-provisioning stack).
+ */
+
+export const AGENT_CLIENTS = [
+  'codex',
+  'claude-code',
+  'cursor',
+  'openclaw',
+  'hermes',
+  'grok',
+] as const;
+
+export type AgentClient = (typeof AGENT_CLIENTS)[number];
+
+/** Pre-selected when the installer runs without an explicit --clients list. */
+export const DEFAULT_AGENT_CLIENTS = [
+  'codex',
+  'claude-code',
+  'cursor',
+  'openclaw',
+] as const satisfies readonly AgentClient[];
+
+/**
+ * Installable but not yet uninstallable. Every entry here is a gap, not a design
+ * choice — tests/docs/host-parity.test.ts fails if a client is missing from the
+ * uninstall surface without being listed.
+ */
+export const UNINSTALL_UNSUPPORTED_CLIENTS = ['openclaw'] as const satisfies readonly AgentClient[];
+
+/**
+ * Hosts with their own `mcp-automem <name>` setup and uninstall commands that the
+ * guided installer does not offer in its agent list. Copilot is configured per-surface
+ * (CLI vs VS Code) rather than as a single checkbox, so it is not an AgentClient.
+ */
+export const STANDALONE_PLATFORMS = ['copilot'] as const;
+
+export type UninstallPlatform =
+  | Exclude<AgentClient, (typeof UNINSTALL_UNSUPPORTED_CLIENTS)[number]>
+  | (typeof STANDALONE_PLATFORMS)[number];
+
+export const UNINSTALL_PLATFORMS = [
+  ...AGENT_CLIENTS.filter(
+    (client): client is Exclude<AgentClient, (typeof UNINSTALL_UNSUPPORTED_CLIENTS)[number]> =>
+      !(UNINSTALL_UNSUPPORTED_CLIENTS as readonly string[]).includes(client)
+  ),
+  ...STANDALONE_PLATFORMS,
+] as const satisfies readonly UninstallPlatform[];
+
+/**
+ * Every per-host setup subcommand the CLI routes. Derived so a new client cannot be
+ * routed without also being recognized (an unlisted command falls through to stdio
+ * server mode and skips dotenv-banner silencing).
+ */
+export const HOST_SETUP_COMMANDS = [...AGENT_CLIENTS, ...STANDALONE_PLATFORMS] as const;

--- a/src/cli/grok-config.test.ts
+++ b/src/cli/grok-config.test.ts
@@ -240,6 +240,44 @@ describe('grok-config', () => {
       }
     });
 
+    it('tightens an unchanged config that already holds a key', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      const entry = buildGrokAutoMemServerEntry('https://automem.example', 'sk-secret');
+      upsertGrokMemoryServer(configPath, entry, { quiet: true });
+      // Simulate a hand-written (or previously mis-permissioned) secret-bearing config.
+      fs.chmodSync(configPath, 0o644);
+
+      // Re-running with an identical entry writes nothing — but must still not leave a
+      // world-readable credential behind.
+      const result = upsertGrokMemoryServer(configPath, entry, { quiet: true });
+      expect(result.changed).toBe(false);
+      expect(fs.statSync(configPath).mode & 0o777).toBe(0o600);
+    });
+
+    it('protects a backup that retains a key being removed from the entry', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      upsertGrokMemoryServer(
+        configPath,
+        buildGrokAutoMemServerEntry('https://first.example', 'sk-old-host'),
+        { quiet: true }
+      );
+      fs.chmodSync(configPath, 0o644);
+
+      // Switching endpoints drops the key from the *new* entry, but the backup still
+      // contains the old one.
+      upsertGrokMemoryServer(configPath, buildGrokAutoMemServerEntry('https://second.example'), {
+        quiet: true,
+      });
+
+      const backups = fs.readdirSync(tmpDir).filter((f) => f.startsWith('config.toml.bak'));
+      expect(backups.length).toBeGreaterThan(0);
+      for (const backup of backups) {
+        const full = path.join(tmpDir, backup);
+        expect(fs.readFileSync(full, 'utf8')).toContain('sk-old-host');
+        expect(fs.statSync(full).mode & 0o777).toBe(0o600);
+      }
+    });
+
     it('leaves permissions alone when no API key is written', () => {
       const configPath = path.join(tmpDir, 'config.toml');
       upsertGrokMemoryServer(configPath, buildGrokAutoMemServerEntry('https://automem.example'), {
@@ -451,6 +489,27 @@ describe('grok-config', () => {
   });
 
   describe('removeGrokMemoryServer', () => {
+    it('protects the uninstall backup when the removed entry held a key', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      upsertGrokMemoryServer(
+        configPath,
+        buildGrokAutoMemServerEntry('https://automem.example', 'sk-uninstall'),
+        { quiet: true }
+      );
+      fs.chmodSync(configPath, 0o644);
+
+      removeGrokMemoryServer(configPath, { quiet: true, onlyIfAutoMem: true });
+
+      const backups = fs.readdirSync(tmpDir).filter((f) => f.startsWith('config.toml.bak'));
+      const withKey = backups.filter((f) =>
+        fs.readFileSync(path.join(tmpDir, f), 'utf8').includes('sk-uninstall')
+      );
+      expect(withKey.length).toBeGreaterThan(0);
+      for (const backup of withKey) {
+        expect(fs.statSync(path.join(tmpDir, backup)).mode & 0o777).toBe(0o600);
+      }
+    });
+
     it('removes AutoMem memory entry and leaves siblings intact', () => {
       const configPath = path.join(tmpDir, 'config.toml');
       upsertGrokMemoryServer(configPath, buildGrokAutoMemServerEntry('http://127.0.0.1:8001'), {

--- a/src/cli/grok-config.test.ts
+++ b/src/cli/grok-config.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { parse as parseToml } from 'smol-toml';
+import {
+  buildGrokAutoMemServerEntry,
+  removeGrokMemoryServer,
+  resolveGrokPaths,
+  upsertGrokMemoryServer,
+} from './grok-config.js';
+
+describe('grok-config', () => {
+  let tmpDir: string;
+  let originalGrokHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-config-'));
+    originalGrokHome = process.env.GROK_HOME;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (originalGrokHome === undefined) delete process.env.GROK_HOME;
+    else process.env.GROK_HOME = originalGrokHome;
+  });
+
+  describe('resolveGrokPaths', () => {
+    it('uses --dir when provided', () => {
+      const p = resolveGrokPaths({ dir: '/custom/grok' });
+      expect(p.home).toBe('/custom/grok');
+      expect(p.configPath).toBe('/custom/grok/config.toml');
+      expect(p.agentsPath).toBe('/custom/grok/AGENTS.md');
+    });
+
+    it('uses GROK_HOME when set', () => {
+      process.env.GROK_HOME = '/env/grok';
+      const p = resolveGrokPaths();
+      expect(p.home).toBe('/env/grok');
+    });
+
+    it('falls back to ~/.grok', () => {
+      delete process.env.GROK_HOME;
+      const p = resolveGrokPaths();
+      expect(p.home).toBe(path.join(os.homedir(), '.grok'));
+    });
+  });
+
+  describe('buildGrokAutoMemServerEntry', () => {
+    it('includes API key and process tag when key provided', () => {
+      const entry = buildGrokAutoMemServerEntry('https://api.example.com', 'sk-test');
+      expect(entry).toEqual({
+        command: 'npx',
+        args: ['-y', '@verygoodplugins/mcp-automem'],
+        enabled: true,
+        env: {
+          AUTOMEM_API_URL: 'https://api.example.com',
+          AUTOMEM_API_KEY: 'sk-test',
+          AUTOMEM_PROCESS_TAG: 'grok:memory',
+        },
+      });
+    });
+
+    it('omits the API key when not provided', () => {
+      const entry = buildGrokAutoMemServerEntry('https://api.example.com');
+      expect(entry.env).not.toHaveProperty('AUTOMEM_API_KEY');
+      expect(entry.env.AUTOMEM_PROCESS_TAG).toBe('grok:memory');
+    });
+  });
+
+  describe('upsertGrokMemoryServer', () => {
+    it('creates a fresh config.toml when none exists', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      const result = upsertGrokMemoryServer(
+        configPath,
+        buildGrokAutoMemServerEntry('http://127.0.0.1:8001', 'sk-x'),
+        { quiet: true }
+      );
+      expect(result.method).toBe('toml');
+      expect(result.changed).toBe(true);
+
+      const parsed = parseToml(fs.readFileSync(configPath, 'utf8')) as {
+        mcp_servers: Record<string, { command: string; env: Record<string, string> }>;
+      };
+      expect(parsed.mcp_servers.memory.command).toBe('npx');
+      expect(parsed.mcp_servers.memory.env.AUTOMEM_API_URL).toBe('http://127.0.0.1:8001');
+      expect(parsed.mcp_servers.memory.env.AUTOMEM_API_KEY).toBe('sk-x');
+    });
+
+    it('preserves other servers and top-level keys when adding memory', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      fs.writeFileSync(
+        configPath,
+        [
+          '[cli]',
+          'installer = "internal"',
+          '',
+          '[mcp_servers.other]',
+          'command = "bash"',
+          'args = ["-c", "echo hi"]',
+          '',
+          '[mcp_servers.other.env]',
+          'FOO = "bar"',
+          '',
+        ].join('\n')
+      );
+
+      upsertGrokMemoryServer(configPath, buildGrokAutoMemServerEntry('http://127.0.0.1:8001'), {
+        quiet: true,
+      });
+
+      const parsed = parseToml(fs.readFileSync(configPath, 'utf8')) as {
+        cli: { installer: string };
+        mcp_servers: Record<string, unknown>;
+      };
+      expect(parsed.cli.installer).toBe('internal');
+      expect(parsed.mcp_servers.other).toBeDefined();
+      expect(parsed.mcp_servers.memory).toBeDefined();
+    });
+
+    it('is idempotent — re-running returns changed: false', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      const entry = buildGrokAutoMemServerEntry('http://127.0.0.1:8001', 'sk-x');
+
+      const first = upsertGrokMemoryServer(configPath, entry, { quiet: true });
+      expect(first.changed).toBe(true);
+
+      const second = upsertGrokMemoryServer(configPath, entry, { quiet: true });
+      expect(second.changed).toBe(false);
+    });
+
+    it('reports dry-run without writing', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      const result = upsertGrokMemoryServer(
+        configPath,
+        buildGrokAutoMemServerEntry('http://127.0.0.1:8001'),
+        { dryRun: true, quiet: true }
+      );
+      expect(result.method).toBe('dry-run');
+      expect(fs.existsSync(configPath)).toBe(false);
+    });
+
+    it('surfaces a clear error for malformed TOML', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      fs.writeFileSync(configPath, 'mcp_servers = {memory = \n');
+      expect(() =>
+        upsertGrokMemoryServer(configPath, buildGrokAutoMemServerEntry('http://127.0.0.1:8001'), {
+          quiet: true,
+        })
+      ).toThrow(/Failed to parse Grok config/);
+    });
+  });
+
+  describe('removeGrokMemoryServer', () => {
+    it('removes AutoMem memory entry and leaves siblings intact', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      upsertGrokMemoryServer(configPath, buildGrokAutoMemServerEntry('http://127.0.0.1:8001'), {
+        quiet: true,
+      });
+      const withOther = parseToml(fs.readFileSync(configPath, 'utf8')) as {
+        mcp_servers: Record<string, unknown>;
+      };
+      withOther.mcp_servers.other = { command: 'bash' };
+      // Re-write via upsert path: write raw TOML with sibling
+      fs.writeFileSync(
+        configPath,
+        [
+          '[mcp_servers.memory]',
+          'command = "npx"',
+          'args = ["-y", "@verygoodplugins/mcp-automem"]',
+          'enabled = true',
+          '',
+          '[mcp_servers.memory.env]',
+          'AUTOMEM_API_URL = "http://127.0.0.1:8001"',
+          'AUTOMEM_PROCESS_TAG = "grok:memory"',
+          '',
+          '[mcp_servers.other]',
+          'command = "bash"',
+          '',
+        ].join('\n')
+      );
+
+      const changed = removeGrokMemoryServer(configPath, { quiet: true, onlyIfAutoMem: true });
+      expect(changed).toBe(true);
+      const parsed = parseToml(fs.readFileSync(configPath, 'utf8')) as {
+        mcp_servers: Record<string, unknown>;
+      };
+      expect(parsed.mcp_servers.memory).toBeUndefined();
+      expect(parsed.mcp_servers.other).toBeDefined();
+    });
+
+    it('returns false when the entry does not exist', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      fs.writeFileSync(configPath, ['[mcp_servers.other]', 'command = "bash"', ''].join('\n'));
+      expect(removeGrokMemoryServer(configPath, { quiet: true })).toBe(false);
+    });
+
+    it('skips non-AutoMem memory entries when onlyIfAutoMem is set', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      fs.writeFileSync(
+        configPath,
+        ['[mcp_servers.memory]', 'command = "node"', 'args = ["./other-memory.js"]', ''].join('\n')
+      );
+      expect(removeGrokMemoryServer(configPath, { quiet: true, onlyIfAutoMem: true })).toBe(false);
+      const parsed = parseToml(fs.readFileSync(configPath, 'utf8')) as {
+        mcp_servers: Record<string, unknown>;
+      };
+      expect(parsed.mcp_servers.memory).toBeDefined();
+    });
+  });
+});

--- a/src/cli/grok-config.test.ts
+++ b/src/cli/grok-config.test.ts
@@ -149,6 +149,155 @@ describe('grok-config', () => {
         })
       ).toThrow(/Failed to parse Grok config/);
     });
+
+    it('reports whether a dry run would add or update the entry', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      const entry = buildGrokAutoMemServerEntry('http://127.0.0.1:8001');
+
+      upsertGrokMemoryServer(configPath, entry, { quiet: true });
+      const before = fs.readFileSync(configPath, 'utf8');
+
+      // Same entry: a dry run must report "unchanged", not a pending write.
+      const unchanged = upsertGrokMemoryServer(configPath, entry, { dryRun: true, quiet: true });
+      expect(unchanged.changed).toBe(false);
+      expect(unchanged.method).toBe('dry-run');
+
+      // Different entry: still no write, but it is a real pending change.
+      const updated = upsertGrokMemoryServer(
+        configPath,
+        buildGrokAutoMemServerEntry('https://elsewhere.example'),
+        { dryRun: true, quiet: true }
+      );
+      expect(updated.method).toBe('dry-run');
+      expect(fs.readFileSync(configPath, 'utf8')).toBe(before);
+    });
+
+    it('fails the dry run on malformed TOML instead of deferring to the real run', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      fs.writeFileSync(configPath, 'mcp_servers = {memory = \n');
+      expect(() =>
+        upsertGrokMemoryServer(configPath, buildGrokAutoMemServerEntry('http://127.0.0.1:8001'), {
+          dryRun: true,
+          quiet: true,
+        })
+      ).toThrow(/Failed to parse Grok config/);
+    });
+  });
+
+  // Grok configs are hand-maintained: comments, multi-line `"""` subagent instructions,
+  // and array formatting all matter. A parse/stringify round-trip destroys them, so the
+  // installer edits the AutoMem table as text and leaves every other byte alone.
+  describe('hand-maintained config fidelity', () => {
+    const HANDWRITTEN = [
+      '# Grok configuration — hand maintained',
+      'disabled_mcp_servers = [',
+      '    "robinhood",',
+      '    "wordpress",',
+      ']',
+      '',
+      '[cli]',
+      'installer = "internal" # keep the internal installer',
+      '',
+      '[subagents.personas.long-haul]',
+      'description = "Long autonomous implementer"',
+      'instructions = """',
+      'You are executing authorized long-haul work.',
+      'Do not claim done without verification commands.',
+      '"""',
+      '',
+      '[mcp_servers.todoist]',
+      'url = "https://ai.todoist.net/mcp"',
+      '',
+      '[mcp_servers.todoist.headers]',
+      'Authorization = "Bearer redacted"',
+      '',
+    ].join('\n');
+
+    /** Everything except the AutoMem table must survive byte-for-byte. */
+    function withoutMemoryTable(source: string): string {
+      return source.replace(/\[mcp_servers\.memory\][\s\S]*?(?=\n\[(?!mcp_servers\.memory)|$)/, '');
+    }
+
+    it('adds the AutoMem table without reformatting the rest of the file', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      fs.writeFileSync(configPath, HANDWRITTEN);
+
+      upsertGrokMemoryServer(configPath, buildGrokAutoMemServerEntry('https://automem.example'), {
+        quiet: true,
+      });
+      const after = fs.readFileSync(configPath, 'utf8');
+
+      expect(after).toContain('# Grok configuration — hand maintained');
+      expect(after).toContain('installer = "internal" # keep the internal installer');
+      expect(after).toContain('instructions = """');
+      expect(after).toContain('You are executing authorized long-haul work.');
+      expect(after).toContain('    "robinhood",');
+      // The multi-line string must not have collapsed into an escaped one-liner.
+      expect(after).not.toContain('\\n');
+
+      const parsed = parseToml(after) as { mcp_servers: Record<string, unknown> };
+      expect(parsed.mcp_servers.memory).toBeDefined();
+      expect(parsed.mcp_servers.todoist).toBeDefined();
+    });
+
+    it('round-trips install then uninstall back to the original bytes', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      fs.writeFileSync(configPath, HANDWRITTEN);
+
+      upsertGrokMemoryServer(configPath, buildGrokAutoMemServerEntry('https://automem.example'), {
+        quiet: true,
+      });
+      removeGrokMemoryServer(configPath, { quiet: true, onlyIfAutoMem: true });
+
+      expect(fs.readFileSync(configPath, 'utf8')).toBe(HANDWRITTEN);
+    });
+
+    it('preserves the surrounding file when updating an existing AutoMem entry', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      fs.writeFileSync(configPath, HANDWRITTEN);
+
+      upsertGrokMemoryServer(configPath, buildGrokAutoMemServerEntry('https://first.example'), {
+        quiet: true,
+      });
+      const afterFirst = fs.readFileSync(configPath, 'utf8');
+
+      upsertGrokMemoryServer(
+        configPath,
+        buildGrokAutoMemServerEntry('https://second.example', 'sk-new'),
+        { quiet: true }
+      );
+      const afterSecond = fs.readFileSync(configPath, 'utf8');
+
+      expect(withoutMemoryTable(afterSecond)).toBe(withoutMemoryTable(afterFirst));
+      const parsed = parseToml(afterSecond) as {
+        mcp_servers: { memory: { env: Record<string, string> } };
+      };
+      expect(parsed.mcp_servers.memory.env.AUTOMEM_API_URL).toBe('https://second.example');
+      expect(parsed.mcp_servers.memory.env.AUTOMEM_API_KEY).toBe('sk-new');
+    });
+
+    it('falls back to a full rewrite when the entry is an inline table', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      // Dotted/inline forms have no `[mcp_servers.memory]` header to splice.
+      fs.writeFileSync(
+        configPath,
+        ['# leading comment', 'mcp_servers.memory = { command = "npx", enabled = true }', ''].join(
+          '\n'
+        )
+      );
+
+      const result = upsertGrokMemoryServer(
+        configPath,
+        buildGrokAutoMemServerEntry('https://automem.example'),
+        { quiet: true }
+      );
+
+      expect(result.changed).toBe(true);
+      const parsed = parseToml(fs.readFileSync(configPath, 'utf8')) as {
+        mcp_servers: { memory: { env: Record<string, string> } };
+      };
+      expect(parsed.mcp_servers.memory.env.AUTOMEM_API_URL).toBe('https://automem.example');
+    });
   });
 
   describe('removeGrokMemoryServer', () => {

--- a/src/cli/grok-config.test.ts
+++ b/src/cli/grok-config.test.ts
@@ -276,6 +276,76 @@ describe('grok-config', () => {
       expect(parsed.mcp_servers.memory.env.AUTOMEM_API_KEY).toBe('sk-new');
     });
 
+    // The fixtures above all end up with the AutoMem table at EOF, where trailing-newline
+    // normalization hides seam problems. A table with neighbours on both sides is the
+    // shape a pre-existing install actually has.
+    it('round-trips an AutoMem table that sits between two other tables', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      const original = [
+        '# top comment',
+        '[cli]',
+        'installer = "internal"',
+        '',
+        '[mcp_servers.memory]',
+        'command = "npx"',
+        'args = [ "-y", "@verygoodplugins/mcp-automem" ]',
+        'enabled = true',
+        '',
+        '[mcp_servers.memory.env]',
+        'AUTOMEM_API_URL = "https://old.example"',
+        '',
+        '[mcp_servers.other]',
+        'command = "bash"',
+        '',
+      ].join('\n');
+      fs.writeFileSync(configPath, original);
+
+      // Updating in place must not disturb the neighbours...
+      upsertGrokMemoryServer(configPath, buildGrokAutoMemServerEntry('https://new.example'), {
+        quiet: true,
+      });
+      const updated = fs.readFileSync(configPath, 'utf8');
+      expect(updated).toContain('# top comment');
+      expect(updated).toContain('[mcp_servers.other]');
+      expect(updated).toContain('https://new.example');
+
+      // ...and removing it must close the gap rather than leave a growing run of blanks.
+      removeGrokMemoryServer(configPath, { quiet: true, onlyIfAutoMem: true });
+      expect(fs.readFileSync(configPath, 'utf8')).toBe(
+        [
+          '# top comment',
+          '[cli]',
+          'installer = "internal"',
+          '',
+          '[mcp_servers.other]',
+          'command = "bash"',
+          '',
+        ].join('\n')
+      );
+    });
+
+    it('does not accumulate blank lines across repeated install/uninstall cycles', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      const original = [
+        '[cli]',
+        'installer = "internal"',
+        '',
+        '[mcp_servers.other]',
+        'command = "bash"',
+        '',
+      ].join('\n');
+      fs.writeFileSync(configPath, original);
+
+      for (let i = 0; i < 3; i += 1) {
+        upsertGrokMemoryServer(configPath, buildGrokAutoMemServerEntry('https://automem.example'), {
+          quiet: true,
+        });
+        removeGrokMemoryServer(configPath, { quiet: true, onlyIfAutoMem: true });
+      }
+
+      expect(fs.readFileSync(configPath, 'utf8')).toBe(original);
+    });
+
     it('falls back to a full rewrite when the entry is an inline table', () => {
       const configPath = path.join(tmpDir, 'config.toml');
       // Dotted/inline forms have no `[mcp_servers.memory]` header to splice.

--- a/src/cli/grok-config.test.ts
+++ b/src/cli/grok-config.test.ts
@@ -172,6 +172,82 @@ describe('grok-config', () => {
       expect(fs.readFileSync(configPath, 'utf8')).toBe(before);
     });
 
+    it('refuses to overwrite a non-AutoMem server named memory', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      const original = [
+        '[mcp_servers.memory]',
+        'command = "some-other-memory-server"',
+        'args = ["--serve"]',
+        '',
+      ].join('\n');
+      fs.writeFileSync(configPath, original);
+
+      expect(() =>
+        upsertGrokMemoryServer(configPath, buildGrokAutoMemServerEntry('https://automem.example'), {
+          quiet: true,
+        })
+      ).toThrow(/Refusing to overwrite/);
+
+      // The user's server survives untouched.
+      expect(fs.readFileSync(configPath, 'utf8')).toBe(original);
+    });
+
+    it('surfaces the collision during a dry run rather than at write time', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      fs.writeFileSync(
+        configPath,
+        ['[mcp_servers.memory]', 'command = "some-other-memory-server"', ''].join('\n')
+      );
+
+      expect(() =>
+        upsertGrokMemoryServer(configPath, buildGrokAutoMemServerEntry('https://automem.example'), {
+          dryRun: true,
+          quiet: true,
+        })
+      ).toThrow(/Refusing to overwrite/);
+    });
+
+    it('restricts the config to the owner when it carries an API key', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      upsertGrokMemoryServer(
+        configPath,
+        buildGrokAutoMemServerEntry('https://automem.example', 'sk-secret'),
+        { quiet: true }
+      );
+      expect(fs.statSync(configPath).mode & 0o777).toBe(0o600);
+    });
+
+    it('tightens an existing world-readable config and its backup once a key is added', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      // Pre-existing config written without a key, at default permissions.
+      upsertGrokMemoryServer(configPath, buildGrokAutoMemServerEntry('https://automem.example'), {
+        quiet: true,
+      });
+      fs.chmodSync(configPath, 0o644);
+
+      upsertGrokMemoryServer(
+        configPath,
+        buildGrokAutoMemServerEntry('https://automem.example', 'sk-secret'),
+        { quiet: true }
+      );
+
+      expect(fs.statSync(configPath).mode & 0o777).toBe(0o600);
+      // The backup holds the same file; if it were left 0644 the tightening is moot.
+      const backups = fs.readdirSync(tmpDir).filter((f) => f.startsWith('config.toml.bak'));
+      expect(backups.length).toBeGreaterThan(0);
+      for (const backup of backups) {
+        expect(fs.statSync(path.join(tmpDir, backup)).mode & 0o777).toBe(0o600);
+      }
+    });
+
+    it('leaves permissions alone when no API key is written', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      upsertGrokMemoryServer(configPath, buildGrokAutoMemServerEntry('https://automem.example'), {
+        quiet: true,
+      });
+      expect(fs.statSync(configPath).mode & 0o777).not.toBe(0o600);
+    });
+
     it('fails the dry run on malformed TOML instead of deferring to the real run', () => {
       const configPath = path.join(tmpDir, 'config.toml');
       fs.writeFileSync(configPath, 'mcp_servers = {memory = \n');
@@ -348,12 +424,16 @@ describe('grok-config', () => {
 
     it('falls back to a full rewrite when the entry is an inline table', () => {
       const configPath = path.join(tmpDir, 'config.toml');
-      // Dotted/inline forms have no `[mcp_servers.memory]` header to splice.
+      // Dotted/inline forms have no `[mcp_servers.memory]` header to splice. The entry
+      // is AutoMem's own (hand-written in a form the installer does not emit), so this
+      // exercises the rewrite fallback rather than the non-AutoMem refusal above.
       fs.writeFileSync(
         configPath,
-        ['# leading comment', 'mcp_servers.memory = { command = "npx", enabled = true }', ''].join(
-          '\n'
-        )
+        [
+          '# leading comment',
+          'mcp_servers.memory = { command = "npx", args = ["-y", "@verygoodplugins/mcp-automem"] }',
+          '',
+        ].join('\n')
       );
 
       const result = upsertGrokMemoryServer(

--- a/src/cli/grok-config.ts
+++ b/src/cli/grok-config.ts
@@ -313,6 +313,24 @@ export function removeGrokMemoryServer(configPath: string, opts: UpsertOptions =
   return true;
 }
 
+/**
+ * Grok's top-level `disabled_mcp_servers` list wins over a server's own `enabled`
+ * flag, so a config can carry a perfectly valid `[mcp_servers.memory]` that Grok
+ * never loads. Returns the list so callers can warn instead of reporting success.
+ */
+export function readDisabledMcpServers(configPath: string): string[] {
+  if (!fs.existsSync(configPath)) return [];
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = parseGrokDocument(fs.readFileSync(configPath, 'utf8'), configPath);
+  } catch {
+    return [];
+  }
+  const disabled = parsed.disabled_mcp_servers;
+  if (!Array.isArray(disabled)) return [];
+  return disabled.filter((name): name is string => typeof name === 'string');
+}
+
 export interface GrokCredentials {
   endpoint?: string;
   apiKey?: string;

--- a/src/cli/grok-config.ts
+++ b/src/cli/grok-config.ts
@@ -81,6 +81,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
+/** Best-effort 0600. Windows and exotic filesystems have no POSIX mode to set. */
+function restrictToOwner(filePath: string): void {
+  try {
+    fs.chmodSync(filePath, 0o600);
+  } catch {
+    // Non-POSIX platform; nothing to tighten.
+  }
+}
+
 function isAutoMemMcpEntry(entry: unknown): boolean {
   if (!isRecord(entry)) return false;
   const haystack = JSON.stringify({
@@ -224,6 +233,18 @@ export function upsertGrokMemoryServer(
     : {};
   const existing = servers[GROK_MCP_SERVER_NAME] ?? null;
 
+  // `memory` is a plausible name for someone else's MCP server. Uninstall already
+  // refuses to touch a non-AutoMem entry (`onlyIfAutoMem`); install must be just as
+  // careful, or it silently destroys a working integration. Checked before the
+  // dry-run branch so a preview surfaces the collision too.
+  if (existing !== null && !isAutoMemMcpEntry(existing)) {
+    throw new Error(
+      `Refusing to overwrite mcp_servers.${GROK_MCP_SERVER_NAME} in ${configPath}: ` +
+        'it points at a server that is not AutoMem. Rename or remove that entry, ' +
+        'then re-run — AutoMem will not replace it.'
+    );
+  }
+
   if (deepEqual(existing, entry)) {
     log(
       `✓ Unchanged: ${path.basename(configPath)} (mcp_servers.${GROK_MCP_SERVER_NAME})`,
@@ -258,14 +279,27 @@ export function upsertGrokMemoryServer(
     );
   }
   const serialized = spliced ?? stringifyToml(doc);
+  // Once the entry carries AUTOMEM_API_KEY the config is a secret file. Writing it
+  // under a typical 022 umask would leave it 0644 and readable by other local
+  // accounts, so match the 0600 treatment host-toolkit gives secret writes — and
+  // apply it to the backup, which holds the same key.
+  const holdsSecret = Boolean(entry.env.AUTOMEM_API_KEY);
 
   fs.mkdirSync(path.dirname(configPath), { recursive: true });
   if (existed) {
     const backup = backupPath(configPath);
     fs.copyFileSync(configPath, backup);
+    if (holdsSecret) restrictToOwner(backup);
     log(`📦 Backup created: ${backup}`, opts.quiet);
   }
-  fs.writeFileSync(configPath, serialized, 'utf8');
+  fs.writeFileSync(
+    configPath,
+    serialized,
+    holdsSecret ? { encoding: 'utf8', mode: 0o600 } : 'utf8'
+  );
+  // writeFileSync's mode only applies when it creates the file, so an existing
+  // 0644 config keeps its permissions without this.
+  if (holdsSecret) restrictToOwner(configPath);
   log(`✅ ${existed ? 'Updated' : 'Created'}: ${path.basename(configPath)}`, opts.quiet);
   return { method: 'toml', changed: true };
 }

--- a/src/cli/grok-config.ts
+++ b/src/cli/grok-config.ts
@@ -90,6 +90,21 @@ function restrictToOwner(filePath: string): void {
   }
 }
 
+/**
+ * Whether an mcp_servers entry carries an API key.
+ *
+ * Secrecy is a property of the *file*, not of the entry being written, so every path
+ * that touches config.toml has to consider both the incoming entry and whatever is
+ * already on disk. Two ways to get this wrong, both real: a file that already holds a
+ * key and is not being changed still needs tightening, and a backup taken while
+ * removing or replacing a key still contains it.
+ */
+function entryHasApiKey(entry: unknown): boolean {
+  if (!isRecord(entry)) return false;
+  const env = entry.env;
+  return isRecord(env) && typeof env.AUTOMEM_API_KEY === 'string' && env.AUTOMEM_API_KEY.length > 0;
+}
+
 function isAutoMemMcpEntry(entry: unknown): boolean {
   if (!isRecord(entry)) return false;
   const haystack = JSON.stringify({
@@ -245,7 +260,14 @@ export function upsertGrokMemoryServer(
     );
   }
 
+  // The file is secret-bearing if either side holds a key: the entry being written, or
+  // what is already on disk (which the backup below will also contain).
+  const holdsSecret = entryHasApiKey(existing) || entryHasApiKey(entry);
+
   if (deepEqual(existing, entry)) {
+    // Nothing to write, but a hand-written config carrying a key can still be 0644 —
+    // returning early used to leave it that way.
+    if (holdsSecret && !opts.dryRun) restrictToOwner(configPath);
     log(
       `✓ Unchanged: ${path.basename(configPath)} (mcp_servers.${GROK_MCP_SERVER_NAME})`,
       opts.quiet
@@ -279,11 +301,11 @@ export function upsertGrokMemoryServer(
     );
   }
   const serialized = spliced ?? stringifyToml(doc);
-  // Once the entry carries AUTOMEM_API_KEY the config is a secret file. Writing it
-  // under a typical 022 umask would leave it 0644 and readable by other local
-  // accounts, so match the 0600 treatment host-toolkit gives secret writes — and
-  // apply it to the backup, which holds the same key.
-  const holdsSecret = Boolean(entry.env.AUTOMEM_API_KEY);
+  // A config carrying AUTOMEM_API_KEY is a secret file. Writing it under a typical 022
+  // umask would leave it 0644 and readable by other local accounts, so match the 0600
+  // treatment host-toolkit gives secret writes. `holdsSecret` covers the outgoing key
+  // too: switching endpoints drops the key from the new entry, but `copyFileSync`
+  // preserves the source mode, so the backup would keep the old credential world-readable.
 
   fs.mkdirSync(path.dirname(configPath), { recursive: true });
   if (existed) {
@@ -352,6 +374,9 @@ export function removeGrokMemoryServer(configPath: string, opts: UpsertOptions =
 
   const backup = backupPath(configPath);
   fs.copyFileSync(configPath, backup);
+  // Uninstalling a keyed entry leaves the credential in the backup, and copyFileSync
+  // preserves the source's mode — so a 0644 config yields a 0644 copy of the secret.
+  if (entryHasApiKey(entry)) restrictToOwner(backup);
   fs.writeFileSync(configPath, spliced ?? stringifyToml(doc), 'utf8');
   log(
     `🗑️  Removed mcp_servers.${GROK_MCP_SERVER_NAME} from ${path.basename(configPath)}`,

--- a/src/cli/grok-config.ts
+++ b/src/cli/grok-config.ts
@@ -108,6 +108,88 @@ function parseGrokDocument(raw: string, configPath: string): Record<string, unkn
   }
 }
 
+const MEMORY_TABLE_HEADER = new RegExp(`^\\s*\\[mcp_servers\\.${GROK_MCP_SERVER_NAME}\\]\\s*$`);
+const MEMORY_SUBTABLE_HEADER = new RegExp(
+  `^\\s*\\[mcp_servers\\.${GROK_MCP_SERVER_NAME}\\.[^\\]]+\\]\\s*$`
+);
+const ANY_TABLE_HEADER = /^\s*\[/;
+
+/**
+ * Byte range of the `[mcp_servers.memory]` table and its sub-tables, as line indices
+ * into `lines`. Null when the entry is absent or expressed some other way (inline
+ * table, dotted keys) — callers fall back to a whole-document rewrite.
+ */
+function locateMemoryTableLines(lines: string[]): { start: number; end: number } | null {
+  const start = lines.findIndex((line) => MEMORY_TABLE_HEADER.test(line));
+  if (start === -1) return null;
+
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i += 1) {
+    if (!ANY_TABLE_HEADER.test(lines[i])) continue;
+    // `[mcp_servers.memory.env]` and friends belong to the block we are replacing.
+    if (MEMORY_SUBTABLE_HEADER.test(lines[i])) continue;
+    end = i;
+    break;
+  }
+
+  // Trim trailing blank lines back to the owning block so replacement doesn't
+  // accumulate or swallow the separator before the next table.
+  while (end > start + 1 && lines[end - 1].trim() === '') end -= 1;
+  return { start, end };
+}
+
+/** Serialize just the AutoMem entry, as its own `[mcp_servers.memory]` table block. */
+function renderMemoryTableBlock(entry: GrokAutoMemServerEntry): string[] {
+  return stringifyToml({ mcp_servers: { [GROK_MCP_SERVER_NAME]: entry } })
+    .replace(/\n+$/, '')
+    .split('\n');
+}
+
+/**
+ * Rewrite `configPath` by splicing only the AutoMem table, leaving every other byte
+ * of the user's config untouched.
+ *
+ * Grok configs are hand-maintained and carry things a parse/stringify round-trip
+ * destroys: comments, multi-line `"""` subagent instructions (which collapse into
+ * escaped one-liners), and array formatting. So the parsed document is used only to
+ * decide *what* to write; the file itself is edited as text.
+ *
+ * Returns null when the splice can't be verified, so the caller can fall back.
+ */
+function spliceMemoryTable(
+  raw: string,
+  expected: Record<string, unknown>,
+  next: string[]
+): string | null {
+  const lines = raw.split('\n');
+  const located = locateMemoryTableLines(lines);
+
+  let spliced: string[];
+  if (located) {
+    spliced = [...lines.slice(0, located.start), ...next, ...lines.slice(located.end)];
+  } else {
+    // No existing table: append, keeping exactly one blank line as separator.
+    const head = [...lines];
+    while (head.length > 0 && head[head.length - 1].trim() === '') head.pop();
+    spliced = head.length > 0 ? [...head, '', ...next] : [...next];
+  }
+
+  const candidate = `${spliced.join('\n').replace(/\n+$/, '')}\n`;
+
+  // Verify by round-tripping: the spliced text must parse, and must parse to exactly
+  // the document we intended. This is what makes the line-scanning above safe — a
+  // table header matched inside a multi-line string would fail this check, not corrupt
+  // the user's file.
+  try {
+    const reparsed = parseToml(candidate) as unknown;
+    if (!isRecord(reparsed)) return null;
+    if (!deepEqual(reparsed, expected)) return null;
+    return candidate;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Merge AutoMem into ~/.grok/config.toml under `mcp_servers.memory`, preserving
  * unrelated servers and top-level keys. Returns whether the file changed.
@@ -117,13 +199,10 @@ export function upsertGrokMemoryServer(
   entry: GrokAutoMemServerEntry,
   opts: UpsertOptions = {}
 ): UpsertResult {
-  if (opts.dryRun) {
-    log(`[DRY RUN] Would upsert mcp_servers.${GROK_MCP_SERVER_NAME} in: ${configPath}`, opts.quiet);
-    return { method: 'dry-run', changed: false };
-  }
-
   const existed = fs.existsSync(configPath);
   const raw = existed ? fs.readFileSync(configPath, 'utf8') : '';
+  // Parse even on dry runs: it is the only way to report add-vs-update-vs-unchanged
+  // honestly, and a malformed config should fail the preview, not just the real run.
   const doc = parseGrokDocument(raw, configPath);
 
   const servers = isRecord(doc.mcp_servers)
@@ -136,12 +215,35 @@ export function upsertGrokMemoryServer(
       `✓ Unchanged: ${path.basename(configPath)} (mcp_servers.${GROK_MCP_SERVER_NAME})`,
       opts.quiet
     );
-    return { method: 'toml', changed: false };
+    return { method: opts.dryRun ? 'dry-run' : 'toml', changed: false };
   }
 
   servers[GROK_MCP_SERVER_NAME] = entry;
   doc.mcp_servers = servers;
-  const serialized = stringifyToml(doc);
+
+  if (opts.dryRun) {
+    const verb = existing ? 'update' : 'add';
+    log(
+      `[DRY RUN] Would ${verb} mcp_servers.${GROK_MCP_SERVER_NAME} in: ${configPath}`,
+      opts.quiet
+    );
+    return { method: 'dry-run', changed: false };
+  }
+
+  const spliced = existed ? spliceMemoryTable(raw, doc, renderMemoryTableBlock(entry)) : null;
+  if (existed && !spliced) {
+    // Fall back loudly: the rewrite is correct but reformats the whole document,
+    // dropping comments and collapsing multi-line strings.
+    log(
+      `⚠️  Could not edit mcp_servers.${GROK_MCP_SERVER_NAME} in place in ${path.basename(configPath)} — rewriting the whole file.`,
+      opts.quiet
+    );
+    log(
+      '   Comments and multi-line string formatting will be lost (a backup is kept).',
+      opts.quiet
+    );
+  }
+  const serialized = spliced ?? stringifyToml(doc);
 
   fs.mkdirSync(path.dirname(configPath), { recursive: true });
   if (existed) {
@@ -186,9 +288,23 @@ export function removeGrokMemoryServer(configPath: string, opts: UpsertOptions =
     doc.mcp_servers = servers;
   }
 
+  // Splice out just the AutoMem table so the rest of the config keeps its comments
+  // and formatting; fall back to a full rewrite only when that can't be verified.
+  const spliced = spliceMemoryTable(raw, doc, []);
+  if (!spliced) {
+    log(
+      `⚠️  Could not remove mcp_servers.${GROK_MCP_SERVER_NAME} in place in ${path.basename(configPath)} — rewriting the whole file.`,
+      opts.quiet
+    );
+    log(
+      '   Comments and multi-line string formatting will be lost (a backup is kept).',
+      opts.quiet
+    );
+  }
+
   const backup = backupPath(configPath);
   fs.copyFileSync(configPath, backup);
-  fs.writeFileSync(configPath, stringifyToml(doc), 'utf8');
+  fs.writeFileSync(configPath, spliced ?? stringifyToml(doc), 'utf8');
   log(
     `🗑️  Removed mcp_servers.${GROK_MCP_SERVER_NAME} from ${path.basename(configPath)}`,
     opts.quiet

--- a/src/cli/grok-config.ts
+++ b/src/cli/grok-config.ts
@@ -166,7 +166,21 @@ function spliceMemoryTable(
 
   let spliced: string[];
   if (located) {
-    spliced = [...lines.slice(0, located.start), ...next, ...lines.slice(located.end)];
+    const before = lines.slice(0, located.start);
+    const after = lines.slice(located.end);
+    // Removing a table mid-file leaves the blank line that preceded it next to the
+    // one that followed it. TOML ignores the extra blank, so the verify below would
+    // accept it and every install/uninstall cycle would add another. Collapse the seam.
+    if (
+      next.length === 0 &&
+      before.length > 0 &&
+      after.length > 0 &&
+      before[before.length - 1].trim() === '' &&
+      after[0].trim() === ''
+    ) {
+      before.pop();
+    }
+    spliced = [...before, ...next, ...after];
   } else {
     // No existing table: append, keeping exactly one blank line as separator.
     const head = [...lines];

--- a/src/cli/grok-config.ts
+++ b/src/cli/grok-config.ts
@@ -1,0 +1,236 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { parse as parseToml, stringify as stringifyToml } from 'smol-toml';
+import { backupPath, log } from './host-toolkit.js';
+
+export const GROK_MCP_SERVER_NAME = 'memory';
+
+export interface GrokPaths {
+  home: string;
+  configPath: string;
+  agentsPath: string;
+}
+
+export interface GrokAutoMemServerEntry {
+  command: string;
+  args: string[];
+  enabled: boolean;
+  env: Record<string, string>;
+}
+
+export interface UpsertOptions {
+  dryRun?: boolean;
+  quiet?: boolean;
+  onlyIfAutoMem?: boolean;
+}
+
+export type UpsertMethod = 'toml' | 'dry-run';
+
+export interface UpsertResult {
+  method: UpsertMethod;
+  changed: boolean;
+}
+
+export function resolveGrokPaths(opts: { dir?: string } = {}): GrokPaths {
+  const home = opts.dir ?? process.env.GROK_HOME ?? path.join(os.homedir(), '.grok');
+  return {
+    home,
+    configPath: path.join(home, 'config.toml'),
+    agentsPath: path.join(home, 'AGENTS.md'),
+  };
+}
+
+export function buildGrokAutoMemServerEntry(
+  endpoint: string,
+  apiKey?: string
+): GrokAutoMemServerEntry {
+  const env: Record<string, string> = {
+    AUTOMEM_API_URL: endpoint,
+    AUTOMEM_PROCESS_TAG: 'grok:memory',
+  };
+  if (apiKey) {
+    env.AUTOMEM_API_KEY = apiKey;
+  }
+  return {
+    command: 'npx',
+    args: ['-y', '@verygoodplugins/mcp-automem'],
+    enabled: true,
+    env,
+  };
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return false;
+  if (typeof a !== 'object') return false;
+  const ka = Object.keys(a as Record<string, unknown>).sort();
+  const kb = Object.keys(b as Record<string, unknown>).sort();
+  if (ka.length !== kb.length) return false;
+  for (let i = 0; i < ka.length; i += 1) {
+    if (ka[i] !== kb[i]) return false;
+    if (!deepEqual((a as Record<string, unknown>)[ka[i]], (b as Record<string, unknown>)[kb[i]])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isAutoMemMcpEntry(entry: unknown): boolean {
+  if (!isRecord(entry)) return false;
+  const haystack = JSON.stringify({
+    command: entry.command,
+    args: entry.args,
+    env: entry.env,
+  });
+  return haystack.includes('@verygoodplugins/mcp-automem') || haystack.includes('mcp-automem');
+}
+
+function parseGrokDocument(raw: string, configPath: string): Record<string, unknown> {
+  try {
+    const parsed = parseToml(raw || '') as unknown;
+    if (parsed === null || parsed === undefined) return {};
+    if (!isRecord(parsed)) {
+      throw new Error('root value must be a table');
+    }
+    return parsed;
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Failed to parse Grok config at ${configPath}: ${reason}. Fix the TOML syntax and re-run.`,
+      { cause: error }
+    );
+  }
+}
+
+/**
+ * Merge AutoMem into ~/.grok/config.toml under `mcp_servers.memory`, preserving
+ * unrelated servers and top-level keys. Returns whether the file changed.
+ */
+export function upsertGrokMemoryServer(
+  configPath: string,
+  entry: GrokAutoMemServerEntry,
+  opts: UpsertOptions = {}
+): UpsertResult {
+  if (opts.dryRun) {
+    log(`[DRY RUN] Would upsert mcp_servers.${GROK_MCP_SERVER_NAME} in: ${configPath}`, opts.quiet);
+    return { method: 'dry-run', changed: false };
+  }
+
+  const existed = fs.existsSync(configPath);
+  const raw = existed ? fs.readFileSync(configPath, 'utf8') : '';
+  const doc = parseGrokDocument(raw, configPath);
+
+  const servers = isRecord(doc.mcp_servers)
+    ? { ...(doc.mcp_servers as Record<string, unknown>) }
+    : {};
+  const existing = servers[GROK_MCP_SERVER_NAME] ?? null;
+
+  if (deepEqual(existing, entry)) {
+    log(
+      `✓ Unchanged: ${path.basename(configPath)} (mcp_servers.${GROK_MCP_SERVER_NAME})`,
+      opts.quiet
+    );
+    return { method: 'toml', changed: false };
+  }
+
+  servers[GROK_MCP_SERVER_NAME] = entry;
+  doc.mcp_servers = servers;
+  const serialized = stringifyToml(doc);
+
+  fs.mkdirSync(path.dirname(configPath), { recursive: true });
+  if (existed) {
+    const backup = backupPath(configPath);
+    fs.copyFileSync(configPath, backup);
+    log(`📦 Backup created: ${backup}`, opts.quiet);
+  }
+  fs.writeFileSync(configPath, serialized, 'utf8');
+  log(`✅ ${existed ? 'Updated' : 'Created'}: ${path.basename(configPath)}`, opts.quiet);
+  return { method: 'toml', changed: true };
+}
+
+/**
+ * Remove `mcp_servers.memory` when it points at AutoMem (or always when
+ * onlyIfAutoMem is false). Returns true if a change was written.
+ */
+export function removeGrokMemoryServer(configPath: string, opts: UpsertOptions = {}): boolean {
+  if (!fs.existsSync(configPath)) return false;
+  const raw = fs.readFileSync(configPath, 'utf8');
+  const doc = parseGrokDocument(raw, configPath);
+  if (!isRecord(doc.mcp_servers)) return false;
+  if (!(GROK_MCP_SERVER_NAME in doc.mcp_servers)) return false;
+
+  const entry = (doc.mcp_servers as Record<string, unknown>)[GROK_MCP_SERVER_NAME];
+  if (opts.onlyIfAutoMem && !isAutoMemMcpEntry(entry)) {
+    return false;
+  }
+
+  if (opts.dryRun) {
+    log(
+      `[DRY RUN] Would remove mcp_servers.${GROK_MCP_SERVER_NAME} from: ${configPath}`,
+      opts.quiet
+    );
+    return false;
+  }
+
+  const servers = { ...(doc.mcp_servers as Record<string, unknown>) };
+  delete servers[GROK_MCP_SERVER_NAME];
+  if (Object.keys(servers).length === 0) {
+    delete doc.mcp_servers;
+  } else {
+    doc.mcp_servers = servers;
+  }
+
+  const backup = backupPath(configPath);
+  fs.copyFileSync(configPath, backup);
+  fs.writeFileSync(configPath, stringifyToml(doc), 'utf8');
+  log(
+    `🗑️  Removed mcp_servers.${GROK_MCP_SERVER_NAME} from ${path.basename(configPath)}`,
+    opts.quiet
+  );
+  log(`   Backup: ${backup}`, opts.quiet);
+  return true;
+}
+
+export interface GrokCredentials {
+  endpoint?: string;
+  apiKey?: string;
+}
+
+function normalizeCred(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Read AutoMem credentials already installed for Grok so a re-run with no
+ * explicit flags preserves them rather than overwriting with defaults.
+ */
+export function readExistingGrokCredentials(configPath: string): GrokCredentials {
+  if (!fs.existsSync(configPath)) return {};
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = parseGrokDocument(fs.readFileSync(configPath, 'utf8'), configPath);
+  } catch {
+    return {};
+  }
+  const servers = isRecord(parsed.mcp_servers)
+    ? (parsed.mcp_servers as Record<string, unknown>)
+    : null;
+  const entry =
+    servers && isRecord(servers[GROK_MCP_SERVER_NAME])
+      ? (servers[GROK_MCP_SERVER_NAME] as Record<string, unknown>)
+      : null;
+  const env = entry && isRecord(entry.env) ? (entry.env as Record<string, unknown>) : null;
+  if (!env) return {};
+  return {
+    endpoint: normalizeCred(env.AUTOMEM_API_URL) ?? normalizeCred(env.AUTOMEM_ENDPOINT),
+    apiKey: normalizeCred(env.AUTOMEM_API_KEY),
+  };
+}

--- a/src/cli/grok.test.ts
+++ b/src/cli/grok.test.ts
@@ -134,7 +134,34 @@ describe('grok setup', () => {
 
     const output = lines.join('\n');
     expect(output).toContain('listed in disabled_mcp_servers');
-    expect(output).toContain('Grok will not load it');
+    expect(output).toContain('Grok may ignore the server entry');
+  });
+
+  it('surfaces the disabled_mcp_servers warning during a dry run too', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'config.toml'),
+      ['disabled_mcp_servers = ["memory"]', ''].join('\n')
+    );
+
+    const lines: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => void lines.push(args.join(' '));
+    try {
+      await applyGrokSetup({
+        endpoint: 'https://automem.example.test',
+        dryRun: true,
+        projectName: 'demo',
+      });
+    } finally {
+      console.log = originalLog;
+    }
+
+    const output = lines.join('\n');
+    // The diagnostic is about existing state, so a preview must still report it...
+    expect(output).toContain('listed in disabled_mcp_servers');
+    // ...without claiming any work happened.
+    expect(output).toContain('Dry run — no files were changed.');
+    expect(output).not.toContain('setup complete');
   });
 
   it('stays quiet about disabled_mcp_servers when memory is not in the list', async () => {

--- a/src/cli/grok.test.ts
+++ b/src/cli/grok.test.ts
@@ -93,4 +93,65 @@ describe('grok setup', () => {
     expect(fs.existsSync(path.join(tmpDir, 'config.toml'))).toBe(false);
     expect(fs.existsSync(path.join(tmpDir, 'AGENTS.md'))).toBe(false);
   });
+
+  it('dry-run does not claim files were written', async () => {
+    const lines: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => void lines.push(args.join(' '));
+    try {
+      await applyGrokSetup({
+        endpoint: 'https://automem.example.test',
+        dryRun: true,
+        projectName: 'demo',
+      });
+    } finally {
+      console.log = originalLog;
+    }
+
+    const output = lines.join('\n');
+    expect(output).toContain('[DRY RUN]');
+    expect(output).toContain('Dry run — no files were changed.');
+    // The success report belongs to real runs only.
+    expect(output).not.toContain('written to');
+    expect(output).not.toContain('rules installed in');
+    expect(output).not.toContain('setup complete');
+  });
+
+  it('warns when disabled_mcp_servers would keep Grok from loading AutoMem', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'config.toml'),
+      ['disabled_mcp_servers = ["memory", "wordpress"]', ''].join('\n')
+    );
+
+    const lines: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => void lines.push(args.join(' '));
+    try {
+      await applyGrokSetup({ endpoint: 'https://automem.example.test', projectName: 'demo' });
+    } finally {
+      console.log = originalLog;
+    }
+
+    const output = lines.join('\n');
+    expect(output).toContain('listed in disabled_mcp_servers');
+    expect(output).toContain('Grok will not load it');
+  });
+
+  it('stays quiet about disabled_mcp_servers when memory is not in the list', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'config.toml'),
+      ['disabled_mcp_servers = ["wordpress"]', ''].join('\n')
+    );
+
+    const lines: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => void lines.push(args.join(' '));
+    try {
+      await applyGrokSetup({ endpoint: 'https://automem.example.test', projectName: 'demo' });
+    } finally {
+      console.log = originalLog;
+    }
+
+    expect(lines.join('\n')).not.toContain('disabled_mcp_servers');
+  });
 });

--- a/src/cli/grok.test.ts
+++ b/src/cli/grok.test.ts
@@ -169,6 +169,62 @@ describe('grok setup', () => {
     expect(fs.readFileSync(realRules, 'utf8')).not.toContain('tags: ["some-project"]');
   });
 
+  it('does not hand a shell-exported key to a different endpoint', async () => {
+    // The shell's key belongs to the shell's endpoint; --endpoint elsewhere must not
+    // disclose it to that host.
+    process.env.AUTOMEM_API_URL = 'https://shell.example.test';
+    process.env.AUTOMEM_API_KEY = 'sk-shell-host';
+
+    await applyGrokSetup({ endpoint: 'https://elsewhere.example.test', quiet: true });
+
+    const parsed = parseToml(fs.readFileSync(path.join(tmpDir, 'config.toml'), 'utf8')) as {
+      mcp_servers: { memory: { env: Record<string, string> } };
+    };
+    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_URL).toBe('https://elsewhere.example.test');
+    expect(parsed.mcp_servers.memory.env).not.toHaveProperty('AUTOMEM_API_KEY');
+  });
+
+  it('uses a shell-exported key when it belongs to the chosen endpoint', async () => {
+    process.env.AUTOMEM_API_URL = 'https://shell.example.test';
+    process.env.AUTOMEM_API_KEY = 'sk-shell-host';
+
+    await applyGrokSetup({ endpoint: 'https://shell.example.test', quiet: true });
+
+    const parsed = parseToml(fs.readFileSync(path.join(tmpDir, 'config.toml'), 'utf8')) as {
+      mcp_servers: { memory: { env: Record<string, string> } };
+    };
+    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_KEY).toBe('sk-shell-host');
+  });
+
+  it('uses an unbound shell key when no endpoint is exported', async () => {
+    delete process.env.AUTOMEM_API_URL;
+    process.env.AUTOMEM_API_KEY = 'sk-unbound';
+
+    await applyGrokSetup({ endpoint: 'https://anywhere.example.test', quiet: true });
+
+    const parsed = parseToml(fs.readFileSync(path.join(tmpDir, 'config.toml'), 'utf8')) as {
+      mcp_servers: { memory: { env: Record<string, string> } };
+    };
+    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_KEY).toBe('sk-unbound');
+  });
+
+  it('refuses to write rules over the Grok config file', async () => {
+    const configPath = path.join(tmpDir, 'config.toml');
+    await applyGrokSetup({ endpoint: 'https://automem.example.test', quiet: true });
+    const before = fs.readFileSync(configPath, 'utf8');
+
+    await expect(
+      applyGrokSetup({
+        endpoint: 'https://automem.example.test',
+        quiet: true,
+        rulesPath: configPath,
+      })
+    ).rejects.toThrow(/that is the Grok config file/);
+
+    // The registration survives rather than being overwritten with Markdown.
+    expect(fs.readFileSync(configPath, 'utf8')).toBe(before);
+  });
+
   it('keeps the stored API key when the endpoint is unchanged', async () => {
     await applyGrokSetup({
       endpoint: 'https://same.example.test',

--- a/src/cli/grok.test.ts
+++ b/src/cli/grok.test.ts
@@ -134,6 +134,41 @@ describe('grok setup', () => {
     expect(parsed.mcp_servers.memory.env).not.toHaveProperty('AUTOMEM_API_KEY');
   });
 
+  it('treats a trailing slash as the same endpoint and keeps the key', async () => {
+    // AutoMemClient strips the trailing slash, so these address the same server;
+    // dropping the key here would leave every request unauthenticated.
+    await applyGrokSetup({
+      endpoint: 'https://same.example.test',
+      apiKey: 'sk-keep-me',
+      quiet: true,
+    });
+    await applyGrokSetup({ endpoint: 'https://same.example.test/', quiet: true });
+
+    const parsed = parseToml(fs.readFileSync(path.join(tmpDir, 'config.toml'), 'utf8')) as {
+      mcp_servers: { memory: { env: Record<string, string> } };
+    };
+    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_KEY).toBe('sk-keep-me');
+  });
+
+  it('keeps the global rules project-agnostic through a symlinked path', async () => {
+    // A dotfiles setup: ~/.grok/AGENTS.md is a symlink, and --rules names the real file.
+    const realRules = path.join(tmpDir, 'dotfiles', 'grok-AGENTS.md');
+    fs.mkdirSync(path.dirname(realRules), { recursive: true });
+    fs.writeFileSync(realRules, '# dotfiles-managed\n');
+    fs.symlinkSync(realRules, path.join(tmpDir, 'AGENTS.md'));
+
+    await applyGrokSetup({
+      endpoint: 'https://automem.example.test',
+      quiet: true,
+      rulesPath: realRules,
+      projectName: 'some-project',
+    });
+
+    // Same file as the global rules, so the project tag must stay a placeholder.
+    expect(fs.readFileSync(realRules, 'utf8')).toContain('tags: ["<project-slug>"]');
+    expect(fs.readFileSync(realRules, 'utf8')).not.toContain('tags: ["some-project"]');
+  });
+
   it('keeps the stored API key when the endpoint is unchanged', async () => {
     await applyGrokSetup({
       endpoint: 'https://same.example.test',

--- a/src/cli/grok.test.ts
+++ b/src/cli/grok.test.ts
@@ -62,8 +62,10 @@ describe('grok setup', () => {
     const agents = fs.readFileSync(agentsPath, 'utf8');
     expect(agents).toContain(GROK_RULES_START);
     expect(agents).toContain(GROK_RULES_END);
-    expect(agents).toContain('demo-project');
     expect(agents).toContain('memory__recall_memory');
+    // This is the global rules file, so the project tag stays a placeholder even
+    // though --name was given; see the dedicated cases below.
+    expect(agents).toContain('tags: ["<project-slug>"]');
   });
 
   // ~/.grok/AGENTS.md loads in every Grok session, whatever repo it runs in. Baking
@@ -79,16 +81,31 @@ describe('grok setup', () => {
     expect(agents).not.toContain('tags: ["mcp-automem"]');
   });
 
-  it('bakes in a real project only when the caller scopes the rules', async () => {
+  // The target file decides, not the flags: --name and --rules can both still be
+  // pointing at the global file, where a real project tag is always wrong.
+  it('keeps the global rules project-agnostic even when flags name a project', async () => {
     await applyGrokSetup({
       endpoint: 'https://automem.example.test',
       quiet: true,
       projectName: 'demo-project',
     });
-    expect(fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf8')).toContain(
-      'tags: ["demo-project"]'
-    );
+    const viaName = fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf8');
+    expect(viaName).toContain('tags: ["<project-slug>"]');
+    expect(viaName).not.toContain('tags: ["demo-project"]');
 
+    // --rules aimed explicitly at the global path is still the global path.
+    await applyGrokSetup({
+      endpoint: 'https://automem.example.test',
+      quiet: true,
+      projectName: 'demo-project',
+      rulesPath: path.join(tmpDir, 'AGENTS.md'),
+    });
+    expect(fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf8')).toContain(
+      'tags: ["<project-slug>"]'
+    );
+  });
+
+  it('bakes in a real project for a project-local rules file', async () => {
     const projectRules = path.join(tmpDir, 'project', 'AGENTS.md');
     fs.mkdirSync(path.dirname(projectRules), { recursive: true });
     await applyGrokSetup({
@@ -97,8 +114,38 @@ describe('grok setup', () => {
       rulesPath: projectRules,
       projectName: 'scoped-project',
     });
-    // A --rules target is project-local, so a real project name is correct there.
     expect(fs.readFileSync(projectRules, 'utf8')).toContain('tags: ["scoped-project"]');
+  });
+
+  it('does not carry a stored API key over to a different endpoint', async () => {
+    await applyGrokSetup({
+      endpoint: 'https://first.example.test',
+      apiKey: 'sk-first-host',
+      quiet: true,
+    });
+
+    // Re-point at another host with no --api-key: the old host's key must not follow.
+    await applyGrokSetup({ endpoint: 'https://second.example.test', quiet: true });
+
+    const parsed = parseToml(fs.readFileSync(path.join(tmpDir, 'config.toml'), 'utf8')) as {
+      mcp_servers: { memory: { env: Record<string, string> } };
+    };
+    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_URL).toBe('https://second.example.test');
+    expect(parsed.mcp_servers.memory.env).not.toHaveProperty('AUTOMEM_API_KEY');
+  });
+
+  it('keeps the stored API key when the endpoint is unchanged', async () => {
+    await applyGrokSetup({
+      endpoint: 'https://same.example.test',
+      apiKey: 'sk-keep-me',
+      quiet: true,
+    });
+    await applyGrokSetup({ endpoint: 'https://same.example.test', quiet: true });
+
+    const parsed = parseToml(fs.readFileSync(path.join(tmpDir, 'config.toml'), 'utf8')) as {
+      mcp_servers: { memory: { env: Record<string, string> } };
+    };
+    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_KEY).toBe('sk-keep-me');
   });
 
   it('preserves existing credentials on re-run without flags', async () => {

--- a/src/cli/grok.test.ts
+++ b/src/cli/grok.test.ts
@@ -165,6 +165,33 @@ describe('grok setup', () => {
     expect(parsed.mcp_servers.memory.env.AUTOMEM_API_KEY).toBe('sk-persist');
   });
 
+  // Appending past a half-written block leaves one start and two ends, so the *next*
+  // run replaces everything between the original start and the appended end — silently
+  // eating whatever the user wrote in between.
+  it('refuses to append when the rules file has a one-sided marker', async () => {
+    const rulesPath = path.join(tmpDir, 'AGENTS.md');
+    const handWritten = ['# My notes', GROK_RULES_START, 'half a block, no end marker', ''].join(
+      '\n'
+    );
+    fs.writeFileSync(rulesPath, handWritten);
+
+    await expect(
+      applyGrokSetup({ endpoint: 'https://automem.example.test', quiet: true })
+    ).rejects.toThrow(/without a matching/);
+
+    // The user's file is left exactly as it was.
+    expect(fs.readFileSync(rulesPath, 'utf8')).toBe(handWritten);
+  });
+
+  it('refuses on a stray end marker too', async () => {
+    const rulesPath = path.join(tmpDir, 'AGENTS.md');
+    fs.writeFileSync(rulesPath, ['# My notes', GROK_RULES_END, ''].join('\n'));
+
+    await expect(
+      applyGrokSetup({ endpoint: 'https://automem.example.test', quiet: true })
+    ).rejects.toThrow(/without a matching/);
+  });
+
   it('dry-run does not write files', async () => {
     await applyGrokSetup({
       endpoint: 'https://automem.example.test',

--- a/src/cli/grok.test.ts
+++ b/src/cli/grok.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { parse as parseToml } from 'smol-toml';
+import { applyGrokSetup, GROK_RULES_END, GROK_RULES_START } from './grok.js';
+
+describe('grok setup', () => {
+  let tmpDir: string;
+  let originalGrokHome: string | undefined;
+  let originalApiUrl: string | undefined;
+  let originalApiKey: string | undefined;
+  let originalEndpoint: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-setup-'));
+    originalGrokHome = process.env.GROK_HOME;
+    originalApiUrl = process.env.AUTOMEM_API_URL;
+    originalApiKey = process.env.AUTOMEM_API_KEY;
+    originalEndpoint = process.env.AUTOMEM_ENDPOINT;
+    process.env.GROK_HOME = tmpDir;
+    delete process.env.AUTOMEM_API_URL;
+    delete process.env.AUTOMEM_API_KEY;
+    delete process.env.AUTOMEM_ENDPOINT;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    if (originalGrokHome === undefined) delete process.env.GROK_HOME;
+    else process.env.GROK_HOME = originalGrokHome;
+    if (originalApiUrl === undefined) delete process.env.AUTOMEM_API_URL;
+    else process.env.AUTOMEM_API_URL = originalApiUrl;
+    if (originalApiKey === undefined) delete process.env.AUTOMEM_API_KEY;
+    else process.env.AUTOMEM_API_KEY = originalApiKey;
+    if (originalEndpoint === undefined) delete process.env.AUTOMEM_ENDPOINT;
+    else process.env.AUTOMEM_ENDPOINT = originalEndpoint;
+  });
+
+  it('writes mcp_servers.memory and AGENTS.md rules', async () => {
+    await applyGrokSetup({
+      endpoint: 'https://automem.example.test',
+      apiKey: 'sk-test',
+      quiet: true,
+      projectName: 'demo-project',
+    });
+
+    const configPath = path.join(tmpDir, 'config.toml');
+    const agentsPath = path.join(tmpDir, 'AGENTS.md');
+    expect(fs.existsSync(configPath)).toBe(true);
+    expect(fs.existsSync(agentsPath)).toBe(true);
+
+    const parsed = parseToml(fs.readFileSync(configPath, 'utf8')) as {
+      mcp_servers: {
+        memory: { command: string; env: Record<string, string> };
+      };
+    };
+    expect(parsed.mcp_servers.memory.command).toBe('npx');
+    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_URL).toBe('https://automem.example.test');
+    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_KEY).toBe('sk-test');
+    expect(parsed.mcp_servers.memory.env.AUTOMEM_PROCESS_TAG).toBe('grok:memory');
+
+    const agents = fs.readFileSync(agentsPath, 'utf8');
+    expect(agents).toContain(GROK_RULES_START);
+    expect(agents).toContain(GROK_RULES_END);
+    expect(agents).toContain('demo-project');
+    expect(agents).toContain('memory__recall_memory');
+  });
+
+  it('preserves existing credentials on re-run without flags', async () => {
+    await applyGrokSetup({
+      endpoint: 'https://automem.example.test',
+      apiKey: 'sk-persist',
+      quiet: true,
+      projectName: 'demo',
+    });
+
+    await applyGrokSetup({ quiet: true, projectName: 'demo' });
+
+    const parsed = parseToml(fs.readFileSync(path.join(tmpDir, 'config.toml'), 'utf8')) as {
+      mcp_servers: { memory: { env: Record<string, string> } };
+    };
+    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_URL).toBe('https://automem.example.test');
+    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_KEY).toBe('sk-persist');
+  });
+
+  it('dry-run does not write files', async () => {
+    await applyGrokSetup({
+      endpoint: 'https://automem.example.test',
+      dryRun: true,
+      quiet: true,
+      projectName: 'demo',
+    });
+    expect(fs.existsSync(path.join(tmpDir, 'config.toml'))).toBe(false);
+    expect(fs.existsSync(path.join(tmpDir, 'AGENTS.md'))).toBe(false);
+  });
+});

--- a/src/cli/grok.test.ts
+++ b/src/cli/grok.test.ts
@@ -183,6 +183,32 @@ describe('grok setup', () => {
     expect(fs.readFileSync(rulesPath, 'utf8')).toBe(handWritten);
   });
 
+  it('writes nothing at all when the rules file is rejected', async () => {
+    // Validation used to run after the config write, so a rejected run still replaced
+    // the live endpoint and credentials while telling the user to fix their rules file.
+    const configPath = path.join(tmpDir, 'config.toml');
+    await applyGrokSetup({
+      endpoint: 'https://live.example.test',
+      apiKey: 'sk-live',
+      quiet: true,
+    });
+    const configBefore = fs.readFileSync(configPath, 'utf8');
+
+    const rulesPath = path.join(tmpDir, 'AGENTS.md');
+    fs.writeFileSync(rulesPath, ['# notes', GROK_RULES_START, 'no end marker', ''].join('\n'));
+    const rulesBefore = fs.readFileSync(rulesPath, 'utf8');
+
+    await expect(
+      applyGrokSetup({ endpoint: 'https://other.example.test', apiKey: 'sk-other', quiet: true })
+    ).rejects.toThrow(/without a matching/);
+
+    // Neither file moved: no partial install.
+    expect(fs.readFileSync(configPath, 'utf8')).toBe(configBefore);
+    expect(fs.readFileSync(rulesPath, 'utf8')).toBe(rulesBefore);
+    expect(configBefore).toContain('https://live.example.test');
+    expect(configBefore).not.toContain('https://other.example.test');
+  });
+
   it('refuses on a stray end marker too', async () => {
     const rulesPath = path.join(tmpDir, 'AGENTS.md');
     fs.writeFileSync(rulesPath, ['# My notes', GROK_RULES_END, ''].join('\n'));

--- a/src/cli/grok.test.ts
+++ b/src/cli/grok.test.ts
@@ -66,6 +66,41 @@ describe('grok setup', () => {
     expect(agents).toContain('memory__recall_memory');
   });
 
+  // ~/.grok/AGENTS.md loads in every Grok session, whatever repo it runs in. Baking
+  // the install-time project into it would hard-gate every later recall to that slug
+  // and tag every store with it.
+  it('keeps the global rules project-agnostic', async () => {
+    await applyGrokSetup({ endpoint: 'https://automem.example.test', quiet: true });
+
+    const agents = fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf8');
+    // The tag gate itself must stay a placeholder, not the installer's cwd.
+    expect(agents).toContain('tags: ["<project-slug>"]');
+    expect(agents).toContain('use the slug of the repository you are working in');
+    expect(agents).not.toContain('tags: ["mcp-automem"]');
+  });
+
+  it('bakes in a real project only when the caller scopes the rules', async () => {
+    await applyGrokSetup({
+      endpoint: 'https://automem.example.test',
+      quiet: true,
+      projectName: 'demo-project',
+    });
+    expect(fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf8')).toContain(
+      'tags: ["demo-project"]'
+    );
+
+    const projectRules = path.join(tmpDir, 'project', 'AGENTS.md');
+    fs.mkdirSync(path.dirname(projectRules), { recursive: true });
+    await applyGrokSetup({
+      endpoint: 'https://automem.example.test',
+      quiet: true,
+      rulesPath: projectRules,
+      projectName: 'scoped-project',
+    });
+    // A --rules target is project-local, so a real project name is correct there.
+    expect(fs.readFileSync(projectRules, 'utf8')).toContain('tags: ["scoped-project"]');
+  });
+
   it('preserves existing credentials on re-run without flags', async () => {
     await applyGrokSetup({
       endpoint: 'https://automem.example.test',

--- a/src/cli/grok.ts
+++ b/src/cli/grok.ts
@@ -58,7 +58,15 @@ function sameFile(a: string, b: string): boolean {
     try {
       return fs.realpathSync(p);
     } catch {
-      return path.resolve(p);
+      // Not created yet — the first-install case. Resolve the parent instead, so a
+      // symlinked `~/.grok` still matches a `--rules` path spelled through its real
+      // directory; falling straight back to a lexical compare would call them different
+      // files and bake a project into the global rules.
+      try {
+        return path.join(fs.realpathSync(path.dirname(p)), path.basename(p));
+      } catch {
+        return path.resolve(p);
+      }
     }
   };
   return real(a) === real(b);
@@ -112,18 +120,35 @@ export async function applyGrokSetup(cliOptions: GrokSetupOptions): Promise<void
     process.env.AUTOMEM_ENDPOINT ||
     existingCreds.endpoint ||
     DEFAULT_AUTOMEM_API_URL;
-  // A stored key belongs to the endpoint it was issued for. Carrying it over to a
-  // different host would send that secret as a Bearer credential to a server that was
-  // never meant to have it, so only reuse it when the endpoint is unchanged — compared
-  // the way the client compares it, since AutoMemClient strips a trailing slash and
-  // `https://x` and `https://x/` are the same server.
-  const reusableStoredKey =
-    existingCreds.endpoint &&
-    normalizeEndpoint(existingCreds.endpoint) === normalizeEndpoint(endpoint)
-      ? existingCreds.apiKey
-      : undefined;
-  const apiKey = cliOptions.apiKey ?? readAutoMemApiKeyFromEnv() ?? reusableStoredKey;
+  // A key belongs to the endpoint it was issued for. Handing it to a different host
+  // discloses the secret to a server that was never meant to have it, so every
+  // inherited key is paired with the endpoint it came from before being reused.
+  // Compared the way the client compares endpoints, since AutoMemClient strips a
+  // trailing slash and `https://x` and `https://x/` are the same server.
+  const sameEndpoint = (candidate?: string): boolean =>
+    Boolean(candidate) && normalizeEndpoint(candidate!) === normalizeEndpoint(endpoint);
+
+  // The shell's key belongs to the shell's endpoint. `--endpoint other` with
+  // AUTOMEM_API_URL/AUTOMEM_API_KEY exported would otherwise ship that key to `other`.
+  // An exported key with no exported endpoint is not bound to anything, so it stands.
+  const envEndpoint = process.env.AUTOMEM_API_URL || process.env.AUTOMEM_ENDPOINT;
+  const envKey = readAutoMemApiKeyFromEnv();
+  const reusableEnvKey = !envEndpoint || sameEndpoint(envEndpoint) ? envKey : undefined;
+
+  const reusableStoredKey = sameEndpoint(existingCreds.endpoint) ? existingCreds.apiKey : undefined;
+
+  const apiKey = cliOptions.apiKey ?? reusableEnvKey ?? reusableStoredKey;
   const rulesPath = cliOptions.rulesPath ?? paths.agentsPath;
+
+  // `--rules` pointing at config.toml (directly or through a symlink) would write the
+  // server entry as TOML and then overwrite the whole file with Markdown rules,
+  // destroying the registration it just made and leaving Grok an unparseable config.
+  if (sameFile(rulesPath, paths.configPath)) {
+    throw new Error(
+      `Refusing to write AutoMem rules to ${rulesPath}: that is the Grok config file. ` +
+        'Point --rules at a Markdown rules file (for example <grok-home>/AGENTS.md).'
+    );
+  }
   const disabledServers = readDisabledMcpServers(paths.configPath);
 
   // ~/.grok/AGENTS.md is injected into every Grok session regardless of which repo it

--- a/src/cli/grok.ts
+++ b/src/cli/grok.ts
@@ -42,6 +42,28 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/** Endpoint equality as the API client sees it — a trailing slash is not a new host. */
+function normalizeEndpoint(value: string): string {
+  return value.trim().replace(/\/+$/, '');
+}
+
+/**
+ * Whether two paths name the same file. Resolves symlinks, because the global rules
+ * file is commonly a symlink into a dotfiles repo and `--rules <real target>` then
+ * spells the same file differently. Falls back to lexical resolution for paths that do
+ * not exist yet, which is the normal case on a first install.
+ */
+function sameFile(a: string, b: string): boolean {
+  const real = (p: string): string => {
+    try {
+      return fs.realpathSync(p);
+    } catch {
+      return path.resolve(p);
+    }
+  };
+  return real(a) === real(b);
+}
+
 function upsertRulesWithMarkers(existing: string | null, block: string, rulesPath: string): string {
   const normalize = (s: string) => `${s.replace(/\n+$/, '')}\n`;
   if (!existing) {
@@ -92,9 +114,12 @@ export async function applyGrokSetup(cliOptions: GrokSetupOptions): Promise<void
     DEFAULT_AUTOMEM_API_URL;
   // A stored key belongs to the endpoint it was issued for. Carrying it over to a
   // different host would send that secret as a Bearer credential to a server that was
-  // never meant to have it, so only reuse it when the endpoint is unchanged.
+  // never meant to have it, so only reuse it when the endpoint is unchanged — compared
+  // the way the client compares it, since AutoMemClient strips a trailing slash and
+  // `https://x` and `https://x/` are the same server.
   const reusableStoredKey =
-    existingCreds.endpoint && existingCreds.endpoint === endpoint
+    existingCreds.endpoint &&
+    normalizeEndpoint(existingCreds.endpoint) === normalizeEndpoint(endpoint)
       ? existingCreds.apiKey
       : undefined;
   const apiKey = cliOptions.apiKey ?? readAutoMemApiKeyFromEnv() ?? reusableStoredKey;
@@ -106,7 +131,9 @@ export async function applyGrokSetup(cliOptions: GrokSetupOptions): Promise<void
   // every later recall and mistags every store, silently, because tags filter before
   // scoring. The decision is the target file, not the flags: `--name` with the default
   // path, or `--rules` pointed at the global file, are still writing the global file.
-  const writesGlobalRules = path.resolve(rulesPath) === path.resolve(paths.agentsPath);
+  // Compared by file identity, not spelling: the global rules are commonly a symlink
+  // into a dotfiles repo, and `--rules <the real target>` addresses the same file.
+  const writesGlobalRules = sameFile(rulesPath, paths.agentsPath);
   const rulesProjectName = writesGlobalRules ? GLOBAL_PROJECT_PLACEHOLDER : projectName;
 
   log(`\n🔧 Setting up Grok AutoMem for: ${projectName}`, cliOptions.quiet);

--- a/src/cli/grok.ts
+++ b/src/cli/grok.ts
@@ -96,10 +96,28 @@ export async function applyGrokSetup(cliOptions: GrokSetupOptions): Promise<void
   const finalContent = upsertRulesWithMarkers(existingContent, processed);
   writeFileWithBackup(rulesPath, finalContent, cliOptions);
 
+  // Diagnostics describe existing state rather than work performed, so they belong in
+  // the preview too — a dry run is exactly when someone wants to hear about them.
+  const diagnostics: string[] = [];
+  if (!apiKey) {
+    diagnostics.push(
+      '  ⚠️  No AUTOMEM_API_KEY set — set one before connecting to a remote AutoMem instance'
+    );
+  }
+  if (disabledServers.includes(GROK_MCP_SERVER_NAME)) {
+    // This top-level list gates MCP servers independently of a server's own `enabled`
+    // flag, so the install can look successful while AutoMem never loads.
+    diagnostics.push(
+      `  ⚠️  "${GROK_MCP_SERVER_NAME}" is listed in disabled_mcp_servers — Grok may ignore the server entry.`,
+      `      Remove it from that list in ${path.basename(paths.configPath)} to enable AutoMem.`
+    );
+  }
+
   // A dry run has written nothing, so it must not claim it did. The per-step
-  // "[DRY RUN] Would …" lines above are the whole report in that mode.
+  // "[DRY RUN] Would …" lines above are the whole report of pending work.
   if (cliOptions.dryRun) {
     log('\n📊 Dry run — no files were changed.', cliOptions.quiet);
+    for (const line of diagnostics) log(line, cliOptions.quiet);
     return;
   }
 
@@ -109,24 +127,7 @@ export async function applyGrokSetup(cliOptions: GrokSetupOptions): Promise<void
     cliOptions.quiet
   );
   log(`  ✅ AutoMem rules installed in ${path.basename(rulesPath)}`, cliOptions.quiet);
-  if (!apiKey) {
-    log(
-      '  ⚠️  No AUTOMEM_API_KEY set — set one before connecting to a remote AutoMem instance',
-      cliOptions.quiet
-    );
-  }
-  if (disabledServers.includes(GROK_MCP_SERVER_NAME)) {
-    // Grok honors this top-level list over the server entry, so the install would
-    // look successful while the server never loads.
-    log(
-      `  ⚠️  "${GROK_MCP_SERVER_NAME}" is listed in disabled_mcp_servers — Grok will not load it.`,
-      cliOptions.quiet
-    );
-    log(
-      `      Remove it from that list in ${path.basename(paths.configPath)} to enable AutoMem.`,
-      cliOptions.quiet
-    );
-  }
+  for (const line of diagnostics) log(line, cliOptions.quiet);
 
   log('\n✨ Grok AutoMem setup complete! Next steps:', cliOptions.quiet);
   log('  1. Start a new Grok session (existing sessions keep the old MCP child)', cliOptions.quiet);

--- a/src/cli/grok.ts
+++ b/src/cli/grok.ts
@@ -31,6 +31,13 @@ const TEMPLATE_ROOT = path.resolve(fileURLToPath(new URL('../../templates/grok',
 export const GROK_RULES_START = '<!-- BEGIN AUTOMEM GROK RULES -->';
 export const GROK_RULES_END = '<!-- END AUTOMEM GROK RULES -->';
 
+/**
+ * Stands in for the project tag when the rules land in the global
+ * `~/.grok/AGENTS.md`. Matches what the Claude Desktop instructions use for the
+ * same reason: the file is not project-scoped, so no single slug can be correct.
+ */
+export const GLOBAL_PROJECT_PLACEHOLDER = '<project-slug>';
+
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -73,6 +80,16 @@ export async function applyGrokSetup(cliOptions: GrokSetupOptions): Promise<void
   const rulesPath = cliOptions.rulesPath ?? paths.agentsPath;
   const disabledServers = readDisabledMcpServers(paths.configPath);
 
+  // The default rules target is the GLOBAL ~/.grok/AGENTS.md, which Grok injects into
+  // every session regardless of which repo it is run in. Baking the install-time
+  // project into it would hard-gate all later recalls to that one slug and tag every
+  // store with it — tags are a hard filter, so the damage is silent. Keep the
+  // placeholder there and only bake in a real name when the caller scopes it.
+  const writesGlobalRules = rulesPath === paths.agentsPath;
+  const scopedByCaller = cliOptions.projectName !== undefined || cliOptions.rulesPath !== undefined;
+  const rulesProjectName =
+    writesGlobalRules && !scopedByCaller ? GLOBAL_PROJECT_PLACEHOLDER : projectName;
+
   log(`\n🔧 Setting up Grok AutoMem for: ${projectName}`, cliOptions.quiet);
   log(`📁 Grok home: ${paths.home}`, cliOptions.quiet);
   log(`📄 Config: ${paths.configPath}`, cliOptions.quiet);
@@ -90,7 +107,7 @@ export async function applyGrokSetup(cliOptions: GrokSetupOptions): Promise<void
 
   const templateContent = fs.readFileSync(path.join(TEMPLATE_ROOT, 'memory-rules.md'), 'utf8');
   const processed = replaceTemplateVars(templateContent, {
-    PROJECT_NAME: projectName,
+    PROJECT_NAME: rulesProjectName,
   });
   const existingContent = fs.existsSync(rulesPath) ? fs.readFileSync(rulesPath, 'utf8') : null;
   const finalContent = upsertRulesWithMarkers(existingContent, processed);

--- a/src/cli/grok.ts
+++ b/src/cli/grok.ts
@@ -114,7 +114,19 @@ export async function applyGrokSetup(cliOptions: GrokSetupOptions): Promise<void
   log(`📄 Config: ${paths.configPath}`, cliOptions.quiet);
   log(`📄 Rules: ${rulesPath}\n`, cliOptions.quiet);
 
+  // Everything that can reject the run happens before anything is written. Both the
+  // rules content and the server entry are computed up front: upsertRulesWithMarkers
+  // throws on a one-sided marker, and building the entry is pure. Validating after the
+  // config write would leave a failed run having already replaced the live endpoint and
+  // credentials while telling the user to repair their rules file and re-run.
+  const templateContent = fs.readFileSync(path.join(TEMPLATE_ROOT, 'memory-rules.md'), 'utf8');
+  const processed = replaceTemplateVars(templateContent, {
+    PROJECT_NAME: rulesProjectName,
+  });
+  const existingContent = fs.existsSync(rulesPath) ? fs.readFileSync(rulesPath, 'utf8') : null;
+  const finalContent = upsertRulesWithMarkers(existingContent, processed, rulesPath);
   const entry = buildGrokAutoMemServerEntry(endpoint, apiKey);
+
   const result = upsertGrokMemoryServer(paths.configPath, entry, {
     dryRun: cliOptions.dryRun,
     quiet: cliOptions.quiet,
@@ -124,12 +136,6 @@ export async function applyGrokSetup(cliOptions: GrokSetupOptions): Promise<void
     log(`✅ Registered AutoMem MCP server (mcp_servers.${GROK_MCP_SERVER_NAME})`, cliOptions.quiet);
   }
 
-  const templateContent = fs.readFileSync(path.join(TEMPLATE_ROOT, 'memory-rules.md'), 'utf8');
-  const processed = replaceTemplateVars(templateContent, {
-    PROJECT_NAME: rulesProjectName,
-  });
-  const existingContent = fs.existsSync(rulesPath) ? fs.readFileSync(rulesPath, 'utf8') : null;
-  const finalContent = upsertRulesWithMarkers(existingContent, processed, rulesPath);
   writeFileWithBackup(rulesPath, finalContent, cliOptions);
 
   // Diagnostics describe existing state rather than work performed, so they belong in

--- a/src/cli/grok.ts
+++ b/src/cli/grok.ts
@@ -12,6 +12,7 @@ import {
 import {
   buildGrokAutoMemServerEntry,
   GROK_MCP_SERVER_NAME,
+  readDisabledMcpServers,
   readExistingGrokCredentials,
   resolveGrokPaths,
   upsertGrokMemoryServer,
@@ -70,6 +71,7 @@ export async function applyGrokSetup(cliOptions: GrokSetupOptions): Promise<void
     DEFAULT_AUTOMEM_API_URL;
   const apiKey = cliOptions.apiKey ?? readAutoMemApiKeyFromEnv() ?? existingCreds.apiKey;
   const rulesPath = cliOptions.rulesPath ?? paths.agentsPath;
+  const disabledServers = readDisabledMcpServers(paths.configPath);
 
   log(`\n🔧 Setting up Grok AutoMem for: ${projectName}`, cliOptions.quiet);
   log(`📁 Grok home: ${paths.home}`, cliOptions.quiet);
@@ -94,6 +96,13 @@ export async function applyGrokSetup(cliOptions: GrokSetupOptions): Promise<void
   const finalContent = upsertRulesWithMarkers(existingContent, processed);
   writeFileWithBackup(rulesPath, finalContent, cliOptions);
 
+  // A dry run has written nothing, so it must not claim it did. The per-step
+  // "[DRY RUN] Would …" lines above are the whole report in that mode.
+  if (cliOptions.dryRun) {
+    log('\n📊 Dry run — no files were changed.', cliOptions.quiet);
+    return;
+  }
+
   log('\n📊 Configuration Status:', cliOptions.quiet);
   log(
     `  ✅ mcp_servers.${GROK_MCP_SERVER_NAME} written to ${path.basename(paths.configPath)}`,
@@ -103,6 +112,18 @@ export async function applyGrokSetup(cliOptions: GrokSetupOptions): Promise<void
   if (!apiKey) {
     log(
       '  ⚠️  No AUTOMEM_API_KEY set — set one before connecting to a remote AutoMem instance',
+      cliOptions.quiet
+    );
+  }
+  if (disabledServers.includes(GROK_MCP_SERVER_NAME)) {
+    // Grok honors this top-level list over the server entry, so the install would
+    // look successful while the server never loads.
+    log(
+      `  ⚠️  "${GROK_MCP_SERVER_NAME}" is listed in disabled_mcp_servers — Grok will not load it.`,
+      cliOptions.quiet
+    );
+    log(
+      `      Remove it from that list in ${path.basename(paths.configPath)} to enable AutoMem.`,
       cliOptions.quiet
     );
   }

--- a/src/cli/grok.ts
+++ b/src/cli/grok.ts
@@ -7,6 +7,7 @@ import {
   log,
   parseCommonFlags,
   replaceTemplateVars,
+  sameEndpoint,
   writeFileWithBackup,
 } from './host-toolkit.js';
 import {
@@ -40,11 +41,6 @@ export const GLOBAL_PROJECT_PLACEHOLDER = '<project-slug>';
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-/** Endpoint equality as the API client sees it — a trailing slash is not a new host. */
-function normalizeEndpoint(value: string): string {
-  return value.trim().replace(/\/+$/, '');
 }
 
 /**
@@ -125,17 +121,18 @@ export async function applyGrokSetup(cliOptions: GrokSetupOptions): Promise<void
   // inherited key is paired with the endpoint it came from before being reused.
   // Compared the way the client compares endpoints, since AutoMemClient strips a
   // trailing slash and `https://x` and `https://x/` are the same server.
-  const sameEndpoint = (candidate?: string): boolean =>
-    Boolean(candidate) && normalizeEndpoint(candidate!) === normalizeEndpoint(endpoint);
+  const matchesChosenEndpoint = (candidate?: string): boolean => sameEndpoint(candidate, endpoint);
 
   // The shell's key belongs to the shell's endpoint. `--endpoint other` with
   // AUTOMEM_API_URL/AUTOMEM_API_KEY exported would otherwise ship that key to `other`.
   // An exported key with no exported endpoint is not bound to anything, so it stands.
   const envEndpoint = process.env.AUTOMEM_API_URL || process.env.AUTOMEM_ENDPOINT;
   const envKey = readAutoMemApiKeyFromEnv();
-  const reusableEnvKey = !envEndpoint || sameEndpoint(envEndpoint) ? envKey : undefined;
+  const reusableEnvKey = !envEndpoint || matchesChosenEndpoint(envEndpoint) ? envKey : undefined;
 
-  const reusableStoredKey = sameEndpoint(existingCreds.endpoint) ? existingCreds.apiKey : undefined;
+  const reusableStoredKey = matchesChosenEndpoint(existingCreds.endpoint)
+    ? existingCreds.apiKey
+    : undefined;
 
   const apiKey = cliOptions.apiKey ?? reusableEnvKey ?? reusableStoredKey;
   const rulesPath = cliOptions.rulesPath ?? paths.agentsPath;

--- a/src/cli/grok.ts
+++ b/src/cli/grok.ts
@@ -42,7 +42,7 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function upsertRulesWithMarkers(existing: string | null, block: string): string {
+function upsertRulesWithMarkers(existing: string | null, block: string, rulesPath: string): string {
   const normalize = (s: string) => `${s.replace(/\n+$/, '')}\n`;
   if (!existing) {
     return normalize(block);
@@ -53,6 +53,20 @@ function upsertRulesWithMarkers(existing: string | null, block: string): string 
     const before = existing.slice(0, startIdx);
     const after = existing.slice(endIdx + GROK_RULES_END.length);
     return normalize(`${before}${block}${after}`);
+  }
+  // One-sided markers (an interrupted run, or a hand edit that deleted half the block)
+  // used to fall through to "append". That is quietly destructive: the file then holds
+  // one start marker and two ends, so the *next* run replaces everything between the
+  // original start and the appended end — deleting whatever the user wrote in between.
+  // Refuse instead; the repair is a judgement call about their content, not ours.
+  if (startIdx !== -1 || endIdx !== -1) {
+    const present = startIdx !== -1 ? GROK_RULES_START : GROK_RULES_END;
+    const missing = startIdx !== -1 ? GROK_RULES_END : GROK_RULES_START;
+    throw new Error(
+      `${rulesPath} has ${present} without a matching ${missing}. ` +
+        'Appending would let a later run delete the content between them. ' +
+        `Restore or remove the stray marker (or point --rules elsewhere), then re-run.`
+    );
   }
   const sep = existing.endsWith('\n') ? '\n' : '\n\n';
   return normalize(`${existing}${sep}${block}`);
@@ -115,7 +129,7 @@ export async function applyGrokSetup(cliOptions: GrokSetupOptions): Promise<void
     PROJECT_NAME: rulesProjectName,
   });
   const existingContent = fs.existsSync(rulesPath) ? fs.readFileSync(rulesPath, 'utf8') : null;
-  const finalContent = upsertRulesWithMarkers(existingContent, processed);
+  const finalContent = upsertRulesWithMarkers(existingContent, processed, rulesPath);
   writeFileWithBackup(rulesPath, finalContent, cliOptions);
 
   // Diagnostics describe existing state rather than work performed, so they belong in

--- a/src/cli/grok.ts
+++ b/src/cli/grok.ts
@@ -1,0 +1,137 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import {
+  CommonOptions,
+  detectProjectName,
+  log,
+  parseCommonFlags,
+  replaceTemplateVars,
+  writeFileWithBackup,
+} from './host-toolkit.js';
+import {
+  buildGrokAutoMemServerEntry,
+  GROK_MCP_SERVER_NAME,
+  readExistingGrokCredentials,
+  resolveGrokPaths,
+  upsertGrokMemoryServer,
+} from './grok-config.js';
+import { readAutoMemApiKeyFromEnv } from '../env.js';
+import { DEFAULT_AUTOMEM_API_URL } from './templates.js';
+
+export interface GrokSetupOptions extends CommonOptions {
+  endpoint?: string;
+  apiKey?: string;
+  rulesPath?: string;
+}
+
+const TEMPLATE_ROOT = path.resolve(fileURLToPath(new URL('../../templates/grok', import.meta.url)));
+
+export const GROK_RULES_START = '<!-- BEGIN AUTOMEM GROK RULES -->';
+export const GROK_RULES_END = '<!-- END AUTOMEM GROK RULES -->';
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function upsertRulesWithMarkers(existing: string | null, block: string): string {
+  const normalize = (s: string) => `${s.replace(/\n+$/, '')}\n`;
+  if (!existing) {
+    return normalize(block);
+  }
+  const startIdx = existing.indexOf(GROK_RULES_START);
+  const endIdx = existing.indexOf(GROK_RULES_END);
+  if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+    const before = existing.slice(0, startIdx);
+    const after = existing.slice(endIdx + GROK_RULES_END.length);
+    return normalize(`${before}${block}${after}`);
+  }
+  const sep = existing.endsWith('\n') ? '\n' : '\n\n';
+  return normalize(`${existing}${sep}${block}`);
+}
+
+export function stripGrokRulesMarkers(existing: string): string {
+  const pattern = new RegExp(
+    `\\n?${escapeRegExp(GROK_RULES_START)}[\\s\\S]*?${escapeRegExp(GROK_RULES_END)}\\n?`,
+    'g'
+  );
+  return existing.replace(pattern, '\n').replace(/\n{3,}/g, '\n\n');
+}
+
+export async function applyGrokSetup(cliOptions: GrokSetupOptions): Promise<void> {
+  const paths = resolveGrokPaths({ dir: cliOptions.targetDir });
+  const projectName = cliOptions.projectName ?? detectProjectName();
+  const existingCreds = readExistingGrokCredentials(paths.configPath);
+  const endpoint =
+    cliOptions.endpoint ||
+    process.env.AUTOMEM_API_URL ||
+    process.env.AUTOMEM_ENDPOINT ||
+    existingCreds.endpoint ||
+    DEFAULT_AUTOMEM_API_URL;
+  const apiKey = cliOptions.apiKey ?? readAutoMemApiKeyFromEnv() ?? existingCreds.apiKey;
+  const rulesPath = cliOptions.rulesPath ?? paths.agentsPath;
+
+  log(`\n🔧 Setting up Grok AutoMem for: ${projectName}`, cliOptions.quiet);
+  log(`📁 Grok home: ${paths.home}`, cliOptions.quiet);
+  log(`📄 Config: ${paths.configPath}`, cliOptions.quiet);
+  log(`📄 Rules: ${rulesPath}\n`, cliOptions.quiet);
+
+  const entry = buildGrokAutoMemServerEntry(endpoint, apiKey);
+  const result = upsertGrokMemoryServer(paths.configPath, entry, {
+    dryRun: cliOptions.dryRun,
+    quiet: cliOptions.quiet,
+  });
+
+  if (result.method === 'toml' && result.changed) {
+    log(`✅ Registered AutoMem MCP server (mcp_servers.${GROK_MCP_SERVER_NAME})`, cliOptions.quiet);
+  }
+
+  const templateContent = fs.readFileSync(path.join(TEMPLATE_ROOT, 'memory-rules.md'), 'utf8');
+  const processed = replaceTemplateVars(templateContent, {
+    PROJECT_NAME: projectName,
+  });
+  const existingContent = fs.existsSync(rulesPath) ? fs.readFileSync(rulesPath, 'utf8') : null;
+  const finalContent = upsertRulesWithMarkers(existingContent, processed);
+  writeFileWithBackup(rulesPath, finalContent, cliOptions);
+
+  log('\n📊 Configuration Status:', cliOptions.quiet);
+  log(
+    `  ✅ mcp_servers.${GROK_MCP_SERVER_NAME} written to ${path.basename(paths.configPath)}`,
+    cliOptions.quiet
+  );
+  log(`  ✅ AutoMem rules installed in ${path.basename(rulesPath)}`, cliOptions.quiet);
+  if (!apiKey) {
+    log(
+      '  ⚠️  No AUTOMEM_API_KEY set — set one before connecting to a remote AutoMem instance',
+      cliOptions.quiet
+    );
+  }
+
+  log('\n✨ Grok AutoMem setup complete! Next steps:', cliOptions.quiet);
+  log('  1. Start a new Grok session (existing sessions keep the old MCP child)', cliOptions.quiet);
+  log(
+    '  2. Confirm: grok mcp list  →  memory: npx -y @verygoodplugins/mcp-automem',
+    cliOptions.quiet
+  );
+  log(
+    '  3. Prefer native config.toml over Claude/Cursor compat imports for AutoMem',
+    cliOptions.quiet
+  );
+}
+
+function parseArgs(args: string[]): GrokSetupOptions {
+  let endpoint: string | undefined;
+  let apiKey: string | undefined;
+  let rulesPath: string | undefined;
+  const common = parseCommonFlags(args, {
+    '--endpoint': { kind: 'value', set: (v) => (endpoint = v) },
+    '--api-key': { kind: 'value', set: (v) => (apiKey = v) },
+    '--rules': { kind: 'value', set: (v) => (rulesPath = v) },
+  });
+  return { ...common, endpoint, apiKey, rulesPath };
+}
+
+export async function runGrokSetup(args: string[] = []): Promise<void> {
+  const options = parseArgs(args);
+  await applyGrokSetup(options);
+}

--- a/src/cli/grok.ts
+++ b/src/cli/grok.ts
@@ -76,19 +76,24 @@ export async function applyGrokSetup(cliOptions: GrokSetupOptions): Promise<void
     process.env.AUTOMEM_ENDPOINT ||
     existingCreds.endpoint ||
     DEFAULT_AUTOMEM_API_URL;
-  const apiKey = cliOptions.apiKey ?? readAutoMemApiKeyFromEnv() ?? existingCreds.apiKey;
+  // A stored key belongs to the endpoint it was issued for. Carrying it over to a
+  // different host would send that secret as a Bearer credential to a server that was
+  // never meant to have it, so only reuse it when the endpoint is unchanged.
+  const reusableStoredKey =
+    existingCreds.endpoint && existingCreds.endpoint === endpoint
+      ? existingCreds.apiKey
+      : undefined;
+  const apiKey = cliOptions.apiKey ?? readAutoMemApiKeyFromEnv() ?? reusableStoredKey;
   const rulesPath = cliOptions.rulesPath ?? paths.agentsPath;
   const disabledServers = readDisabledMcpServers(paths.configPath);
 
-  // The default rules target is the GLOBAL ~/.grok/AGENTS.md, which Grok injects into
-  // every session regardless of which repo it is run in. Baking the install-time
-  // project into it would hard-gate all later recalls to that one slug and tag every
-  // store with it — tags are a hard filter, so the damage is silent. Keep the
-  // placeholder there and only bake in a real name when the caller scopes it.
-  const writesGlobalRules = rulesPath === paths.agentsPath;
-  const scopedByCaller = cliOptions.projectName !== undefined || cliOptions.rulesPath !== undefined;
-  const rulesProjectName =
-    writesGlobalRules && !scopedByCaller ? GLOBAL_PROJECT_PLACEHOLDER : projectName;
+  // ~/.grok/AGENTS.md is injected into every Grok session regardless of which repo it
+  // runs in, so no single project tag can be correct there — a baked-in slug hard-gates
+  // every later recall and mistags every store, silently, because tags filter before
+  // scoring. The decision is the target file, not the flags: `--name` with the default
+  // path, or `--rules` pointed at the global file, are still writing the global file.
+  const writesGlobalRules = path.resolve(rulesPath) === path.resolve(paths.agentsPath);
+  const rulesProjectName = writesGlobalRules ? GLOBAL_PROJECT_PLACEHOLDER : projectName;
 
   log(`\n🔧 Setting up Grok AutoMem for: ${projectName}`, cliOptions.quiet);
   log(`📁 Grok home: ${paths.home}`, cliOptions.quiet);

--- a/src/cli/host-toolkit.ts
+++ b/src/cli/host-toolkit.ts
@@ -17,6 +17,21 @@ export function log(message: string, quiet?: boolean): void {
   }
 }
 
+/**
+ * Endpoint equality as the API client sees it: AutoMemClient strips a trailing slash,
+ * so `https://x` and `https://x/` are the same server. Shared because credential
+ * pairing depends on it — a key must never follow a "changed" endpoint that is only
+ * spelled differently, and must never ride along to one that genuinely differs.
+ */
+export function normalizeEndpoint(value: string): string {
+  return value.trim().replace(/\/+$/, '');
+}
+
+/** Whether two endpoint spellings address the same server. */
+export function sameEndpoint(a?: string, b?: string): boolean {
+  return Boolean(a) && Boolean(b) && normalizeEndpoint(a!) === normalizeEndpoint(b!);
+}
+
 export function backupPath(filePath: string): string {
   let candidate = `${filePath}.bak`;
   let counter = 1;

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -265,6 +265,21 @@ describe('guided install helpers', () => {
     expect(DEFAULT_AGENT_CLIENTS.filter((client) => detected.has(client))).not.toContain('hermes');
   });
 
+  it('pre-checks Grok when ~/.grok is detected (opt-in, not a blind --yes default)', () => {
+    const homeDir = '/Users/tester';
+    const environment = detectInstallEnvironment({
+      homeDir,
+      cwd: '/repo/project',
+      platform: 'darwin',
+      commandExists: () => true,
+      pathExists: (filePath) => filePath === path.join(homeDir, '.grok'),
+    });
+    const detected = new Set(environment.detectedClients.map((client) => client.client));
+    expect(detected.has('grok')).toBe(true);
+    expect(AGENT_CLIENTS.filter((client) => detected.has(client))).toContain('grok');
+    expect(DEFAULT_AGENT_CLIENTS.filter((client) => detected.has(client))).not.toContain('grok');
+  });
+
   it('quotes .env values only when they would break dotenv parsing', () => {
     // Plain url-safe values pass through unquoted.
     expect(formatEnvValue('https://automem.example')).toBe('https://automem.example');
@@ -378,6 +393,41 @@ describe('guided install helpers', () => {
     expect(AGENT_CLIENTS).toContain('hermes');
     expect(parseInstallArgs(['--clients', 'hermes'], {}).clients).toEqual(['hermes']);
     expect(parseInstallArgs([], { AUTOMEM_CLIENTS: 'hermes' }).clients).toEqual(['hermes']);
+  });
+
+  it('keeps Grok available only when explicitly requested', () => {
+    expect(AGENT_CLIENTS).toContain('grok');
+    expect(parseInstallArgs([], {}).clients).not.toContain('grok');
+    expect(parseInstallArgs(['--clients', 'grok'], {}).clients).toEqual(['grok']);
+    expect(parseInstallArgs([], { AUTOMEM_CLIENTS: 'grok' }).clients).toEqual(['grok']);
+  });
+
+  it('plans Grok write surfaces as ~/.grok/config.toml and AGENTS.md', () => {
+    const grokHome = '/tmp/grok-home';
+    const plan = buildInstallPlan({
+      options: {
+        target: 'existing',
+        clients: ['grok'],
+        endpoint: 'https://memory.example',
+        hermesMode: 'mcp',
+        claudeCodeMode: 'plugin',
+        dryRun: true,
+        yes: false,
+        noAgentInstall: false,
+      },
+      environment: detectInstallEnvironment({
+        homeDir: '/Users/tester',
+        cwd: '/repo/project',
+        env: { GROK_HOME: grokHome },
+        pathExists: () => false,
+        commandExists: () => true,
+      }),
+    });
+    const grokAction = plan.actions.find((action) => action.client === 'grok');
+    expect(grokAction?.paths).toEqual([
+      path.join(grokHome, 'config.toml'),
+      path.join(grokHome, 'AGENTS.md'),
+    ]);
   });
 
   it('defaults Claude Code to the plugin and parses the mode override', () => {

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -85,6 +85,40 @@ describe('guided install helpers', () => {
     ).toBe('flag-key');
   });
 
+  it('does not forward an environment key to a different --endpoint', () => {
+    // The per-host installers receive this as an *explicit* apiKey, which bypasses their
+    // own endpoint-pairing checks — so the pairing has to hold here. An inherited key
+    // belongs to the endpoint it was exported alongside.
+    const parsed = parseInstallArgs(['--endpoint', 'https://new.example'], {
+      AUTOMEM_API_URL: 'https://old.example',
+      AUTOMEM_API_KEY: 'env-secret',
+    });
+    expect(parsed.endpoint).toBe('https://new.example');
+    expect(parsed.apiKey).toBeUndefined();
+
+    // Same host spelled with a trailing slash is the same host; the key still applies.
+    expect(
+      parseInstallArgs(['--endpoint', 'https://old.example/'], {
+        AUTOMEM_API_URL: 'https://old.example',
+        AUTOMEM_API_KEY: 'env-secret',
+      }).apiKey
+    ).toBe('env-secret');
+
+    // An explicit --api-key is the operator naming the credential for this run.
+    expect(
+      parseInstallArgs(['--endpoint', 'https://new.example', '--api-key', 'flag-key'], {
+        AUTOMEM_API_URL: 'https://old.example',
+        AUTOMEM_API_KEY: 'env-secret',
+      }).apiKey
+    ).toBe('flag-key');
+
+    // No exported endpoint means the key is not bound to one — the curl|sh path.
+    expect(
+      parseInstallArgs(['--endpoint', 'https://new.example'], { AUTOMEM_API_KEY: 'env-secret' })
+        .apiKey
+    ).toBe('env-secret');
+  });
+
   it('rejects unknown install targets and clients', () => {
     expect(() => parseInstallArgs(['--target', 'serverless'])).toThrow(/invalid install target/i);
     expect(() => parseInstallArgs(['--clients', 'codex,nope'])).toThrow(/invalid AutoMem client/i);

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { execFileSync, spawnSync } from 'child_process';
+import { AGENT_CLIENTS, DEFAULT_AGENT_CLIENTS, type AgentClient } from './clients.js';
 import { applyClaudeCodeSetup } from './claude-code.js';
 import { applyCodexSetup } from './codex.js';
 import { applyCursorSetup } from './cursor.js';
@@ -123,22 +124,10 @@ export async function installClaudeCodePlugin(params: {
 // How the guided installer wires Claude Code. Defaults to the recommended plugin.
 export type ClaudeCodeMode = 'plugin' | 'settings';
 
-export const AGENT_CLIENTS = [
-  'codex',
-  'claude-code',
-  'cursor',
-  'openclaw',
-  'hermes',
-  'grok',
-] as const;
-
-export type AgentClient = (typeof AGENT_CLIENTS)[number];
-export const DEFAULT_AGENT_CLIENTS = [
-  'codex',
-  'claude-code',
-  'cursor',
-  'openclaw',
-] as const satisfies readonly AgentClient[];
+// Re-exported so existing importers (and the CLI surface) keep one entry point,
+// while the definitions themselves stay dependency-free in ./clients.js.
+export { AGENT_CLIENTS, DEFAULT_AGENT_CLIENTS };
+export type { AgentClient };
 export type InstallTarget = 'local' | 'cloud' | 'existing';
 // Hosted-cloud sub-target: InstaPods (open the setup page → paste the emailed
 // URL+key), Railway (guided via the railway CLI), or 'other' (paste credentials

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -10,7 +10,7 @@ import { applyGrokSetup } from './grok.js';
 import { applyOpenClawSetup } from './openclaw.js';
 import { resolveGrokPaths } from './grok-config.js';
 import { DEFAULT_AUTOMEM_API_URL } from './templates.js';
-import { mergeEnvContent, writeFileWithBackup } from './host-toolkit.js';
+import { mergeEnvContent, sameEndpoint, writeFileWithBackup } from './host-toolkit.js';
 import { provisionViaInstaPodsLink, provisionViaRailway } from './cloud/installer-bridge.js';
 // Re-exported so existing importers (and install.test.ts) keep a stable path.
 export { formatEnvValue } from './host-toolkit.js';
@@ -373,8 +373,13 @@ export function parseInstallArgs(
   let target = parseTarget(env.AUTOMEM_INSTALL_TARGET);
   let cloudProvider = parseCloudProvider(env.AUTOMEM_CLOUD_PROVIDER);
   let clients = parseClients(env.AUTOMEM_CLIENTS);
-  let endpoint = env.AUTOMEM_API_URL || env.AUTOMEM_ENDPOINT;
-  let apiKey = env.AUTOMEM_API_KEY || env.AUTOMEM_API_TOKEN;
+  const envEndpoint = env.AUTOMEM_API_URL || env.AUTOMEM_ENDPOINT;
+  const envApiKey = env.AUTOMEM_API_KEY || env.AUTOMEM_API_TOKEN;
+  let endpoint = envEndpoint;
+  let apiKey = envApiKey;
+  // Whether the key came from --api-key rather than the environment. An explicit flag
+  // is the operator naming the credential for this run; an inherited one is not.
+  let apiKeyFromFlag = false;
   let localDir = env.AUTOMEM_LOCAL_DIR;
   let hermesMode = parseHermesMode(env.AUTOMEM_HERMES_MODE);
   let claudeCodeMode = parseClaudeCodeMode(env.AUTOMEM_CLAUDE_CODE_MODE);
@@ -407,6 +412,7 @@ export function parseInstallArgs(
         break;
       case '--api-key':
         apiKey = assertValue(args, i, arg);
+        apiKeyFromFlag = true;
         i += 1;
         break;
       case '--local-dir':
@@ -434,6 +440,20 @@ export function parseInstallArgs(
       default:
         break;
     }
+  }
+
+  // An environment key belongs to the environment's endpoint. Selecting a different
+  // host with --endpoint must not forward that credential to it — the per-host
+  // installers receive this as an explicit apiKey, which bypasses their own pairing
+  // checks, so the pairing has to happen here too.
+  if (
+    !apiKeyFromFlag &&
+    envApiKey &&
+    envEndpoint &&
+    endpoint &&
+    !sameEndpoint(endpoint, envEndpoint)
+  ) {
+    apiKey = undefined;
   }
 
   return {

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -6,7 +6,9 @@ import { applyClaudeCodeSetup } from './claude-code.js';
 import { applyCodexSetup } from './codex.js';
 import { applyCursorSetup } from './cursor.js';
 import { applyHermesSetup, type HermesInstallMode } from './hermes.js';
+import { applyGrokSetup } from './grok.js';
 import { applyOpenClawSetup } from './openclaw.js';
+import { resolveGrokPaths } from './grok-config.js';
 import { DEFAULT_AUTOMEM_API_URL } from './templates.js';
 import { mergeEnvContent, writeFileWithBackup } from './host-toolkit.js';
 import { provisionViaInstaPodsLink, provisionViaRailway } from './cloud/installer-bridge.js';
@@ -121,7 +123,14 @@ export async function installClaudeCodePlugin(params: {
 // How the guided installer wires Claude Code. Defaults to the recommended plugin.
 export type ClaudeCodeMode = 'plugin' | 'settings';
 
-export const AGENT_CLIENTS = ['codex', 'claude-code', 'cursor', 'openclaw', 'hermes'] as const;
+export const AGENT_CLIENTS = [
+  'codex',
+  'claude-code',
+  'cursor',
+  'openclaw',
+  'hermes',
+  'grok',
+] as const;
 
 export type AgentClient = (typeof AGENT_CLIENTS)[number];
 export const DEFAULT_AGENT_CLIENTS = [
@@ -470,6 +479,7 @@ export function detectInstallEnvironment(options: DetectOptions = {}): InstallEn
     cursor: path.join(homeDir, '.cursor'),
     openclaw: path.join(homeDir, '.openclaw'),
     hermes: env.HERMES_HOME || path.join(homeDir, '.hermes'),
+    grok: env.GROK_HOME || path.join(homeDir, '.grok'),
   };
 
   const candidates: DetectedClient[] = AGENT_CLIENTS.map((client) => ({
@@ -544,6 +554,10 @@ function agentPaths(
       return [path.join(environment.clientRoots.openclaw, 'openclaw.json')];
     case 'hermes':
       return hermesPaths(environment, options.hermesMode);
+    case 'grok': {
+      const grok = resolveGrokPaths({ dir: environment.clientRoots.grok });
+      return [grok.configPath, grok.agentsPath];
+    }
   }
 }
 
@@ -983,6 +997,8 @@ function clientLabel(client: AgentClient): string {
       return 'OpenClaw';
     case 'hermes':
       return 'Hermes';
+    case 'grok':
+      return 'Grok Build';
   }
 }
 
@@ -1000,6 +1016,8 @@ export function manualFixHint(client: AgentClient): string {
       return 'Codex: re-run  npx @verygoodplugins/mcp-automem install --clients codex';
     case 'claude-code':
       return 'Claude Code: re-run  npx @verygoodplugins/mcp-automem install --clients claude-code';
+    case 'grok':
+      return 'Grok: re-run  npx @verygoodplugins/mcp-automem install --clients grok';
   }
 }
 
@@ -1049,6 +1067,7 @@ function clientGlyph(client: AgentClient, theme: RenderTheme): string {
     cursor: '❯',
     openclaw: '◆',
     hermes: '☿',
+    grok: '⚡',
   };
   return glyphs[client] ?? '•';
 }
@@ -1376,6 +1395,15 @@ async function applyAgentInstall(
     case 'hermes':
       await applyHermesSetup({
         mode: params.hermesMode,
+        endpoint: params.endpoint ?? DEFAULT_AUTOMEM_API_URL,
+        apiKey: params.apiKey,
+        dryRun: params.dryRun,
+        quiet: true,
+        yes: true,
+      });
+      break;
+    case 'grok':
+      await applyGrokSetup({
         endpoint: params.endpoint ?? DEFAULT_AUTOMEM_API_URL,
         apiKey: params.apiKey,
         dryRun: params.dryRun,

--- a/src/cli/uninstall.test.ts
+++ b/src/cli/uninstall.test.ts
@@ -625,3 +625,99 @@ describe('uninstall codex', () => {
     expect(fs.readdirSync(tmpDir).filter((f) => f.includes('.backup.'))).toEqual([]);
   });
 });
+
+describe('uninstall grok', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'automem-uninstall-grok-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeGrokState(): void {
+    fs.writeFileSync(
+      path.join(tmpDir, 'config.toml'),
+      [
+        '[cli]',
+        'installer = "internal"',
+        '',
+        '[mcp_servers.memory]',
+        'command = "npx"',
+        'args = ["-y", "@verygoodplugins/mcp-automem"]',
+        'enabled = true',
+        '',
+        '[mcp_servers.memory.env]',
+        'AUTOMEM_API_URL = "https://automem.example.test"',
+        'AUTOMEM_PROCESS_TAG = "grok:memory"',
+        '',
+        '[mcp_servers.other]',
+        'command = "bash"',
+        '',
+      ].join('\n')
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, 'AGENTS.md'),
+      [
+        '# Grok',
+        '',
+        '<!-- BEGIN AUTOMEM GROK RULES -->',
+        'AutoMem managed rules',
+        '<!-- END AUTOMEM GROK RULES -->',
+        '',
+        'keep this',
+        '',
+      ].join('\n')
+    );
+  }
+
+  it('removes AutoMem mcp_servers.memory and strips AGENTS.md markers', async () => {
+    writeGrokState();
+
+    await runUninstall({
+      platform: 'grok',
+      projectDir: tmpDir,
+      yes: true,
+      quiet: true,
+    });
+
+    const { parse: parseToml } = await import('smol-toml');
+    const parsed = parseToml(fs.readFileSync(path.join(tmpDir, 'config.toml'), 'utf8')) as {
+      mcp_servers: Record<string, unknown>;
+      cli: { installer: string };
+    };
+    expect(parsed.cli.installer).toBe('internal');
+    expect(parsed.mcp_servers.memory).toBeUndefined();
+    expect(parsed.mcp_servers.other).toBeDefined();
+
+    const agents = fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf8');
+    expect(agents).toContain('keep this');
+    expect(agents).not.toContain('BEGIN AUTOMEM GROK RULES');
+  });
+
+  it('parses grok as an uninstall platform', () => {
+    expect(parseUninstallArgs(['grok', '--yes'])).toMatchObject({
+      platform: 'grok',
+      yes: true,
+    });
+  });
+
+  it('honors dry-run without changing Grok files', async () => {
+    writeGrokState();
+    const beforeConfig = fs.readFileSync(path.join(tmpDir, 'config.toml'), 'utf8');
+    const beforeAgents = fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf8');
+
+    await runUninstall({
+      platform: 'grok',
+      projectDir: tmpDir,
+      yes: true,
+      dryRun: true,
+      quiet: true,
+    });
+
+    expect(fs.readFileSync(path.join(tmpDir, 'config.toml'), 'utf8')).toBe(beforeConfig);
+    expect(fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf8')).toBe(beforeAgents);
+  });
+});

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -11,9 +11,11 @@ import {
   removeMcpServerEntry,
   resolveHermesPaths,
 } from './hermes-config.js';
+import { removeGrokMemoryServer, resolveGrokPaths } from './grok-config.js';
+import { GROK_RULES_END, GROK_RULES_START, stripGrokRulesMarkers } from './grok.js';
 
 interface UninstallOptions {
-  platform: 'cursor' | 'claude-code' | 'copilot' | 'codex' | 'hermes';
+  platform: 'cursor' | 'claude-code' | 'copilot' | 'codex' | 'hermes' | 'grok';
   projectDir?: string;
   rulesPath?: string;
   cleanAll?: boolean;
@@ -356,6 +358,51 @@ async function uninstallHermes(options: UninstallOptions): Promise<void> {
   }
 }
 
+async function uninstallGrok(options: UninstallOptions): Promise<void> {
+  const paths = resolveGrokPaths({ dir: options.projectDir });
+  const rulesFile = options.rulesPath ?? paths.agentsPath;
+
+  log('\n🗑️  Uninstalling Grok AutoMem...', options.quiet);
+
+  let didChange = false;
+  if (fs.existsSync(paths.configPath)) {
+    didChange =
+      removeGrokMemoryServer(paths.configPath, {
+        dryRun: options.dryRun,
+        quiet: options.quiet,
+        onlyIfAutoMem: true,
+      }) || didChange;
+  } else {
+    log(`ℹ️  No Grok config at ${paths.configPath}`, options.quiet);
+  }
+
+  if (fs.existsSync(rulesFile)) {
+    const raw = fs.readFileSync(rulesFile, 'utf8');
+    const startIdx = raw.indexOf(GROK_RULES_START);
+    const endIdx = raw.indexOf(GROK_RULES_END);
+
+    if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) {
+      log(`ℹ️  No AutoMem rule block in ${rulesFile}`, options.quiet);
+    } else if (options.dryRun) {
+      log(`[DRY RUN] Would strip AutoMem block from: ${rulesFile}`, options.quiet);
+    } else {
+      const next = `${stripGrokRulesMarkers(raw).replace(/\n+$/, '')}\n`;
+      const backupPath = `${rulesFile}.backup.${Date.now()}`;
+      fs.copyFileSync(rulesFile, backupPath);
+      fs.writeFileSync(rulesFile, next, 'utf8');
+      log(`🗑️  Stripped AutoMem block from ${rulesFile}`, options.quiet);
+      log(`   Backup: ${backupPath}`, options.quiet);
+      didChange = true;
+    }
+  }
+
+  if (didChange) {
+    log('\n✅ Grok AutoMem configuration removed', options.quiet);
+  } else if (!options.dryRun) {
+    log('\nℹ️  Nothing to remove for Grok AutoMem', options.quiet);
+  }
+}
+
 async function uninstallCodex(options: UninstallOptions): Promise<void> {
   // Plugin-first codex install is rules-only: it writes a single marked AutoMem
   // block into AGENTS.md (cwd by default, or --rules). Uninstall strips that
@@ -695,6 +742,8 @@ export async function runUninstall(options: UninstallOptions): Promise<void> {
     await uninstallCodex(options);
   } else if (options.platform === 'hermes') {
     await uninstallHermes(options);
+  } else if (options.platform === 'grok') {
+    await uninstallGrok(options);
   }
 
   // Clean up external changes (Claude Desktop config) if requested
@@ -732,11 +781,13 @@ export async function runUninstall(options: UninstallOptions): Promise<void> {
 }
 
 export function parseUninstallArgs(args: string[]): UninstallOptions | null {
-  const allowed = ['cursor', 'claude-code', 'copilot', 'codex', 'hermes'] as const;
+  const allowed = ['cursor', 'claude-code', 'copilot', 'codex', 'hermes', 'grok'] as const;
   if (args.length === 0 || !allowed.includes(args[0] as (typeof allowed)[number])) {
-    console.error('❌ Error: Platform required (cursor, claude-code, copilot, codex, or hermes)');
     console.error(
-      'Usage: mcp-automem uninstall <cursor|claude-code|copilot|codex|hermes> [options]'
+      '❌ Error: Platform required (cursor, claude-code, copilot, codex, hermes, or grok)'
+    );
+    console.error(
+      'Usage: mcp-automem uninstall <cursor|claude-code|copilot|codex|hermes|grok> [options]'
     );
     return null;
   }

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -13,9 +13,10 @@ import {
 } from './hermes-config.js';
 import { removeGrokMemoryServer, resolveGrokPaths } from './grok-config.js';
 import { GROK_RULES_END, GROK_RULES_START, stripGrokRulesMarkers } from './grok.js';
+import { UNINSTALL_PLATFORMS, type UninstallPlatform } from './clients.js';
 
 interface UninstallOptions {
-  platform: 'cursor' | 'claude-code' | 'copilot' | 'codex' | 'hermes' | 'grok';
+  platform: UninstallPlatform;
   projectDir?: string;
   rulesPath?: string;
   cleanAll?: boolean;
@@ -716,6 +717,28 @@ function isAutoMemMcpServer(server: unknown): boolean {
   return values.some((value) => value.includes('mcp-automem'));
 }
 
+/**
+ * Platform → handler. A total `Record` rather than an if-chain so TypeScript rejects a
+ * new `UninstallPlatform` that has no handler, and so the parity suite can assert the
+ * mapping directly. Grepping the source for `options.platform === 'x'` could not: the
+ * same predicate appears in the `--clean-all` and next-steps blocks below, so deleting
+ * a real dispatch branch still left a match.
+ */
+const UNINSTALL_HANDLERS: Record<UninstallPlatform, (options: UninstallOptions) => Promise<void>> =
+  {
+    cursor: uninstallCursor,
+    'claude-code': uninstallClaudeCode,
+    copilot: uninstallCopilot,
+    codex: uninstallCodex,
+    hermes: uninstallHermes,
+    grok: uninstallGrok,
+  };
+
+/** Platforms with a registered uninstall handler, for the parity suite. */
+export function uninstallHandlerPlatforms(): string[] {
+  return Object.keys(UNINSTALL_HANDLERS);
+}
+
 export async function runUninstall(options: UninstallOptions): Promise<void> {
   log(`\n🚮 AutoMem Uninstaller`, options.quiet);
   log(`   Platform: ${options.platform}`, options.quiet);
@@ -732,19 +755,7 @@ export async function runUninstall(options: UninstallOptions): Promise<void> {
   }
 
   // Platform-specific uninstall
-  if (options.platform === 'cursor') {
-    await uninstallCursor(options);
-  } else if (options.platform === 'claude-code') {
-    await uninstallClaudeCode(options);
-  } else if (options.platform === 'copilot') {
-    await uninstallCopilot(options);
-  } else if (options.platform === 'codex') {
-    await uninstallCodex(options);
-  } else if (options.platform === 'hermes') {
-    await uninstallHermes(options);
-  } else if (options.platform === 'grok') {
-    await uninstallGrok(options);
-  }
+  await UNINSTALL_HANDLERS[options.platform](options);
 
   // Clean up external changes (Claude Desktop config) if requested
   if (options.cleanAll) {
@@ -781,14 +792,13 @@ export async function runUninstall(options: UninstallOptions): Promise<void> {
 }
 
 export function parseUninstallArgs(args: string[]): UninstallOptions | null {
-  const allowed = ['cursor', 'claude-code', 'copilot', 'codex', 'hermes', 'grok'] as const;
-  if (args.length === 0 || !allowed.includes(args[0] as (typeof allowed)[number])) {
-    console.error(
-      '❌ Error: Platform required (cursor, claude-code, copilot, codex, hermes, or grok)'
-    );
-    console.error(
-      'Usage: mcp-automem uninstall <cursor|claude-code|copilot|codex|hermes|grok> [options]'
-    );
+  // Derived from AGENT_CLIENTS so a new installer client cannot quietly ship without
+  // an uninstall path — it either lands here or is listed in UNINSTALL_UNSUPPORTED_CLIENTS.
+  const allowed = UNINSTALL_PLATFORMS;
+  if (args.length === 0 || !allowed.includes(args[0] as UninstallPlatform)) {
+    const list = allowed.join(', ');
+    console.error(`❌ Error: Platform required (${list})`);
+    console.error(`Usage: mcp-automem uninstall <${allowed.join('|')}> [options]`);
     return null;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   Tool,
 } from '@modelcontextprotocol/sdk/types.js';
 import { config } from 'dotenv';
+import { HOST_SETUP_COMMANDS } from './cli/clients.js';
 import { runConfig, runSetup } from './cli/setup.js';
 import { runInstallCommand } from './cli/install.js';
 import { runClaudeCodeSetup } from './cli/claude-code.js';
@@ -49,13 +50,9 @@ const KNOWN_COMMANDS = new Set([
   'setup',
   'install',
   'config',
-  'claude-code',
-  'copilot',
-  'cursor',
-  'codex',
-  'openclaw',
-  'hermes',
-  'grok',
+  // Per-host setup commands come from the client registry so routing a new host
+  // cannot leave it unrecognized here — the drift that left `copilot` missing.
+  ...HOST_SETUP_COMMANDS,
   'migrate',
   'uninstall',
   'queue',

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { runCodexSetup } from './cli/codex.js';
 import { runOpenClawSetup } from './cli/openclaw.js';
 import { COPILOT_USAGE, runCopilotSetup } from './cli/copilot.js';
 import { runHermesSetup } from './cli/hermes.js';
+import { runGrokSetup } from './cli/grok.js';
 import { runMigrateCommand } from './cli/migrate.js';
 import { runUninstallCommand } from './cli/uninstall.js';
 import { runQueueCommand } from './cli/queue.js';
@@ -54,6 +55,7 @@ const KNOWN_COMMANDS = new Set([
   'codex',
   'openclaw',
   'hermes',
+  'grok',
   'migrate',
   'uninstall',
   'queue',
@@ -207,6 +209,7 @@ COMMANDS:
   codex              Set up AutoMem for Codex
   openclaw           Set up AutoMem for OpenClaw
   hermes             Set up AutoMem for Hermes Agent
+  grok               Set up AutoMem for Grok Build
   migrate            Migrate existing projects to AutoMem
   uninstall          Remove AutoMem configuration
   queue              Manage memory queue
@@ -254,11 +257,11 @@ MIGRATION:
     --yes, -y             Skip confirmation
 
 UNINSTALL:
-  npx @verygoodplugins/mcp-automem uninstall <cursor|claude-code|codex|hermes> [options]
+  npx @verygoodplugins/mcp-automem uninstall <cursor|claude-code|codex|hermes|grok> [options]
 
   Options:
-    --dir <path>          Project / hermes-home directory
-    --rules <path>        Rules file to strip (default: codex <project>/AGENTS.md, hermes <hermes-home>/AGENTS.md)
+    --dir <path>          Project / hermes-home / grok-home directory
+    --rules <path>        Rules file to strip (default: codex <project>/AGENTS.md, hermes/grok <home>/AGENTS.md)
     --clean-all          Also remove MCP server config (Cursor/Claude Desktop)
     --dry-run           Show what would be removed
     --yes, -y           Skip confirmation
@@ -312,6 +315,21 @@ HERMES SETUP:
     --dry-run             Show what would be changed
     --quiet               Suppress output
 
+GROK SETUP:
+  npx @verygoodplugins/mcp-automem grok [options]
+
+  Writes native ~/.grok/config.toml [mcp_servers.memory] with AUTOMEM_* env
+  (required — Claude/Cursor compat imports can drop env and fail with fetch failed).
+
+  Options:
+    --dir <path>          Grok home directory (default: $GROK_HOME or ~/.grok)
+    --name <name>         Project name (auto-detected if not provided)
+    --endpoint <url>      AutoMem endpoint (default: $AUTOMEM_API_URL or http://127.0.0.1:8001)
+    --api-key <key>       AutoMem API key (optional)
+    --rules <path>        Target rules file (default: <grok-home>/AGENTS.md)
+    --dry-run             Show what would be changed
+    --quiet               Suppress output
+
 OPENCLAW SETUP:
   npx @verygoodplugins/mcp-automem openclaw [options]
 
@@ -339,7 +357,7 @@ GUIDED INSTALL:
 
   Options:
     --target <local|cloud|existing>  Where AutoMem runs
-    --clients <list>                 Comma-separated agents: codex,claude-code,cursor,openclaw,hermes
+    --clients <list>                 Comma-separated agents: codex,claude-code,cursor,openclaw,hermes,grok
     --endpoint <url>                 Existing or hosted AutoMem endpoint
     --api-key <key>                  API key for authenticated endpoints
     --local-dir <path>               Local server directory (default: ~/.automem/server)
@@ -396,6 +414,11 @@ if (command === 'openclaw') {
 
 if (command === 'hermes') {
   await runHermesSetup(process.argv.slice(3));
+  process.exit(0);
+}
+
+if (command === 'grok') {
+  await runGrokSetup(process.argv.slice(3));
   process.exit(0);
 }
 

--- a/src/memory-policy.test.ts
+++ b/src/memory-policy.test.ts
@@ -377,6 +377,13 @@ describe('shared AutoMem memory policy', () => {
     // Prose references are strings, not callables, so they stay backticked.
     expect(grok).toContain('Prefer `memory__update_memory`');
 
+    // The truncated-response recovery path is an instruction Grok must be able to
+    // follow: a bare `recall_memory({ memory_id })` names nothing it can call.
+    expect(grok).toContain(
+      'use_tool({ tool_name: "memory__recall_memory", tool_input: { memory_id: "<id>" } })'
+    );
+    expect(grok).not.toContain('with `recall_memory({ memory_id })`');
+
     // Host-specific guidance that only Grok carries.
     expect(grok).toContain('Always run `search_tool` before the first `use_tool`');
     expect(grok).toContain('~/.grok/config.toml');

--- a/src/memory-policy.test.ts
+++ b/src/memory-policy.test.ts
@@ -14,6 +14,7 @@ import {
   renderClaudeMdMemoryRules,
   renderCodexMemoryRules,
   renderCursorProjectRule,
+  renderGrokMemoryRules,
   renderClaudeCodeSessionStartPrompt,
   renderCopilotSessionStartPrompt,
   renderClaudeCodeSessionStartHook,
@@ -323,6 +324,10 @@ describe('shared AutoMem memory policy', () => {
         templateVersion,
       })
     );
+    expectFileEquals(
+      'templates/grok/memory-rules.md',
+      renderGrokMemoryRules({ projectName: '{{PROJECT_NAME}}', templateVersion })
+    );
   });
 
   it('keeps the Copilot bash session-start hook aligned with the shared renderer', () => {
@@ -349,6 +354,47 @@ describe('shared AutoMem memory policy', () => {
 
   it('keeps the Codex memory rules aligned with the shared defaults', () => {
     expectSharedPolicySurface(readRepoFile('templates/codex/memory-rules.md'));
+  });
+
+  it('keeps the Grok memory rules aligned with the shared defaults', () => {
+    expectSharedPolicySurface(readRepoFile('templates/grok/memory-rules.md'));
+  });
+
+  it('renders Grok calls through use_tool instead of the direct-call style', () => {
+    const grok = renderGrokMemoryRules({
+      projectName: '{{PROJECT_NAME}}',
+      templateVersion: readPackageVersion(),
+    });
+
+    // Grok has no callable tool names — every call goes through the dispatcher.
+    // Emitting `memory__recall_memory({…})` here produces rules Grok cannot execute
+    // (the class of bug that shipped for Copilot in #186).
+    expect(grok).toContain('use_tool({ tool_name: "memory__recall_memory"');
+    expect(grok).toContain('tool_name: "memory__store_memory"');
+    expect(grok).not.toMatch(/^memory__\w+\(\{/m);
+    expect(grok).not.toContain('mcp__memory__');
+
+    // Prose references are strings, not callables, so they stay backticked.
+    expect(grok).toContain('Prefer `memory__update_memory`');
+
+    // Host-specific guidance that only Grok carries.
+    expect(grok).toContain('Always run `search_tool` before the first `use_tool`');
+    expect(grok).toContain('~/.grok/config.toml');
+    expect(grok).toContain('do not rely on Claude/Cursor compat imports alone');
+
+    // The ritual is narrated, not variable-bound: `use_tool` returns no promise.
+    expect(grok).toContain('// 4) associate when a prior memory exists');
+    expect(grok).not.toContain('const related = await');
+  });
+
+  it('keeps the direct-call style intact for hosts that expose callable tools', () => {
+    const codex = renderCodexMemoryRules({
+      projectName: '{{PROJECT_NAME}}',
+      templateVersion: readPackageVersion(),
+    });
+    expect(codex).toContain('mcp__memory__recall_memory({');
+    expect(codex).toContain('const related = await mcp__memory__recall_memory(');
+    expect(codex).not.toContain('use_tool(');
   });
 
   it('keeps the Hermes provider template aligned with the provider profile', () => {

--- a/src/memory-policy/shared.ts
+++ b/src/memory-policy/shared.ts
@@ -478,14 +478,23 @@ function toolCallInline(style: ToolCallStyle, toolName: string, args: string): s
   return `${style.wrapper}({ tool_name: ${quote(full)}, tool_input: { ${args} } })`;
 }
 
-function renderToolBehaviorSection(): string {
+function renderToolBehaviorSection(style: ToolCallStyle): string {
+  // The recovery path for a budget-truncated response has to be callable on the host
+  // reading it. Direct hosts can invoke the tool by name, so the generic short form is
+  // correct there (and keeps every existing generated artifact byte-identical). A
+  // wrapped host has no callable `recall_memory` at all, so the bare form is an
+  // instruction it cannot follow — the exact failure this style abstraction exists for.
+  const idFetch =
+    style.kind === 'wrapped'
+      ? toolCallInline(style, 'recall_memory', 'memory_id: "<id>"')
+      : 'recall_memory({ memory_id })';
   return [
     "## Tool's real behavior (validated against production corpus)",
     '',
     '- **Tags are a hard gate** - memories without matching tags are excluded before scoring. Use tags for stable categories like `preference` and `bugfix`; do not guess topic tags.',
     '- **One good query beats `queries[]` + `auto_decompose`** for focused tasks. Use `queries[]` only for genuinely multi-topic questions.',
     '- **`limit` caps at 50.** Routine recall should use enough budget to be useful.',
-    '- **Default `text` format shows content previews with created/updated timestamps and importance.** `detailed` adds type/confidence/metadata summary. Responses are budget-capped; fetch a full record with `recall_memory({ memory_id })`.',
+    `- **Default \`text\` format shows content previews with created/updated timestamps and importance.** \`detailed\` adds type/confidence/metadata summary. Responses are budget-capped; fetch a full record with \`${idFetch}\`.`,
     '- **`store_memory` can silently fail.** Verify important stores by recalling a distinctive phrase; retry once if missing.',
     '- **Bare tag convention** - use `automem`, not `project/automem`; no `lang/` prefixes, platform tags, or date-stamped tags. `entity:*:*` tags are server-injected.',
     '',
@@ -701,7 +710,7 @@ export function renderCodexMemoryRules(params: ToolRuleRenderOptions): string {
     '',
     'AutoMem is wired as the `memory` MCP server (see `~/.codex/config.toml`). Tools are `mcp__memory__*`. Use this layer proactively for continuity across turns.',
     '',
-    renderToolBehaviorSection(),
+    renderToolBehaviorSection(style),
     '',
     renderRecallRulesSection({ projectName: params.projectName, style }),
     '',
@@ -741,7 +750,7 @@ export function renderGrokMemoryRules(params: ToolRuleRenderOptions): string {
     '',
     'AutoMem is wired as the `memory` MCP server in `~/.grok/config.toml` (native config — do not rely on Claude/Cursor compat imports alone). Tools are discovered via `search_tool` and called via `use_tool` as `memory__recall_memory`, `memory__store_memory`, etc.',
     '',
-    renderToolBehaviorSection(),
+    renderToolBehaviorSection(style),
     '',
     'Always run `search_tool` before the first `use_tool` on MCP servers.',
     '',
@@ -772,6 +781,7 @@ export type CursorProjectRuleOptions = ToolRuleRenderOptions & {
 };
 
 export function renderCursorProjectRule(params: CursorProjectRuleOptions): string {
+  const style = directStyle(params.mcpToolPrefix);
   return [
     '---',
     'description: AutoMem persistent memory - validated two-phase recall, curated storage, mandatory associations',
@@ -786,15 +796,15 @@ export function renderCursorProjectRule(params: CursorProjectRuleOptions): strin
     '',
     `Tools are \`${params.mcpToolPrefix}*\` (e.g. \`${params.mcpToolPrefix}recall_memory\`). Cursor MCP server: \`${params.mcpServerName}\`.`,
     '',
-    renderToolBehaviorSection(),
+    renderToolBehaviorSection(style),
     '',
     renderRecallRulesSection({
       projectName: params.projectName,
-      style: directStyle(params.mcpToolPrefix),
+      style,
       cursor: true,
     }),
     '',
-    renderStorageRulesSection(directStyle(params.mcpToolPrefix), params.projectName),
+    renderStorageRulesSection(style, params.projectName),
     '',
     '## Optional GPT-5.4 Overlay',
     '',
@@ -837,7 +847,7 @@ export function renderClaudeDesktopInstructions(params: PolicyTemplateOptions): 
     '',
     'Desktop conversations often are not project-scoped. Use semantic recall from the actual content nouns first; add tags only when the user clearly scopes the task.',
     '',
-    renderToolBehaviorSection(),
+    renderToolBehaviorSection(style),
     '',
     renderRecallRulesSection({
       projectName: '<project-slug>',

--- a/src/memory-policy/shared.ts
+++ b/src/memory-policy/shared.ts
@@ -745,6 +745,10 @@ export function renderGrokMemoryRules(params: ToolRuleRenderOptions): string {
     '',
     'Always run `search_tool` before the first `use_tool` on MCP servers.',
     '',
+    // These rules normally live in the global ~/.grok/AGENTS.md and load in every
+    // session, so the project tag below cannot be fixed at install time.
+    'Project tag: use the slug of the repository you are working in. When the examples below show `<project-slug>`, substitute it — these rules load in every Grok session, so no single project is baked in. Drop the tag gate entirely when there is no project or the slug collides with a common word.',
+    '',
     renderRecallRulesSection({ projectName: params.projectName, style }),
     '',
     renderStorageRulesSection(style, params.projectName),

--- a/src/memory-policy/shared.ts
+++ b/src/memory-policy/shared.ts
@@ -421,8 +421,61 @@ function quote(value: string): string {
   return JSON.stringify(value);
 }
 
+/**
+ * How a host spells an AutoMem tool call in its rules.
+ *
+ * `direct` hosts (Codex, Cursor, Claude Code/Desktop, Hermes) expose the tools as
+ * callable names and take arguments directly: `mcp__memory__recall_memory({ … })`.
+ *
+ * `wrapped` hosts route every MCP call through one generic dispatcher, so the tool
+ * name becomes an argument: Grok's `use_tool({ tool_name: "memory__recall_memory",
+ * tool_input: { … } })`. Emitting the direct form for those hosts produces rules the
+ * model cannot execute — the failure mode that shipped for Copilot in #186.
+ */
+export type ToolCallStyle =
+  | { kind: 'direct'; toolPrefix: string }
+  | { kind: 'wrapped'; wrapper: string; toolPrefix: string };
+
+function directStyle(toolPrefix: string): ToolCallStyle {
+  return { kind: 'direct', toolPrefix };
+}
+
 function renderToolCallName(toolPrefix: string, toolName: string): string {
   return `${toolPrefix}${toolName}`;
+}
+
+/** Prose reference to a tool. Wrapped hosts backtick it — it is a string, not a callable. */
+function toolRef(style: ToolCallStyle, toolName: string): string {
+  const full = renderToolCallName(style.toolPrefix, toolName);
+  return style.kind === 'wrapped' ? `\`${full}\`` : full;
+}
+
+/**
+ * Multi-line call. `argLines` carry their own two-space indent and trailing commas so
+ * the direct path stays byte-identical to what it emitted before this abstraction existed.
+ */
+function toolCallBlock(style: ToolCallStyle, toolName: string, argLines: string[]): string[] {
+  const full = renderToolCallName(style.toolPrefix, toolName);
+  if (style.kind === 'direct') {
+    return [`${full}({`, ...argLines, '})'];
+  }
+  return [
+    `${style.wrapper}({`,
+    `  tool_name: ${quote(full)},`,
+    '  tool_input: {',
+    ...argLines.map((line) => `  ${line}`),
+    '  }',
+    '})',
+  ];
+}
+
+/** Single-line call, for the compact steps of the atomic ritual. */
+function toolCallInline(style: ToolCallStyle, toolName: string, args: string): string {
+  const full = renderToolCallName(style.toolPrefix, toolName);
+  if (style.kind === 'direct') {
+    return `${full}({ ${args} })`;
+  }
+  return `${style.wrapper}({ tool_name: ${quote(full)}, tool_input: { ${args} } })`;
 }
 
 function renderToolBehaviorSection(): string {
@@ -444,17 +497,35 @@ function renderToolBehaviorSection(): string {
 
 function renderRecallRulesSection(params: {
   projectName: string;
-  toolPrefix: string;
+  style: ToolCallStyle;
   desktop?: boolean;
   cursor?: boolean;
 }): string {
-  const recall = renderToolCallName(params.toolPrefix, 'recall_memory');
-  const projectTagLine = params.desktop
-    ? ''
-    : `  tags: [${quote(params.projectName)}],        // drop if slug collides with a common word\n`;
-  const cursorRankers = params.cursor
-    ? '  language: "<typescript|python|...>", // optional ranker - boosts, does not gate\n  active_path: "<current file path>"   // optional Cursor ranker\n'
-    : '  language: "<typescript|python|go|rust|...>" // optional ranker\n';
+  const preferenceArgs = [
+    '  tags: ["preference"],',
+    `  limit: ${AUTOMEM_RULES_POLICY_DEFAULTS.preferenceRecallLimit},`,
+    '  sort: "updated_desc"',
+  ];
+  const taskContextArgs = [
+    '  query: "<proper nouns, product names, people, tools, specific topics from the user\'s message>",',
+    ...(params.desktop
+      ? []
+      : [
+          `  tags: [${quote(params.projectName)}],        // drop if slug collides with a common word`,
+        ]),
+    `  time_query: "last ${AUTOMEM_RULES_POLICY_DEFAULTS.contextRecallWindowDays} days",`,
+    `  limit: ${AUTOMEM_RULES_POLICY_DEFAULTS.contextRecallLimit},`,
+    ...(params.cursor
+      ? [
+          '  language: "<typescript|python|...>", // optional ranker - boosts, does not gate',
+          '  active_path: "<current file path>"   // optional Cursor ranker',
+        ]
+      : ['  language: "<typescript|python|go|rust|...>" // optional ranker']),
+  ];
+  const debugArgs = [
+    '  query: "<error symptom or exact message>",',
+    `  limit: ${AUTOMEM_RULES_POLICY_DEFAULTS.debugRecallLimit}`,
+  ];
   const heading = params.desktop
     ? '## Conversation start - semantic-first recall'
     : '## Session start — two-phase recall';
@@ -482,22 +553,13 @@ function renderRecallRulesSection(params: {
     'Preferences first:',
     '',
     '```javascript',
-    `${recall}({`,
-    '  tags: ["preference"],',
-    `  limit: ${AUTOMEM_RULES_POLICY_DEFAULTS.preferenceRecallLimit},`,
-    '  sort: "updated_desc"',
-    '})',
+    ...toolCallBlock(params.style, 'recall_memory', preferenceArgs),
     '```',
     '',
     'Task context: one semantic query built from proper nouns, products, files, error strings, tools, and specific topics in the user message.',
     '',
     '```javascript',
-    `${recall}({`,
-    '  query: "<proper nouns, product names, people, tools, specific topics from the user\'s message>",',
-    `${projectTagLine}  time_query: "last ${AUTOMEM_RULES_POLICY_DEFAULTS.contextRecallWindowDays} days",`,
-    `  limit: ${AUTOMEM_RULES_POLICY_DEFAULTS.contextRecallLimit},`,
-    cursorRankers.trimEnd(),
-    '})',
+    ...toolCallBlock(params.style, 'recall_memory', taskContextArgs),
     '```',
     '',
     'Skip task-context recall for pure syntax questions, trivial edits, one-off calculations, direct factual queries about current files, or casual openings.',
@@ -505,10 +567,7 @@ function renderRecallRulesSection(params: {
     'Debug context, only when actively investigating a concrete symptom:',
     '',
     '```javascript',
-    `${recall}({`,
-    '  query: "<error symptom or exact message>",',
-    `  limit: ${AUTOMEM_RULES_POLICY_DEFAULTS.debugRecallLimit}`,
-    '})',
+    ...toolCallBlock(params.style, 'recall_memory', debugArgs),
     '```',
     '',
     'No tag gate on debug recall - bugfix/solution tagging is incomplete and a hard gate hides cross-corpus fixes.',
@@ -519,11 +578,61 @@ function renderRecallRulesSection(params: {
   ].join('\n');
 }
 
-function renderStorageRulesSection(toolPrefix: string, projectName: string): string {
-  const recall = renderToolCallName(toolPrefix, 'recall_memory');
-  const store = renderToolCallName(toolPrefix, 'store_memory');
-  const update = renderToolCallName(toolPrefix, 'update_memory');
-  const associate = renderToolCallName(toolPrefix, 'associate_memories');
+/**
+ * The four-step ritual, told two ways. Direct hosts bind results to variables and
+ * await them; wrapped hosts have no promise API to bind, so the steps are numbered
+ * comments with placeholder ids. Forcing one template to serve both would produce
+ * `const related = await use_tool(…)` — syntactically fine, semantically wrong.
+ */
+function renderAtomicRitual(style: ToolCallStyle, projectName: string): string[] {
+  const storeArgs = [
+    '  content: "Brief title. Context + reasoning. Outcome.",',
+    '  type: "Preference",',
+    `  tags: ["correction", ${quote(projectName)}],`,
+    '  importance: 0.9,',
+    '  confidence: 0.95',
+  ];
+
+  if (style.kind === 'direct') {
+    const recall = renderToolCallName(style.toolPrefix, 'recall_memory');
+    const store = renderToolCallName(style.toolPrefix, 'store_memory');
+    const associate = renderToolCallName(style.toolPrefix, 'associate_memories');
+    return [
+      `const related = await ${recall}({ query: "<what is being corrected / decided / named>", limit: 5 })`,
+      `const stored = await ${store}({`,
+      ...storeArgs,
+      '})',
+      `await ${recall}({ query: "<distinctive phrase from content>", limit: 3 })`,
+      'if (related?.results?.length) {',
+      `  await ${associate}({ memory1_id: related.results[0].id, memory2_id: stored.memory_id, type: "INVALIDATED_BY", strength: 0.9 })`,
+      '}',
+    ];
+  }
+
+  return [
+    '// 1) recall related',
+    toolCallInline(
+      style,
+      'recall_memory',
+      'query: "<what is being corrected / decided / named>", limit: 5'
+    ),
+    '// 2) store',
+    ...toolCallBlock(style, 'store_memory', storeArgs),
+    '// 3) verify with a distinctive phrase',
+    toolCallInline(style, 'recall_memory', 'query: "<distinctive phrase from content>", limit: 3'),
+    '// 4) associate when a prior memory exists',
+    ...toolCallBlock(style, 'associate_memories', [
+      '  memory1_id: "<related-id>",',
+      '  memory2_id: "<stored-id>",',
+      '  type: "INVALIDATED_BY",',
+      '  strength: 0.9',
+    ]),
+  ];
+}
+
+function renderStorageRulesSection(style: ToolCallStyle, projectName: string): string {
+  const update = toolRef(style, 'update_memory');
+  const associate = toolRef(style, 'associate_memories');
 
   return [
     '## Storage Discipline',
@@ -531,13 +640,13 @@ function renderStorageRulesSection(toolPrefix: string, projectName: string): str
     'Store only durable decisions, corrections, explicit preferences, bug-fix root causes, and articulated reusable patterns. Never store secrets, credentials, tokens, PII, session summaries, progress reports, confirmations, speculative context, or attentiveness notes.',
     '',
     '```javascript',
-    `${store}({`,
-    '  content: "Brief title. Context + reasoning. Outcome.",',
-    '  type: "Decision",',
-    `  tags: ["<category>", ${quote(projectName)}, "<language>"], // bare strings; NO platform tag, NO [YYYY-MM]`,
-    '  importance: 0.85,',
-    '  confidence: 0.9',
-    '})',
+    ...toolCallBlock(style, 'store_memory', [
+      '  content: "Brief title. Context + reasoning. Outcome.",',
+      '  type: "Decision",',
+      `  tags: ["<category>", ${quote(projectName)}, "<language>"], // bare strings; NO platform tag, NO [YYYY-MM]`,
+      '  importance: 0.85,',
+      '  confidence: 0.9',
+    ]),
     '```',
     '',
     'Use content of 150-300 chars when possible; put file paths, metrics, exit codes, and other structured details in `metadata`. For facts with a shelf life, use `t_valid` and `t_invalid` instead of date tags.',
@@ -551,18 +660,7 @@ function renderStorageRulesSection(toolPrefix: string, projectName: string): str
     '### The atomic ritual - every store runs all four steps',
     '',
     '```javascript',
-    `const related = await ${recall}({ query: "<what is being corrected / decided / named>", limit: 5 })`,
-    `const stored = await ${store}({`,
-    '  content: "Brief title. Context + reasoning. Outcome.",',
-    '  type: "Preference",',
-    `  tags: ["correction", ${quote(projectName)}],`,
-    '  importance: 0.9,',
-    '  confidence: 0.95',
-    '})',
-    `await ${recall}({ query: "<distinctive phrase from content>", limit: 3 })`,
-    'if (related?.results?.length) {',
-    `  await ${associate}({ memory1_id: related.results[0].id, memory2_id: stored.memory_id, type: "INVALIDATED_BY", strength: 0.9 })`,
-    '}',
+    ...renderAtomicRitual(style, projectName),
     '```',
     '',
     'Step 4 is where the graph gets built. Skipping it is the main reason AutoMem degrades into a flat bag of notes.',
@@ -594,7 +692,7 @@ function renderMemoryVsCurrentState(): string {
 }
 
 export function renderCodexMemoryRules(params: ToolRuleRenderOptions): string {
-  const toolPrefix = params.toolPrefix ?? 'mcp__memory__';
+  const style = directStyle(params.toolPrefix ?? 'mcp__memory__');
   return [
     '<!-- BEGIN AUTOMEM CODEX RULES -->',
     `<!-- automem-template-version: ${params.templateVersion} -->`,
@@ -605,9 +703,9 @@ export function renderCodexMemoryRules(params: ToolRuleRenderOptions): string {
     '',
     renderToolBehaviorSection(),
     '',
-    renderRecallRulesSection({ projectName: params.projectName, toolPrefix }),
+    renderRecallRulesSection({ projectName: params.projectName, style }),
     '',
-    renderStorageRulesSection(toolPrefix, params.projectName),
+    renderStorageRulesSection(style, params.projectName),
     '',
     '## Guidelines',
     '',
@@ -618,6 +716,48 @@ export function renderCodexMemoryRules(params: ToolRuleRenderOptions): string {
     renderMemoryVsCurrentState(),
     '',
     '<!-- END AUTOMEM CODEX RULES -->',
+    '',
+  ].join('\n');
+}
+
+/**
+ * Grok Build reaches MCP tools through `search_tool` discovery + a generic `use_tool`
+ * dispatcher, so its rules need the wrapped call style. The native-config warning is
+ * load-bearing: when AutoMem is only present via Grok's Claude/Cursor compat import,
+ * the stdio server starts without AUTOMEM_* env and every recall fails with
+ * "fetch failed" against the default localhost endpoint.
+ */
+export function renderGrokMemoryRules(params: ToolRuleRenderOptions): string {
+  const style: ToolCallStyle = {
+    kind: 'wrapped',
+    wrapper: 'use_tool',
+    toolPrefix: params.toolPrefix ?? 'memory__',
+  };
+  return [
+    '<!-- BEGIN AUTOMEM GROK RULES -->',
+    `<!-- automem-template-version: ${params.templateVersion} -->`,
+    '',
+    `## Memory - AutoMem (persistent context for ${params.projectName})`,
+    '',
+    'AutoMem is wired as the `memory` MCP server in `~/.grok/config.toml` (native config — do not rely on Claude/Cursor compat imports alone). Tools are discovered via `search_tool` and called via `use_tool` as `memory__recall_memory`, `memory__store_memory`, etc.',
+    '',
+    renderToolBehaviorSection(),
+    '',
+    'Always run `search_tool` before the first `use_tool` on MCP servers.',
+    '',
+    renderRecallRulesSection({ projectName: params.projectName, style }),
+    '',
+    renderStorageRulesSection(style, params.projectName),
+    '',
+    '## Guidelines',
+    '',
+    '- Weave recalled context naturally; do not announce memory operations.',
+    '- Prefer high-signal memories: decisions, root causes, reusable patterns, and explicit preferences.',
+    '- Avoid wall-of-text memories; keep them atomic and focused.',
+    '',
+    renderMemoryVsCurrentState(),
+    '',
+    '<!-- END AUTOMEM GROK RULES -->',
     '',
   ].join('\n');
 }
@@ -646,11 +786,11 @@ export function renderCursorProjectRule(params: CursorProjectRuleOptions): strin
     '',
     renderRecallRulesSection({
       projectName: params.projectName,
-      toolPrefix: params.mcpToolPrefix,
+      style: directStyle(params.mcpToolPrefix),
       cursor: true,
     }),
     '',
-    renderStorageRulesSection(params.mcpToolPrefix, params.projectName),
+    renderStorageRulesSection(directStyle(params.mcpToolPrefix), params.projectName),
     '',
     '## Optional GPT-5.4 Overlay',
     '',
@@ -673,7 +813,7 @@ export function renderCursorProjectRule(params: CursorProjectRuleOptions): strin
 }
 
 export function renderClaudeDesktopInstructions(params: PolicyTemplateOptions): string {
-  const toolPrefix = 'mcp__memory__';
+  const style = directStyle('mcp__memory__');
   return [
     '# Claude Desktop Personal Preferences Template',
     '',
@@ -697,11 +837,11 @@ export function renderClaudeDesktopInstructions(params: PolicyTemplateOptions): 
     '',
     renderRecallRulesSection({
       projectName: '<project-slug>',
-      toolPrefix,
+      style,
       desktop: true,
     }),
     '',
-    renderStorageRulesSection(toolPrefix, '<project-slug>'),
+    renderStorageRulesSection(style, '<project-slug>'),
     '',
     renderMemoryVsCurrentState(),
     '',

--- a/templates/grok/config.toml
+++ b/templates/grok/config.toml
@@ -1,0 +1,27 @@
+# AutoMem MCP Server Configuration for Grok Build (xAI)
+#
+# Written by: npx @verygoodplugins/mcp-automem grok
+# Or:         npx @verygoodplugins/mcp-automem install --clients grok
+#
+# Native [mcp_servers.memory] beats Claude/Cursor compat imports. Without
+# AUTOMEM_* env on the stdio process, mcp-automem defaults to
+# http://127.0.0.1:8001 and recall fails with "fetch failed".
+#
+# Setup: https://github.com/verygoodplugins/mcp-automem/blob/main/INSTALLATION.md#grok-build
+
+[mcp_servers.memory]
+command = "npx"
+args = ["-y", "@verygoodplugins/mcp-automem"]
+enabled = true
+
+[mcp_servers.memory.env]
+# Replace with your AutoMem instance URL
+AUTOMEM_API_URL = "https://your-automem-instance.railway.app"
+
+# Optional: API key if your instance requires authentication
+AUTOMEM_API_KEY = "your-api-key-if-required"
+
+AUTOMEM_PROCESS_TAG = "grok:memory"
+
+# For local development:
+# AUTOMEM_API_URL = "http://127.0.0.1:8001"

--- a/templates/grok/memory-rules.md
+++ b/templates/grok/memory-rules.md
@@ -20,6 +20,8 @@ Drop the project tag gate when the slug collides with common topic words: `api`,
 
 Always run `search_tool` before the first `use_tool` on MCP servers.
 
+Project tag: use the slug of the repository you are working in. When the examples below show `<project-slug>`, substitute it — these rules load in every Grok session, so no single project is baked in. Drop the tag gate entirely when there is no project or the slug collides with a common word.
+
 ## Session start — two-phase recall
 
 Standardized defaults: preferences limit 20, task-context limit 30, 90-day task window.

--- a/templates/grok/memory-rules.md
+++ b/templates/grok/memory-rules.md
@@ -18,20 +18,24 @@ AutoMem is wired as the `memory` MCP server in `~/.grok/config.toml` (native con
 
 Drop the project tag gate when the slug collides with common topic words: `api`, `app`, `test`, `video`. Use semantic query alone in that case.
 
+Always run `search_tool` before the first `use_tool` on MCP servers.
+
 ## Session start — two-phase recall
 
 Standardized defaults: preferences limit 20, task-context limit 30, 90-day task window.
 
 Preferences and task context are independent recalls - issue them in parallel in a single message.
 
-Always run `search_tool` before the first `use_tool` on MCP servers.
-
 Preferences first:
 
 ```javascript
 use_tool({
   tool_name: "memory__recall_memory",
-  tool_input: { tags: ["preference"], limit: 20, sort: "updated_desc" }
+  tool_input: {
+    tags: ["preference"],
+    limit: 20,
+    sort: "updated_desc"
+  }
 })
 ```
 
@@ -57,7 +61,10 @@ Debug context, only when actively investigating a concrete symptom:
 ```javascript
 use_tool({
   tool_name: "memory__recall_memory",
-  tool_input: { query: "<error symptom or exact message>", limit: 20 }
+  tool_input: {
+    query: "<error symptom or exact message>",
+    limit: 20
+  }
 })
 ```
 

--- a/templates/grok/memory-rules.md
+++ b/templates/grok/memory-rules.md
@@ -10,7 +10,7 @@ AutoMem is wired as the `memory` MCP server in `~/.grok/config.toml` (native con
 - **Tags are a hard gate** - memories without matching tags are excluded before scoring. Use tags for stable categories like `preference` and `bugfix`; do not guess topic tags.
 - **One good query beats `queries[]` + `auto_decompose`** for focused tasks. Use `queries[]` only for genuinely multi-topic questions.
 - **`limit` caps at 50.** Routine recall should use enough budget to be useful.
-- **Default `text` format shows content previews with created/updated timestamps and importance.** `detailed` adds type/confidence/metadata summary. Responses are budget-capped; fetch a full record with `recall_memory({ memory_id })`.
+- **Default `text` format shows content previews with created/updated timestamps and importance.** `detailed` adds type/confidence/metadata summary. Responses are budget-capped; fetch a full record with `use_tool({ tool_name: "memory__recall_memory", tool_input: { memory_id: "<id>" } })`.
 - **`store_memory` can silently fail.** Verify important stores by recalling a distinctive phrase; retry once if missing.
 - **Bare tag convention** - use `automem`, not `project/automem`; no `lang/` prefixes, platform tags, or date-stamped tags. `entity:*:*` tags are server-injected.
 

--- a/templates/grok/memory-rules.md
+++ b/templates/grok/memory-rules.md
@@ -1,0 +1,160 @@
+<!-- BEGIN AUTOMEM GROK RULES -->
+<!-- automem-template-version: 0.15.0 -->
+
+## Memory - AutoMem (persistent context for {{PROJECT_NAME}})
+
+AutoMem is wired as the `memory` MCP server in `~/.grok/config.toml` (native config — do not rely on Claude/Cursor compat imports alone). Tools are discovered via `search_tool` and called via `use_tool` as `memory__recall_memory`, `memory__store_memory`, etc.
+
+## Tool's real behavior (validated against production corpus)
+
+- **Tags are a hard gate** - memories without matching tags are excluded before scoring. Use tags for stable categories like `preference` and `bugfix`; do not guess topic tags.
+- **One good query beats `queries[]` + `auto_decompose`** for focused tasks. Use `queries[]` only for genuinely multi-topic questions.
+- **`limit` caps at 50.** Routine recall should use enough budget to be useful.
+- **Default `text` format shows content previews with created/updated timestamps and importance.** `detailed` adds type/confidence/metadata summary. Responses are budget-capped; fetch a full record with `recall_memory({ memory_id })`.
+- **`store_memory` can silently fail.** Verify important stores by recalling a distinctive phrase; retry once if missing.
+- **Bare tag convention** - use `automem`, not `project/automem`; no `lang/` prefixes, platform tags, or date-stamped tags. `entity:*:*` tags are server-injected.
+
+### Slug-collision rule
+
+Drop the project tag gate when the slug collides with common topic words: `api`, `app`, `test`, `video`. Use semantic query alone in that case.
+
+## Session start — two-phase recall
+
+Standardized defaults: preferences limit 20, task-context limit 30, 90-day task window.
+
+Preferences and task context are independent recalls - issue them in parallel in a single message.
+
+Always run `search_tool` before the first `use_tool` on MCP servers.
+
+Preferences first:
+
+```javascript
+use_tool({
+  tool_name: "memory__recall_memory",
+  tool_input: { tags: ["preference"], limit: 20, sort: "updated_desc" }
+})
+```
+
+Task context: one semantic query built from proper nouns, products, files, error strings, tools, and specific topics in the user message.
+
+```javascript
+use_tool({
+  tool_name: "memory__recall_memory",
+  tool_input: {
+    query: "<proper nouns, product names, people, tools, specific topics from the user's message>",
+    tags: ["{{PROJECT_NAME}}"],        // drop if slug collides with a common word
+    time_query: "last 90 days",
+    limit: 30,
+    language: "<typescript|python|go|rust|...>" // optional ranker
+  }
+})
+```
+
+Skip task-context recall for pure syntax questions, trivial edits, one-off calculations, direct factual queries about current files, or casual openings.
+
+Debug context, only when actively investigating a concrete symptom:
+
+```javascript
+use_tool({
+  tool_name: "memory__recall_memory",
+  tool_input: { query: "<error symptom or exact message>", limit: 20 }
+})
+```
+
+No tag gate on debug recall - bugfix/solution tagging is incomplete and a hard gate hides cross-corpus fixes.
+
+Don't re-recall mid-conversation unless the topic genuinely shifts, a new proper noun enters, or active debugging starts.
+
+### When recall misses
+
+Escalate only when the task-context recall comes back too broad or empty:
+
+- **Too broad** - add a tag gate (a stable category like `preference`/`bugfix`, or the unambiguous project slug) and tighten the query to the real nouns.
+- **Empty** - drop the time window first (the topic may be dormant-but-important), then broaden the query.
+- **Sparse under a tag gate** - drop the gate and rely on the semantic query alone; older memories use `project/<slug>` prefixes, so gated queries can miss historical content.
+- **Need graph traversal** - use `expand_relations: true`; add `expand_respect_tags: true` when traversal must stay inside the tag gate, or leave it false/drop tags when broader graph context is useful.
+
+## Storage Discipline
+
+Store only durable decisions, corrections, explicit preferences, bug-fix root causes, and articulated reusable patterns. Never store secrets, credentials, tokens, PII, session summaries, progress reports, confirmations, speculative context, or attentiveness notes.
+
+```javascript
+use_tool({
+  tool_name: "memory__store_memory",
+  tool_input: {
+    content: "Brief title. Context + reasoning. Outcome.",
+    type: "Decision",
+    tags: ["<category>", "{{PROJECT_NAME}}", "<language>"], // bare strings; NO platform tag, NO [YYYY-MM]
+    importance: 0.85,
+    confidence: 0.9
+  }
+})
+```
+
+Use content of 150-300 chars when possible; put file paths, metrics, exit codes, and other structured details in `metadata`. For facts with a shelf life, use `t_valid` and `t_invalid` instead of date tags.
+
+### Three mid-conversation triggers (and only three)
+
+1. **User correction or override.** Listen for: "actually", "no, I prefer", "not X, Y", "that's wrong", "stop doing X", "never do X", "I told you before", "we decided X already". Store as `Preference`, importance 0.9, confidence 0.95, tag `correction`, then associate `INVALIDATED_BY` the prior memory.
+2. **Decision stabilizes after at least one round of discussion.** Listen for: "let's go with X", "yeah that's the plan", "ship it", "do it that way", "final answer", "okay let's do that". Store as `Decision`, importance 0.85-0.9, then associate `PREFERS_OVER` alternatives if they came up.
+3. **Pattern articulated - not inferred.** Listen for: "I always do X", "every time", "this is how I usually", "my thing is". Store as `Pattern`, importance 0.8, then associate concrete examples with `EXEMPLIFIES`.
+
+### The atomic ritual - every store runs all four steps
+
+```javascript
+// 1) recall related
+use_tool({ tool_name: "memory__recall_memory", tool_input: { query: "<what is being corrected / decided / named>", limit: 5 } })
+// 2) store
+use_tool({
+  tool_name: "memory__store_memory",
+  tool_input: {
+    content: "Brief title. Context + reasoning. Outcome.",
+    type: "Preference",
+    tags: ["correction", "{{PROJECT_NAME}}"],
+    importance: 0.9,
+    confidence: 0.95
+  }
+})
+// 3) verify with a distinctive phrase
+use_tool({ tool_name: "memory__recall_memory", tool_input: { query: "<distinctive phrase from content>", limit: 3 } })
+// 4) associate when a prior memory exists
+use_tool({
+  tool_name: "memory__associate_memories",
+  tool_input: {
+    memory1_id: "<related-id>",
+    memory2_id: "<stored-id>",
+    type: "INVALIDATED_BY",
+    strength: 0.9
+  }
+})
+```
+
+Step 4 is where the graph gets built. Skipping it is the main reason AutoMem degrades into a flat bag of notes.
+
+### Mandatory association pairings
+
+| Trigger | Store as | Then associate |
+|---|---|---|
+| User correction | `Preference`, 0.9 / 0.95 | Old memory -> `INVALIDATED_BY` |
+| Architectural decision | `Decision`, 0.9 / 0.9 | Alternatives -> `PREFERS_OVER` |
+| Bug fix | `Insight`, 0.75 / 0.85, tags `bugfix` + `solution` | Bug report -> `LEADS_TO` |
+| Pattern discovered | `Pattern`, 0.8 | Concrete examples -> `EXEMPLIFIES` |
+| Knowledge evolved | `update_memory` old + store new | Old -> `EVOLVED_INTO` |
+| Deprecated info | `update_memory` old with deprecated metadata | Old <- `INVALIDATED_BY` |
+
+Prefer `memory__update_memory` over a duplicate store when a fact changes in place.
+Valid relation types for `memory__associate_memories`: RELATES_TO, LEADS_TO, OCCURRED_BEFORE, PREFERS_OVER, EXEMPLIFIES, CONTRADICTS, REINFORCES, INVALIDATED_BY, EVOLVED_INTO, DERIVED_FROM, PART_OF.
+
+## Guidelines
+
+- Weave recalled context naturally; do not announce memory operations.
+- Prefer high-signal memories: decisions, root causes, reusable patterns, and explicit preferences.
+- Avoid wall-of-text memories; keep them atomic and focused.
+
+## Memory vs current state
+
+Recalled context is a prior, not ground truth. If a memory disagrees with the current repo state, the user's latest instruction, or a freshly read file - **current evidence wins**. Update or invalidate stale memory instead of acting on it.
+
+If recall fails or returns nothing, continue without memory and do not mention the failure to the user. Weave recalled context naturally.
+
+<!-- END AUTOMEM GROK RULES -->

--- a/tests/docs/host-parity.test.ts
+++ b/tests/docs/host-parity.test.ts
@@ -1,0 +1,172 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+import {
+  AGENT_CLIENTS,
+  STANDALONE_PLATFORMS,
+  UNINSTALL_PLATFORMS,
+  UNINSTALL_UNSUPPORTED_CLIENTS,
+  type AgentClient,
+} from '../../src/cli/clients.js';
+import { uninstallHandlerPlatforms } from '../../src/cli/uninstall.js';
+import { HOST_SMOKE_SPECS } from '../helpers/host-specs.js';
+
+/** Derived, not hard-coded: a second standalone host must declare its rules artifact too. */
+type StandalonePlatform = (typeof STANDALONE_PLATFORMS)[number];
+
+/**
+ * Adding a host used to mean updating six independent hand-maintained lists, and only
+ * one of them was type-checked. The gaps that produced — OpenClaw installable but not
+ * uninstallable, Grok missing from the policy generator, Copilot missing from the CLI's
+ * known-commands set — were all invisible until someone tripped over them.
+ *
+ * These assertions turn each of those edges into a test failure. Where a gap is
+ * knowingly accepted, it belongs in an exclusion list here with a reason, not in silence.
+ */
+
+const REPO_ROOT = path.resolve(fileURLToPath(new URL('../..', import.meta.url)));
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), 'utf8');
+}
+
+/**
+ * Hosts whose memory rules are still hand-written instead of rendered from
+ * src/memory-policy/shared.ts. Copilot is known debt: #186 ("prefix CLI memory rule
+ * tool calls") was exactly the drift this list exists to make visible. Removing an
+ * entry here is the point — do not add one to make a failure go away.
+ */
+const HAND_WRITTEN_RULES: readonly string[] = ['copilot'];
+
+/**
+ * Rules artifact each client's installer reads. Deliberately a **total** Record with an
+ * explicit `null` for clients that ship none: a `Partial` would let a new client omit
+ * its entry and skip the generator check silently — the exact drift this suite exists
+ * to catch. Adding to `AgentClient` is a compile error until it is declared here.
+ */
+const RULES_TEMPLATES: Record<AgentClient | StandalonePlatform, string | null> = {
+  codex: 'templates/codex/memory-rules.md',
+  cursor: 'templates/cursor/automem.mdc.template',
+  hermes: 'templates/hermes/memory-rules.md',
+  grok: 'templates/grok/memory-rules.md',
+  copilot: 'templates/COPILOT_INSTRUCTIONS_MEMORY_RULES.md',
+  // Ships hooks, not a rules file; its policy lives in the generated hook scripts.
+  'claude-code': null,
+  // Renders policy in-process at runtime (renderOpenClawPolicyContext), no template.
+  openclaw: null,
+};
+
+describe('host integration parity', () => {
+  it('gives every installer client an uninstall path or a documented exclusion', () => {
+    for (const client of AGENT_CLIENTS) {
+      const uninstallable = (UNINSTALL_PLATFORMS as readonly string[]).includes(client);
+      const excluded = (UNINSTALL_UNSUPPORTED_CLIENTS as readonly string[]).includes(client);
+      expect(
+        uninstallable || excluded,
+        `AGENT_CLIENTS includes '${client}' but it has no uninstall path. ` +
+          'Add one in src/cli/uninstall.ts, or list it in UNINSTALL_UNSUPPORTED_CLIENTS with a reason.'
+      ).toBe(true);
+      expect(
+        uninstallable && excluded,
+        `'${client}' is both uninstallable and listed as unsupported — drop it from UNINSTALL_UNSUPPORTED_CLIENTS.`
+      ).toBe(false);
+    }
+  });
+
+  it('routes every uninstall platform through a registered handler', () => {
+    // Asserted against the real dispatch map, not a source substring: `options.platform
+    // === 'cursor'` (and 'claude-code', 'copilot') also appear in the --clean-all and
+    // next-steps blocks, so a grep stayed green even with the dispatch branch deleted.
+    const handled = new Set(uninstallHandlerPlatforms());
+    for (const platform of UNINSTALL_PLATFORMS) {
+      expect(
+        handled.has(platform),
+        `uninstall accepts '${platform}' but no handler is registered for it.`
+      ).toBe(true);
+    }
+    // And nothing is reachable that the CLI does not accept.
+    for (const platform of handled) {
+      expect(
+        (UNINSTALL_PLATFORMS as readonly string[]).includes(platform),
+        `A handler exists for '${platform}' but parseUninstallArgs rejects it.`
+      ).toBe(true);
+    }
+  });
+
+  it('gives every installer client at least one host smoke spec', () => {
+    // Uninstall support and setup-boundary coverage are unrelated concerns. Reusing the
+    // uninstall exclusion here previously let OpenClaw — an installable, default-selected
+    // client — escape smoke coverage entirely while this suite still passed.
+    const covered = new Set(HOST_SMOKE_SPECS.map((spec) => spec.client));
+    for (const client of AGENT_CLIENTS) {
+      expect(
+        covered.has(client),
+        `AGENT_CLIENTS includes '${client}' but tests/helpers/host-specs.ts has no spec for it.`
+      ).toBe(true);
+    }
+    for (const platform of STANDALONE_PLATFORMS) {
+      expect(
+        covered.has(platform),
+        `'${platform}' ships setup and uninstall commands but has no host smoke spec.`
+      ).toBe(true);
+    }
+  });
+
+  it('describes each registration surface exactly once', () => {
+    // Surfaces are keyed by host id; a duplicate means two entries are silently
+    // competing to define the same contract. (Tool names are deliberately *not*
+    // unique across surfaces — Codex and Claude Code both use `mcp__memory__*`.)
+    const seen = new Set<string>();
+    for (const spec of HOST_SMOKE_SPECS) {
+      expect(seen.has(spec.host), `Duplicate host smoke spec for '${spec.host}'.`).toBe(false);
+      seen.add(spec.host);
+    }
+  });
+
+  it('ties every host smoke spec to a real client', () => {
+    const known = new Set<string>([...AGENT_CLIENTS, ...STANDALONE_PLATFORMS]);
+    for (const spec of HOST_SMOKE_SPECS) {
+      expect(
+        known.has(spec.client),
+        `Host '${spec.host}' claims client '${spec.client}', which is neither an AgentClient nor a standalone platform.`
+      ).toBe(true);
+    }
+  });
+
+  it('generates every shipped rules template from the shared memory policy', () => {
+    const sync = readRepoFile('scripts/sync-memory-policy.ts');
+    for (const [client, template] of Object.entries(RULES_TEMPLATES)) {
+      if (!template) continue;
+      expect(
+        fs.existsSync(path.join(REPO_ROOT, template)),
+        `RULES_TEMPLATES points '${client}' at ${template}, which does not exist.`
+      ).toBe(true);
+
+      if (HAND_WRITTEN_RULES.includes(client)) {
+        // Assert the debt is real, so this entry disappears when the host is migrated.
+        expect(
+          sync.includes(template),
+          `'${client}' is listed in HAND_WRITTEN_RULES but ${template} is now generated — remove it from that list.`
+        ).toBe(false);
+        continue;
+      }
+
+      expect(
+        sync.includes(template),
+        `${template} is not registered in scripts/sync-memory-policy.ts, so it will silently drift ` +
+          'from src/memory-policy/shared.ts. Add a renderer, or list the client in HAND_WRITTEN_RULES.'
+      ).toBe(true);
+    }
+  });
+
+  it('recognizes every routed host setup command in the CLI', () => {
+    const source = readRepoFile('src/index.ts');
+    for (const command of [...AGENT_CLIENTS, ...STANDALONE_PLATFORMS]) {
+      expect(
+        source.includes(`command === '${command}'`),
+        `'${command}' is a known command but src/index.ts never routes it.`
+      ).toBe(true);
+    }
+  });
+});

--- a/tests/docs/integration-coverage.test.ts
+++ b/tests/docs/integration-coverage.test.ts
@@ -36,6 +36,7 @@ const DISPLAY_NAMES: Record<AgentClient, string> = {
   cursor: 'Cursor',
   openclaw: 'OpenClaw',
   hermes: 'Hermes',
+  grok: 'Grok',
 };
 
 /** Extract a markdown section: its heading line through (excluding) the next heading. */

--- a/tests/docs/integration-coverage.test.ts
+++ b/tests/docs/integration-coverage.test.ts
@@ -36,7 +36,7 @@ const DISPLAY_NAMES: Record<AgentClient, string> = {
   cursor: 'Cursor',
   openclaw: 'OpenClaw',
   hermes: 'Hermes',
-  grok: 'Grok',
+  grok: 'Grok Build',
 };
 
 /** Extract a markdown section: its heading line through (excluding) the next heading. */

--- a/tests/helpers/host-specs.ts
+++ b/tests/helpers/host-specs.ts
@@ -1,5 +1,5 @@
 export interface HostSmokeSpec {
-  host: 'hermes' | 'codex' | 'claude-code' | 'cursor' | 'copilot-cli' | 'vscode-copilot';
+  host: 'hermes' | 'codex' | 'claude-code' | 'cursor' | 'copilot-cli' | 'vscode-copilot' | 'grok';
   configPath: string;
   installCommand: string[];
   expectedToolNames: string[];
@@ -60,6 +60,13 @@ export const HOST_SMOKE_SPECS: HostSmokeSpec[] = [
     configPath: '.vscode/mcp.json',
     installCommand: ['mcp-automem', 'copilot', '--format', 'vscode'],
     expectedToolNames: RAW_AUTOMEM_TOOLS.map((name) => `mcp_automem_${name}`).sort(),
+    realHostSmoke: 'config-and-mcp-contract',
+  },
+  {
+    host: 'grok',
+    configPath: '~/.grok/config.toml',
+    installCommand: ['mcp-automem', 'grok'],
+    expectedToolNames: RAW_AUTOMEM_TOOLS.map((name) => `memory__${name}`).sort(),
     realHostSmoke: 'config-and-mcp-contract',
   },
 ];

--- a/tests/helpers/host-specs.ts
+++ b/tests/helpers/host-specs.ts
@@ -1,5 +1,26 @@
+import type { AgentClient } from '../../src/cli/clients.js';
+
 export interface HostSmokeSpec {
-  host: 'hermes' | 'codex' | 'claude-code' | 'cursor' | 'copilot-cli' | 'vscode-copilot' | 'grok';
+  /**
+   * The MCP *registration surface*, not the installer client. One client can expose
+   * several (Copilot registers separately for its CLI and for VS Code), and the surface
+   * is what determines the tool-name mangling below.
+   */
+  host:
+    | 'hermes'
+    | 'codex'
+    | 'claude-code'
+    | 'cursor'
+    | 'copilot-cli'
+    | 'vscode-copilot'
+    | 'grok'
+    | 'openclaw';
+  /**
+   * The installer client this surface belongs to, or 'copilot' for the standalone
+   * platform. tests/docs/host-parity.test.ts uses this to prove every client has
+   * smoke coverage.
+   */
+  client: AgentClient | 'copilot';
   configPath: string;
   installCommand: string[];
   expectedToolNames: string[];
@@ -16,10 +37,20 @@ const RAW_AUTOMEM_TOOLS = [
   'check_database_health',
 ];
 const HERMES_AUTOMEM_TOOLS = RAW_AUTOMEM_TOOLS.filter((name) => name !== 'delete_memory');
+/**
+ * OpenClaw registers its tools in-process from src/openclaw-plugin.ts rather than over
+ * stdio MCP, and shortens one of them: `check_database_health` is exposed as
+ * `automem_check_health`. That rename is exactly the kind of per-host quirk these specs
+ * exist to pin down.
+ */
+const OPENCLAW_AUTOMEM_TOOLS = RAW_AUTOMEM_TOOLS.map((name) =>
+  name === 'check_database_health' ? 'automem_check_health' : `automem_${name}`
+);
 
 export const HOST_SMOKE_SPECS: HostSmokeSpec[] = [
   {
     host: 'hermes',
+    client: 'hermes',
     configPath: '$HERMES_HOME/config.yaml',
     installCommand: ['mcp-automem', 'hermes', '--mode', 'mcp'],
     expectedToolNames: HERMES_AUTOMEM_TOOLS.map((name) => `mcp_automem_${name}`).sort(),
@@ -28,6 +59,7 @@ export const HOST_SMOKE_SPECS: HostSmokeSpec[] = [
   },
   {
     host: 'codex',
+    client: 'codex',
     configPath: '~/.codex/config.toml',
     installCommand: ['mcp-automem', 'codex'],
     expectedToolNames: RAW_AUTOMEM_TOOLS.map((name) => `mcp__memory__${name}`).sort(),
@@ -35,6 +67,7 @@ export const HOST_SMOKE_SPECS: HostSmokeSpec[] = [
   },
   {
     host: 'cursor',
+    client: 'cursor',
     configPath: '~/.cursor/mcp.json',
     installCommand: ['mcp-automem', 'cursor'],
     expectedToolNames: RAW_AUTOMEM_TOOLS.map((name) => `mcp_memory_${name}`).sort(),
@@ -42,6 +75,7 @@ export const HOST_SMOKE_SPECS: HostSmokeSpec[] = [
   },
   {
     host: 'claude-code',
+    client: 'claude-code',
     configPath: '~/.claude.json',
     installCommand: ['mcp-automem', 'claude-code'],
     expectedToolNames: RAW_AUTOMEM_TOOLS.map((name) => `mcp__memory__${name}`).sort(),
@@ -50,6 +84,7 @@ export const HOST_SMOKE_SPECS: HostSmokeSpec[] = [
   },
   {
     host: 'copilot-cli',
+    client: 'copilot',
     configPath: '$COPILOT_HOME/mcp-config.json',
     installCommand: ['mcp-automem', 'copilot', '--format', 'cli'],
     expectedToolNames: RAW_AUTOMEM_TOOLS.map((name) => `automem-${name}`).sort(),
@@ -57,6 +92,7 @@ export const HOST_SMOKE_SPECS: HostSmokeSpec[] = [
   },
   {
     host: 'vscode-copilot',
+    client: 'copilot',
     configPath: '.vscode/mcp.json',
     installCommand: ['mcp-automem', 'copilot', '--format', 'vscode'],
     expectedToolNames: RAW_AUTOMEM_TOOLS.map((name) => `mcp_automem_${name}`).sort(),
@@ -64,9 +100,18 @@ export const HOST_SMOKE_SPECS: HostSmokeSpec[] = [
   },
   {
     host: 'grok',
+    client: 'grok',
     configPath: '~/.grok/config.toml',
     installCommand: ['mcp-automem', 'grok'],
     expectedToolNames: RAW_AUTOMEM_TOOLS.map((name) => `memory__${name}`).sort(),
+    realHostSmoke: 'config-and-mcp-contract',
+  },
+  {
+    host: 'openclaw',
+    client: 'openclaw',
+    configPath: '~/.openclaw/openclaw.json',
+    installCommand: ['mcp-automem', 'openclaw'],
+    expectedToolNames: [...OPENCLAW_AUTOMEM_TOOLS].sort(),
     realHostSmoke: 'config-and-mcp-contract',
   },
 ];

--- a/tests/host-smoke/grok-real-host.test.ts
+++ b/tests/host-smoke/grok-real-host.test.ts
@@ -118,6 +118,9 @@ describe('Grok real host contract', () => {
           'check_database_health',
         ]);
 
+        // AGENTS.md's host-integration contract asks for health, recall, store, update
+        // and associate against the fake API — exercising only two would let the rest
+        // regress with this test still green.
         const health = await client.request('tools/call', {
           name: 'check_database_health',
           arguments: {},
@@ -129,6 +132,36 @@ describe('Grok real host contract', () => {
           arguments: { query: 'grok smoke', limit: 1 },
         });
         expect(recalled.structuredContent.count).toBe(1);
+
+        const stored = await client.request('tools/call', {
+          name: 'store_memory',
+          arguments: { content: 'grok host smoke memory', tags: ['grok-smoke'], importance: 0.6 },
+        });
+        expect(stored.structuredContent.memory_id).toBe('mem-1');
+
+        const updated = await client.request('tools/call', {
+          name: 'update_memory',
+          arguments: { memory_id: 'mem-1', importance: 0.8 },
+        });
+        expect(updated.structuredContent.memory_id).toBe('mem-1');
+
+        const associated = await client.request('tools/call', {
+          name: 'associate_memories',
+          arguments: {
+            memory1_id: 'mem-1',
+            memory2_id: 'mem-2',
+            type: 'RELATES_TO',
+            strength: 0.7,
+          },
+        });
+        expect(associated.structuredContent).toBeDefined();
+
+        const paths = fakeApi.requests.map((request) => request.path);
+        expect(paths).toContain('/health');
+        expect(paths.some((p) => p.startsWith('/recall'))).toBe(true);
+        expect(paths).toContain('/memory');
+        expect(paths).toContain('/memory/mem-1');
+        expect(paths).toContain('/associate');
 
         // stdio must stay clean JSON-RPC or Grok cannot parse the stream at all.
         expect(client.invalidStdoutLines).toEqual([]);

--- a/tests/host-smoke/grok-real-host.test.ts
+++ b/tests/host-smoke/grok-real-host.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Grok host boundary: prove the config the installer writes actually produces a
+ * working MCP server.
+ *
+ * Checking the generated TOML alone would miss the failure this integration exists to
+ * prevent. Grok can load AutoMem through its Claude/Cursor compat import, which drops
+ * the `AUTOMEM_*` env; the server then falls back to http://127.0.0.1:8001 and every
+ * session dies with "fetch failed". So this starts a real stdio server using the
+ * command and env taken *from the written config*, and drives it against the shared
+ * fake AutoMem API.
+ *
+ * The published `npx` command is asserted rather than executed (running it would hit
+ * the network); the local server stands in for the same entry point.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { parse as parseToml } from 'smol-toml';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { applyGrokSetup } from '../../src/cli/grok.js';
+import {
+  localMcpServerCommand,
+  startFakeAutoMemApi,
+  StdioMcpClient,
+} from '../helpers/host-smoke.js';
+
+const REPO_ROOT = path.resolve(__dirname, '../..');
+
+interface GrokServerEntry {
+  command: string;
+  args: string[];
+  enabled: boolean;
+  env: Record<string, string>;
+}
+
+describe('Grok real host contract', () => {
+  let grokHome: string;
+  let previousGrokHome: string | undefined;
+  let previousApiUrl: string | undefined;
+  let previousApiKey: string | undefined;
+  let previousEndpoint: string | undefined;
+
+  beforeEach(() => {
+    grokHome = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-host-smoke-'));
+    previousGrokHome = process.env.GROK_HOME;
+    previousApiUrl = process.env.AUTOMEM_API_URL;
+    previousApiKey = process.env.AUTOMEM_API_KEY;
+    previousEndpoint = process.env.AUTOMEM_ENDPOINT;
+    process.env.GROK_HOME = grokHome;
+    // A leaked real key must never reach the temp config or the assertions below.
+    delete process.env.AUTOMEM_API_URL;
+    delete process.env.AUTOMEM_API_KEY;
+    delete process.env.AUTOMEM_ENDPOINT;
+  });
+
+  afterEach(() => {
+    fs.rmSync(grokHome, { recursive: true, force: true });
+    const restore = (key: string, value: string | undefined) => {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    };
+    restore('GROK_HOME', previousGrokHome);
+    restore('AUTOMEM_API_URL', previousApiUrl);
+    restore('AUTOMEM_API_KEY', previousApiKey);
+    restore('AUTOMEM_ENDPOINT', previousEndpoint);
+  });
+
+  it('starts the server from the written config and reaches AutoMem with its env', async () => {
+    const fakeApi = await startFakeAutoMemApi();
+
+    try {
+      await applyGrokSetup({
+        endpoint: fakeApi.url,
+        apiKey: 'grok-smoke-key',
+        quiet: true,
+      });
+
+      const configPath = path.join(grokHome, 'config.toml');
+      const config = parseToml(fs.readFileSync(configPath, 'utf8')) as {
+        mcp_servers: { memory: GrokServerEntry };
+      };
+      const entry = config.mcp_servers.memory;
+
+      // The registration Grok will actually read.
+      expect(entry.command).toBe('npx');
+      expect(entry.args).toEqual(['-y', '@verygoodplugins/mcp-automem']);
+      expect(entry.enabled).toBe(true);
+      // The env is the whole point: without it the server defaults to localhost:8001.
+      expect(entry.env.AUTOMEM_API_URL).toBe(fakeApi.url);
+      expect(entry.env.AUTOMEM_API_KEY).toBe('grok-smoke-key');
+      expect(entry.env.AUTOMEM_PROCESS_TAG).toBe('grok:memory');
+
+      const localServer = localMcpServerCommand(REPO_ROOT);
+      const client = new StdioMcpClient(
+        localServer.command,
+        localServer.args,
+        {
+          ...process.env,
+          // Exactly what Grok would hand the child process — nothing added.
+          ...entry.env,
+          AUTOMEM_PARENT_WATCHDOG_MS: '0',
+          DOTENV_CONFIG_QUIET: 'true',
+        },
+        REPO_ROOT
+      );
+
+      try {
+        await client.initialize();
+
+        const listed = await client.request('tools/list');
+        expect(listed.tools.map((tool: { name: string }) => tool.name)).toEqual([
+          'store_memory',
+          'recall_memory',
+          'associate_memories',
+          'update_memory',
+          'delete_memory',
+          'check_database_health',
+        ]);
+
+        const health = await client.request('tools/call', {
+          name: 'check_database_health',
+          arguments: {},
+        });
+        expect(health.structuredContent.status).toBe('healthy');
+
+        const recalled = await client.request('tools/call', {
+          name: 'recall_memory',
+          arguments: { query: 'grok smoke', limit: 1 },
+        });
+        expect(recalled.structuredContent.count).toBe(1);
+
+        // stdio must stay clean JSON-RPC or Grok cannot parse the stream at all.
+        expect(client.invalidStdoutLines).toEqual([]);
+        // The config's endpoint and key are what actually got used.
+        expect(fakeApi.requests.length).toBeGreaterThan(0);
+        expect(
+          fakeApi.requests.every((request) => request.authorization === 'Bearer grok-smoke-key')
+        ).toBe(true);
+      } finally {
+        await client.close();
+      }
+    } finally {
+      await fakeApi.close();
+    }
+  }, 30_000);
+});

--- a/tests/host-smoke/grok-real-host.test.ts
+++ b/tests/host-smoke/grok-real-host.test.ts
@@ -156,12 +156,34 @@ describe('Grok real host contract', () => {
         });
         expect(associated.structuredContent).toBeDefined();
 
-        const paths = fakeApi.requests.map((request) => request.path);
-        expect(paths).toContain('/health');
-        expect(paths.some((p) => p.startsWith('/recall'))).toBe(true);
-        expect(paths).toContain('/memory');
-        expect(paths).toContain('/memory/mem-1');
-        expect(paths).toContain('/associate');
+        // Routes, methods and payloads: the fake API accepts any body, so asserting
+        // only the route would let a dropped or renamed field through.
+        const find = (method: string, pathMatch: (p: string) => boolean) => {
+          const request = fakeApi.requests.find((r) => r.method === method && pathMatch(r.path));
+          expect(request, `no ${method} request matching`).toBeDefined();
+          return request!;
+        };
+
+        expect(find('GET', (p) => p === '/health').path).toBe('/health');
+
+        const recallParams = new URLSearchParams(
+          find('GET', (p) => p.startsWith('/recall')).path.split('?')[1] ?? ''
+        );
+        expect(recallParams.get('query')).toBe('grok smoke');
+        expect(recallParams.get('limit')).toBe('1');
+
+        expect(find('POST', (p) => p === '/memory').body).toMatchObject({
+          content: 'grok host smoke memory',
+          tags: ['grok-smoke'],
+          importance: 0.6,
+        });
+        expect(find('PATCH', (p) => p === '/memory/mem-1').body).toMatchObject({ importance: 0.8 });
+        expect(find('POST', (p) => p === '/associate').body).toMatchObject({
+          memory1_id: 'mem-1',
+          memory2_id: 'mem-2',
+          type: 'RELATES_TO',
+          strength: 0.7,
+        });
 
         // stdio must stay clean JSON-RPC or Grok cannot parse the stream at all.
         expect(client.invalidStdoutLines).toEqual([]);

--- a/tests/host-smoke/host-specs.test.ts
+++ b/tests/host-smoke/host-specs.test.ts
@@ -11,6 +11,7 @@ describe('host smoke specs', () => {
       'cursor',
       'grok',
       'hermes',
+      'openclaw',
       'vscode-copilot',
     ]);
   });

--- a/tests/host-smoke/host-specs.test.ts
+++ b/tests/host-smoke/host-specs.test.ts
@@ -9,6 +9,7 @@ describe('host smoke specs', () => {
       'codex',
       'copilot-cli',
       'cursor',
+      'grok',
       'hermes',
       'vscode-copilot',
     ]);

--- a/tests/host-smoke/openclaw-real-host.test.ts
+++ b/tests/host-smoke/openclaw-real-host.test.ts
@@ -1,0 +1,120 @@
+/**
+ * OpenClaw plugin boundary: make the host spec executable rather than declarative.
+ *
+ * OpenClaw is the one supported host that does not speak stdio MCP — it loads
+ * src/openclaw-plugin.ts in-process and receives tools through `api.registerTool`.
+ * A spec entry in tests/helpers/host-specs.ts therefore proves nothing on its own:
+ * stale or invented names there would still satisfy the parity suite. This registers
+ * the real plugin and checks the names it actually hands OpenClaw against that spec,
+ * then drives one tool through the shared fake AutoMem API.
+ */
+
+import { describe, expect, it } from 'vitest';
+import openClawPlugin from '../../src/openclaw-plugin.js';
+import { HOST_SMOKE_SPECS } from '../helpers/host-specs.js';
+import { startFakeAutoMemApi } from '../helpers/host-smoke.js';
+
+interface RegisteredTool {
+  name: string;
+  execute: (toolCallId: string, params: unknown) => Promise<unknown>;
+}
+
+function registerPlugin(endpoint: string, apiKey?: string): RegisteredTool[] {
+  const tools: RegisteredTool[] = [];
+  openClawPlugin.register({
+    pluginConfig: {
+      endpoint,
+      ...(apiKey ? { apiKey } : {}),
+      autoRecall: false,
+    },
+    logger: { warn: () => {} },
+    registerTool: (tool) => {
+      tools.push({ name: tool.name, execute: tool.execute });
+    },
+    on: () => {},
+  });
+  return tools;
+}
+
+const openClawSpec = HOST_SMOKE_SPECS.find((spec) => spec.host === 'openclaw');
+
+describe('OpenClaw plugin boundary', () => {
+  it('has a host spec to validate against', () => {
+    expect(openClawSpec, 'HOST_SMOKE_SPECS is missing the openclaw entry').toBeDefined();
+  });
+
+  it('registers exactly the tool names the host spec declares', () => {
+    const registered = registerPlugin('http://127.0.0.1:8001')
+      .map((tool) => tool.name)
+      .sort();
+    // Ties the declaration to reality: renaming a tool in the plugin, or drifting the
+    // spec, now fails here instead of passing as "smoke-covered".
+    expect(registered).toEqual(openClawSpec!.expectedToolNames);
+  });
+
+  it('drives every AutoMem operation through the registered tools', async () => {
+    const fakeApi = await startFakeAutoMemApi();
+    try {
+      const tools = registerPlugin(fakeApi.url, 'openclaw-smoke-key');
+      const call = async (name: string, params: unknown) => {
+        const tool = tools.find((candidate) => candidate.name === name);
+        expect(tool, `plugin did not register ${name}`).toBeDefined();
+        return tool!.execute(`call-${name}`, params);
+      };
+
+      // Exercising only recall would leave wrong methods, payloads or auth on the other
+      // tools invisible — the host-integration contract names all five operations.
+      await call('automem_check_health', {});
+      await call('automem_recall_memory', { query: 'openclaw smoke', limit: 1 });
+      await call('automem_store_memory', {
+        content: 'openclaw host smoke memory',
+        tags: ['openclaw-smoke'],
+        importance: 0.6,
+      });
+      await call('automem_update_memory', { memory_id: 'mem-1', importance: 0.8 });
+      await call('automem_associate_memories', {
+        memory1_id: 'mem-1',
+        memory2_id: 'mem-2',
+        type: 'RELATES_TO',
+        strength: 0.7,
+      });
+
+      // Route + method + auth, and the bodies: the fake API accepts any payload, so a
+      // dropped or renamed field would otherwise sail through every other assertion.
+      const find = (method: string, pathMatch: (p: string) => boolean) => {
+        const request = fakeApi.requests.find((r) => r.method === method && pathMatch(r.path));
+        expect(request, `no ${method} request matching`).toBeDefined();
+        return request!;
+      };
+
+      expect(find('GET', (p) => p === '/health').path).toBe('/health');
+
+      // Recall is a GET, so its arguments live in the query string.
+      const recallRequest = find('GET', (p) => p.startsWith('/recall'));
+      const recallParams = new URLSearchParams(recallRequest.path.split('?')[1] ?? '');
+      expect(recallParams.get('query')).toBe('openclaw smoke');
+      expect(recallParams.get('limit')).toBe('1');
+
+      expect(find('POST', (p) => p === '/memory').body).toMatchObject({
+        content: 'openclaw host smoke memory',
+        tags: ['openclaw-smoke'],
+        importance: 0.6,
+      });
+
+      expect(find('PATCH', (p) => p === '/memory/mem-1').body).toMatchObject({ importance: 0.8 });
+
+      expect(find('POST', (p) => p === '/associate').body).toMatchObject({
+        memory1_id: 'mem-1',
+        memory2_id: 'mem-2',
+        type: 'RELATES_TO',
+        strength: 0.7,
+      });
+
+      expect(
+        fakeApi.requests.every((request) => request.authorization === 'Bearer openclaw-smoke-key')
+      ).toBe(true);
+    } finally {
+      await fakeApi.close();
+    }
+  }, 20_000);
+});


### PR DESCRIPTION
Adds Grok Build (xAI) as an installer client, plus fixes for three issues found reviewing the original commit.

Grok loads MCP from `~/.grok/config.toml` before Claude/Cursor compat sources. Native config is required: when AutoMem is only present via a compat import, the stdio server starts without `AUTOMEM_*` env, defaults to `http://127.0.0.1:8001`, and every session fails with `Mcp error: -32603: fetch failed`.

## Fixes on top of the original commit

**1. Memory rules now come from the shared policy generator.**
`templates/grok/memory-rules.md` was hand-written while every other host renders from `src/memory-policy/shared.ts` — and it still carried an `automem-template-version` stamp, so it looked generated. The next policy change would have silently skipped Grok.

Added a `ToolCallStyle` discriminated union so the shared sections can render for hosts that dispatch through a wrapper. Grok reaches tools via `search_tool` + `use_tool({tool_name, tool_input})`, so a direct `memory__recall_memory({…})` call is not executable there — **Copilot shipped exactly that bug in #186**, which is the best argument for closing this path.

The direct-style path is byte-preserving: all 12 pre-existing policy artifacts regenerate identically. The new artifact was content-accounted line by line — nothing lost; the `search_tool` note moves six lines earlier (still ahead of the first `use_tool` example) and two inline calls reflow to match the others.

**2. `config.toml` is edited in place instead of rewritten.**
`upsertGrokMemoryServer`/`removeGrokMemoryServer` round-tripped the whole document through smol-toml, so the first install reformatted everything the user had written. Verified against a real `~/.grok/config.toml`: multi-line `"""` subagent instructions collapse into escaped one-liners, arrays reflow onto one line, comments are dropped.

Now only the `[mcp_servers.memory]` table (and its `.env` sub-table) is spliced as text. Every splice is verified by re-parsing and comparing to the intended document, so a table header matched inside a multi-line string fails the check and falls back to the old whole-file rewrite — now with a warning that formatting will be lost.

A follow-up commit fixes a seam bug the first round of fixtures missed: they all placed the table at end-of-file, where trailing-newline normalization hid it. Removing a table that sits *between* two others left the preceding blank line adjacent to the following one; TOML ignores the extra blank, so verification accepted it and each install/uninstall cycle added a line.

**3. Dry runs no longer claim work they didn't do.**
`applyGrokSetup` printed its "✅ written / ✅ rules installed / ✨ setup complete" report unconditionally. Dry runs now end at the `[DRY RUN] Would …` lines plus an explicit no-op summary, and report add/update/unchanged rather than always implying a pending write. Malformed TOML now fails the preview instead of only the real run.

Also warns when Grok's top-level `disabled_mcp_servers` contains `"memory"` — that list gates servers independently of the entry's own `enabled` flag, so the install would otherwise look successful while AutoMem never loads. The warning appears in dry runs too, since it describes existing state rather than work performed.

## Smaller items

- `DISPLAY_NAMES.grok` → `"Grok Build"`, matching `clientLabel` and the README.
- Linked `templates/grok/config.toml` from INSTALLATION.md — it shipped in the package but nothing referenced it.

## Verification

- `npm test` 784 passed; typecheck, lint (0 errors), and `format:check` clean.
- Policy sync run twice → "already in sync", no template churn.
- **Round-trip against a real `~/.grok/config.toml`**: dry run writes nothing; install is a pure append; three install/uninstall cycles return the file byte-for-byte with multi-line personas and array formatting intact.

## Review note

#2 in a three-PR stack, based on #191. Merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

### Review round 1 (Codex)

3 findings (all P1), fixed in \`d7a3cd0\`. (1) The global `~/.grok/AGENTS.md` baked in the install-time project, hard-gating every later session's recall to that slug — it now uses the `<project-slug>` placeholder. (2) Install would silently overwrite a non-AutoMem server named `memory`; it now refuses, matching uninstall's existing `onlyIfAutoMem` guard. (3) A config carrying `AUTOMEM_API_KEY` was written at the process umask (commonly 0644); it and its backup are now 0600. All three threads replied and resolved.


### Review round 2 (Codex)

3 findings (all P1), fixed in `623b696`. (1) A stored API key was reused after `--endpoint` changed, sending the previous host's credential to a new server — it is now reused only when the endpoint is unchanged. (2) **Regression from round 1:** the global-rules guard treated `--name`/`--rules` as file scoping, so `--name foo` on the default path still baked a project into the global file; the decision is now the resolved target path alone. (3) The Grok spec was metadata only — added `tests/host-smoke/grok-real-host.test.ts`, which installs into a temp `GROK_HOME`, starts a real stdio server from the written config's env, and drives it against the fake AutoMem API. All three threads replied and resolved.


### Review round 3 (Codex)

4 findings (3× P1, 1× P2), fixed in `b4d574c`. Two were gaps in the round-2 permissions fix, so rather than patch the named paths I swept every write that can touch a secret-bearing config: the unchanged early return, the main write, both upsert backups, and the uninstall backup (that last one was the same class and had not been reported). Sensitivity is now derived from both the on-disk entry and the incoming one. Also: one-sided rules markers are refused instead of appended (appending set up a later run to delete user content between the markers), and the Grok smoke now exercises all five operations AGENTS.md names, not just health and recall. All four threads replied and resolved.

**Budget note:** this was the third and final remediation push allowed for this PR.
