### PR TITLE
chore: derive host lists from one client registry and guard the rest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,7 +318,15 @@ When adding or changing a client host integration, test the real host boundary i
 - Assert tool names are unique across the final provider payload, not just within AutoMem tools.
 - Add uninstall coverage for every file, config key, plugin directory, and environment key the installer writes.
 - Redact secrets and isolate env vars; never let a real `AUTOMEM_API_KEY` leak into temp config or snapshots.
-- Keep `tests/helpers/host-specs.ts` updated as the executable host integration contract for Hermes, Claude Code, Codex, Cursor, Grok, and future platforms.
+- Keep `tests/helpers/host-specs.ts` updated as the executable host integration contract for Hermes, Claude Code, Codex, Cursor, Copilot, Grok, and future platforms. Each spec's `host` is the MCP *registration surface* (Copilot has two: CLI and VS Code); `client` ties it back to the installer client in `src/cli/clients.ts`.
+
+### Adding a host
+
+`src/cli/clients.ts` is the client registry — `AGENT_CLIENTS` plus the exclusion lists that record where a client is deliberately unsupported. Uninstall platforms and the CLI's known-commands set are derived from it, so those cannot drift.
+
+`tests/docs/host-parity.test.ts` enforces the rest: every client needs an uninstall path, a host smoke spec, a dispatch branch, and — if it ships a rules template — a renderer registered in `scripts/sync-memory-policy.ts`. When a gap is knowingly accepted, add it to the exclusion list in that test (or in `clients.ts`) with a reason. Do not delete the assertion.
+
+Known debt tracked this way: OpenClaw has no uninstall path (`UNINSTALL_UNSUPPORTED_CLIENTS`), and Copilot's memory rules are still hand-written rather than generated (`HAND_WRITTEN_RULES`) — the drift that caused #186.
 
 Documentation changes are part of the integration contract. Any new host mode or uninstall behavior should be reflected in `INSTALLATION.md` and covered by a smoke/doc assertion.
 

--- a/src/cli/clients.ts
+++ b/src/cli/clients.ts
@@ -1,0 +1,60 @@
+/**
+ * The set of agent clients the guided installer can configure, plus the drift-control
+ * lists that describe where a client is deliberately *not* supported.
+ *
+ * This lives apart from install.ts so uninstall.ts, src/index.ts, and the parity tests
+ * can name clients without importing the installer (and, transitively, every host
+ * module and the cloud-provisioning stack).
+ */
+
+export const AGENT_CLIENTS = [
+  'codex',
+  'claude-code',
+  'cursor',
+  'openclaw',
+  'hermes',
+  'grok',
+] as const;
+
+export type AgentClient = (typeof AGENT_CLIENTS)[number];
+
+/** Pre-selected when the installer runs without an explicit --clients list. */
+export const DEFAULT_AGENT_CLIENTS = [
+  'codex',
+  'claude-code',
+  'cursor',
+  'openclaw',
+] as const satisfies readonly AgentClient[];
+
+/**
+ * Installable but not yet uninstallable. Every entry here is a gap, not a design
+ * choice — tests/docs/host-parity.test.ts fails if a client is missing from the
+ * uninstall surface without being listed.
+ */
+export const UNINSTALL_UNSUPPORTED_CLIENTS = ['openclaw'] as const satisfies readonly AgentClient[];
+
+/**
+ * Hosts with their own `mcp-automem <name>` setup and uninstall commands that the
+ * guided installer does not offer in its agent list. Copilot is configured per-surface
+ * (CLI vs VS Code) rather than as a single checkbox, so it is not an AgentClient.
+ */
+export const STANDALONE_PLATFORMS = ['copilot'] as const;
+
+export type UninstallPlatform =
+  | Exclude<AgentClient, (typeof UNINSTALL_UNSUPPORTED_CLIENTS)[number]>
+  | (typeof STANDALONE_PLATFORMS)[number];
+
+export const UNINSTALL_PLATFORMS = [
+  ...AGENT_CLIENTS.filter(
+    (client): client is Exclude<AgentClient, (typeof UNINSTALL_UNSUPPORTED_CLIENTS)[number]> =>
+      !(UNINSTALL_UNSUPPORTED_CLIENTS as readonly string[]).includes(client)
+  ),
+  ...STANDALONE_PLATFORMS,
+] as const satisfies readonly UninstallPlatform[];
+
+/**
+ * Every per-host setup subcommand the CLI routes. Derived so a new client cannot be
+ * routed without also being recognized (an unlisted command falls through to stdio
+ * server mode and skips dotenv-banner silencing).
+ */
+export const HOST_SETUP_COMMANDS = [...AGENT_CLIENTS, ...STANDALONE_PLATFORMS] as const;

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { execFileSync, spawnSync } from 'child_process';
+import { AGENT_CLIENTS, DEFAULT_AGENT_CLIENTS, type AgentClient } from './clients.js';
 import { applyClaudeCodeSetup } from './claude-code.js';
 import { applyCodexSetup } from './codex.js';
 import { applyCursorSetup } from './cursor.js';
@@ -123,22 +124,10 @@ export async function installClaudeCodePlugin(params: {
 // How the guided installer wires Claude Code. Defaults to the recommended plugin.
 export type ClaudeCodeMode = 'plugin' | 'settings';
 
-export const AGENT_CLIENTS = [
-  'codex',
-  'claude-code',
-  'cursor',
-  'openclaw',
-  'hermes',
-  'grok',
-] as const;
-
-export type AgentClient = (typeof AGENT_CLIENTS)[number];
-export const DEFAULT_AGENT_CLIENTS = [
-  'codex',
-  'claude-code',
-  'cursor',
-  'openclaw',
-] as const satisfies readonly AgentClient[];
+// Re-exported so existing importers (and the CLI surface) keep one entry point,
+// while the definitions themselves stay dependency-free in ./clients.js.
+export { AGENT_CLIENTS, DEFAULT_AGENT_CLIENTS };
+export type { AgentClient };
 export type InstallTarget = 'local' | 'cloud' | 'existing';
 // Hosted-cloud sub-target: InstaPods (open the setup page → paste the emailed
 // URL+key), Railway (guided via the railway CLI), or 'other' (paste credentials

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -13,9 +13,10 @@ import {
 } from './hermes-config.js';
 import { removeGrokMemoryServer, resolveGrokPaths } from './grok-config.js';
 import { GROK_RULES_END, GROK_RULES_START, stripGrokRulesMarkers } from './grok.js';
+import { UNINSTALL_PLATFORMS, type UninstallPlatform } from './clients.js';
 
 interface UninstallOptions {
-  platform: 'cursor' | 'claude-code' | 'copilot' | 'codex' | 'hermes' | 'grok';
+  platform: UninstallPlatform;
   projectDir?: string;
   rulesPath?: string;
   cleanAll?: boolean;
@@ -781,14 +782,13 @@ export async function runUninstall(options: UninstallOptions): Promise<void> {
 }
 
 export function parseUninstallArgs(args: string[]): UninstallOptions | null {
-  const allowed = ['cursor', 'claude-code', 'copilot', 'codex', 'hermes', 'grok'] as const;
-  if (args.length === 0 || !allowed.includes(args[0] as (typeof allowed)[number])) {
-    console.error(
-      '❌ Error: Platform required (cursor, claude-code, copilot, codex, hermes, or grok)'
-    );
-    console.error(
-      'Usage: mcp-automem uninstall <cursor|claude-code|copilot|codex|hermes|grok> [options]'
-    );
+  // Derived from AGENT_CLIENTS so a new installer client cannot quietly ship without
+  // an uninstall path — it either lands here or is listed in UNINSTALL_UNSUPPORTED_CLIENTS.
+  const allowed = UNINSTALL_PLATFORMS;
+  if (args.length === 0 || !allowed.includes(args[0] as UninstallPlatform)) {
+    const list = allowed.join(', ');
+    console.error(`❌ Error: Platform required (${list})`);
+    console.error(`Usage: mcp-automem uninstall <${allowed.join('|')}> [options]`);
     return null;
   }
 

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -717,6 +717,28 @@ function isAutoMemMcpServer(server: unknown): boolean {
   return values.some((value) => value.includes('mcp-automem'));
 }
 
+/**
+ * Platform → handler. A total `Record` rather than an if-chain so TypeScript rejects a
+ * new `UninstallPlatform` that has no handler, and so the parity suite can assert the
+ * mapping directly. Grepping the source for `options.platform === 'x'` could not: the
+ * same predicate appears in the `--clean-all` and next-steps blocks below, so deleting
+ * a real dispatch branch still left a match.
+ */
+const UNINSTALL_HANDLERS: Record<UninstallPlatform, (options: UninstallOptions) => Promise<void>> =
+  {
+    cursor: uninstallCursor,
+    'claude-code': uninstallClaudeCode,
+    copilot: uninstallCopilot,
+    codex: uninstallCodex,
+    hermes: uninstallHermes,
+    grok: uninstallGrok,
+  };
+
+/** Platforms with a registered uninstall handler, for the parity suite. */
+export function uninstallHandlerPlatforms(): string[] {
+  return Object.keys(UNINSTALL_HANDLERS);
+}
+
 export async function runUninstall(options: UninstallOptions): Promise<void> {
   log(`\n🚮 AutoMem Uninstaller`, options.quiet);
   log(`   Platform: ${options.platform}`, options.quiet);
@@ -733,19 +755,7 @@ export async function runUninstall(options: UninstallOptions): Promise<void> {
   }
 
   // Platform-specific uninstall
-  if (options.platform === 'cursor') {
-    await uninstallCursor(options);
-  } else if (options.platform === 'claude-code') {
-    await uninstallClaudeCode(options);
-  } else if (options.platform === 'copilot') {
-    await uninstallCopilot(options);
-  } else if (options.platform === 'codex') {
-    await uninstallCodex(options);
-  } else if (options.platform === 'hermes') {
-    await uninstallHermes(options);
-  } else if (options.platform === 'grok') {
-    await uninstallGrok(options);
-  }
+  await UNINSTALL_HANDLERS[options.platform](options);
 
   // Clean up external changes (Claude Desktop config) if requested
   if (options.cleanAll) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
   Tool,
 } from '@modelcontextprotocol/sdk/types.js';
 import { config } from 'dotenv';
+import { HOST_SETUP_COMMANDS } from './cli/clients.js';
 import { runConfig, runSetup } from './cli/setup.js';
 import { runInstallCommand } from './cli/install.js';
 import { runClaudeCodeSetup } from './cli/claude-code.js';
@@ -49,13 +50,10 @@ const KNOWN_COMMANDS = new Set([
   'setup',
   'install',
   'config',
-  'claude-code',
-  'copilot',
-  'cursor',
-  'codex',
-  'openclaw',
-  'hermes',
-  'grok',
+  // Per-host setup commands come from the client registry so routing a new host
+  // cannot leave it unrecognized here. Covers the same seven main lists by hand,
+  // including 'copilot' via STANDALONE_PLATFORMS.
+  ...HOST_SETUP_COMMANDS,
   'migrate',
   'uninstall',
   'queue',

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,8 +51,7 @@ const KNOWN_COMMANDS = new Set([
   'install',
   'config',
   // Per-host setup commands come from the client registry so routing a new host
-  // cannot leave it unrecognized here. Covers the same seven main lists by hand,
-  // including 'copilot' via STANDALONE_PLATFORMS.
+  // cannot leave it unrecognized here — the drift that left `copilot` missing.
   ...HOST_SETUP_COMMANDS,
   'migrate',
   'uninstall',

--- a/tests/docs/host-parity.test.ts
+++ b/tests/docs/host-parity.test.ts
@@ -35,13 +35,22 @@ function readRepoFile(relativePath: string): string {
  */
 const HAND_WRITTEN_RULES: readonly string[] = ['copilot'];
 
-/** Rules artifact each client's installer reads, when it ships one. */
-const RULES_TEMPLATES: Partial<Record<AgentClient | 'copilot', string>> = {
+/**
+ * Rules artifact each client's installer reads. Deliberately a **total** Record with an
+ * explicit `null` for clients that ship none: a `Partial` would let a new client omit
+ * its entry and skip the generator check silently — the exact drift this suite exists
+ * to catch. Adding to `AgentClient` is a compile error until it is declared here.
+ */
+const RULES_TEMPLATES: Record<AgentClient | 'copilot', string | null> = {
   codex: 'templates/codex/memory-rules.md',
   cursor: 'templates/cursor/automem.mdc.template',
   hermes: 'templates/hermes/memory-rules.md',
   grok: 'templates/grok/memory-rules.md',
   copilot: 'templates/COPILOT_INSTRUCTIONS_MEMORY_RULES.md',
+  // Ships hooks, not a rules file; its policy lives in the generated hook scripts.
+  'claude-code': null,
+  // Renders policy in-process at runtime (renderOpenClawPolicyContext), no template.
+  openclaw: null,
 };
 
 describe('host integration parity', () => {
@@ -72,10 +81,11 @@ describe('host integration parity', () => {
   });
 
   it('gives every installer client at least one host smoke spec', () => {
+    // Uninstall support and setup-boundary coverage are unrelated concerns. Reusing the
+    // uninstall exclusion here previously let OpenClaw — an installable, default-selected
+    // client — escape smoke coverage entirely while this suite still passed.
     const covered = new Set(HOST_SMOKE_SPECS.map((spec) => spec.client));
     for (const client of AGENT_CLIENTS) {
-      const excluded = (UNINSTALL_UNSUPPORTED_CLIENTS as readonly string[]).includes(client);
-      if (excluded) continue; // No uninstall path yet, so no meaningful round-trip to smoke.
       expect(
         covered.has(client),
         `AGENT_CLIENTS includes '${client}' but tests/helpers/host-specs.ts has no spec for it.`

--- a/tests/docs/host-parity.test.ts
+++ b/tests/docs/host-parity.test.ts
@@ -1,0 +1,148 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, it } from 'vitest';
+import {
+  AGENT_CLIENTS,
+  STANDALONE_PLATFORMS,
+  UNINSTALL_PLATFORMS,
+  UNINSTALL_UNSUPPORTED_CLIENTS,
+  type AgentClient,
+} from '../../src/cli/clients.js';
+import { HOST_SMOKE_SPECS } from '../helpers/host-specs.js';
+
+/**
+ * Adding a host used to mean updating six independent hand-maintained lists, and only
+ * one of them was type-checked. The gaps that produced — OpenClaw installable but not
+ * uninstallable, Grok missing from the policy generator, Copilot missing from the CLI's
+ * known-commands set — were all invisible until someone tripped over them.
+ *
+ * These assertions turn each of those edges into a test failure. Where a gap is
+ * knowingly accepted, it belongs in an exclusion list here with a reason, not in silence.
+ */
+
+const REPO_ROOT = path.resolve(fileURLToPath(new URL('../..', import.meta.url)));
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(REPO_ROOT, relativePath), 'utf8');
+}
+
+/**
+ * Hosts whose memory rules are still hand-written instead of rendered from
+ * src/memory-policy/shared.ts. Copilot is known debt: #186 ("prefix CLI memory rule
+ * tool calls") was exactly the drift this list exists to make visible. Removing an
+ * entry here is the point — do not add one to make a failure go away.
+ */
+const HAND_WRITTEN_RULES: readonly string[] = ['copilot'];
+
+/** Rules artifact each client's installer reads, when it ships one. */
+const RULES_TEMPLATES: Partial<Record<AgentClient | 'copilot', string>> = {
+  codex: 'templates/codex/memory-rules.md',
+  cursor: 'templates/cursor/automem.mdc.template',
+  hermes: 'templates/hermes/memory-rules.md',
+  grok: 'templates/grok/memory-rules.md',
+  copilot: 'templates/COPILOT_INSTRUCTIONS_MEMORY_RULES.md',
+};
+
+describe('host integration parity', () => {
+  it('gives every installer client an uninstall path or a documented exclusion', () => {
+    for (const client of AGENT_CLIENTS) {
+      const uninstallable = (UNINSTALL_PLATFORMS as readonly string[]).includes(client);
+      const excluded = (UNINSTALL_UNSUPPORTED_CLIENTS as readonly string[]).includes(client);
+      expect(
+        uninstallable || excluded,
+        `AGENT_CLIENTS includes '${client}' but it has no uninstall path. ` +
+          'Add one in src/cli/uninstall.ts, or list it in UNINSTALL_UNSUPPORTED_CLIENTS with a reason.'
+      ).toBe(true);
+      expect(
+        uninstallable && excluded,
+        `'${client}' is both uninstallable and listed as unsupported — drop it from UNINSTALL_UNSUPPORTED_CLIENTS.`
+      ).toBe(false);
+    }
+  });
+
+  it('routes every uninstall platform through the uninstall command', () => {
+    const source = readRepoFile('src/cli/uninstall.ts');
+    for (const platform of UNINSTALL_PLATFORMS) {
+      expect(
+        source.includes(`options.platform === '${platform}'`),
+        `uninstall accepts '${platform}' but runUninstall never dispatches it.`
+      ).toBe(true);
+    }
+  });
+
+  it('gives every installer client at least one host smoke spec', () => {
+    const covered = new Set(HOST_SMOKE_SPECS.map((spec) => spec.client));
+    for (const client of AGENT_CLIENTS) {
+      const excluded = (UNINSTALL_UNSUPPORTED_CLIENTS as readonly string[]).includes(client);
+      if (excluded) continue; // No uninstall path yet, so no meaningful round-trip to smoke.
+      expect(
+        covered.has(client),
+        `AGENT_CLIENTS includes '${client}' but tests/helpers/host-specs.ts has no spec for it.`
+      ).toBe(true);
+    }
+    for (const platform of STANDALONE_PLATFORMS) {
+      expect(
+        covered.has(platform),
+        `'${platform}' ships setup and uninstall commands but has no host smoke spec.`
+      ).toBe(true);
+    }
+  });
+
+  it('describes each registration surface exactly once', () => {
+    // Surfaces are keyed by host id; a duplicate means two entries are silently
+    // competing to define the same contract. (Tool names are deliberately *not*
+    // unique across surfaces — Codex and Claude Code both use `mcp__memory__*`.)
+    const seen = new Set<string>();
+    for (const spec of HOST_SMOKE_SPECS) {
+      expect(seen.has(spec.host), `Duplicate host smoke spec for '${spec.host}'.`).toBe(false);
+      seen.add(spec.host);
+    }
+  });
+
+  it('ties every host smoke spec to a real client', () => {
+    const known = new Set<string>([...AGENT_CLIENTS, ...STANDALONE_PLATFORMS]);
+    for (const spec of HOST_SMOKE_SPECS) {
+      expect(
+        known.has(spec.client),
+        `Host '${spec.host}' claims client '${spec.client}', which is neither an AgentClient nor a standalone platform.`
+      ).toBe(true);
+    }
+  });
+
+  it('generates every shipped rules template from the shared memory policy', () => {
+    const sync = readRepoFile('scripts/sync-memory-policy.ts');
+    for (const [client, template] of Object.entries(RULES_TEMPLATES)) {
+      if (!template) continue;
+      expect(
+        fs.existsSync(path.join(REPO_ROOT, template)),
+        `RULES_TEMPLATES points '${client}' at ${template}, which does not exist.`
+      ).toBe(true);
+
+      if (HAND_WRITTEN_RULES.includes(client)) {
+        // Assert the debt is real, so this entry disappears when the host is migrated.
+        expect(
+          sync.includes(template),
+          `'${client}' is listed in HAND_WRITTEN_RULES but ${template} is now generated — remove it from that list.`
+        ).toBe(false);
+        continue;
+      }
+
+      expect(
+        sync.includes(template),
+        `${template} is not registered in scripts/sync-memory-policy.ts, so it will silently drift ` +
+          'from src/memory-policy/shared.ts. Add a renderer, or list the client in HAND_WRITTEN_RULES.'
+      ).toBe(true);
+    }
+  });
+
+  it('recognizes every routed host setup command in the CLI', () => {
+    const source = readRepoFile('src/index.ts');
+    for (const command of [...AGENT_CLIENTS, ...STANDALONE_PLATFORMS]) {
+      expect(
+        source.includes(`command === '${command}'`),
+        `'${command}' is a known command but src/index.ts never routes it.`
+      ).toBe(true);
+    }
+  });
+});

--- a/tests/docs/host-parity.test.ts
+++ b/tests/docs/host-parity.test.ts
@@ -9,7 +9,11 @@ import {
   UNINSTALL_UNSUPPORTED_CLIENTS,
   type AgentClient,
 } from '../../src/cli/clients.js';
+import { uninstallHandlerPlatforms } from '../../src/cli/uninstall.js';
 import { HOST_SMOKE_SPECS } from '../helpers/host-specs.js';
+
+/** Derived, not hard-coded: a second standalone host must declare its rules artifact too. */
+type StandalonePlatform = (typeof STANDALONE_PLATFORMS)[number];
 
 /**
  * Adding a host used to mean updating six independent hand-maintained lists, and only
@@ -41,7 +45,7 @@ const HAND_WRITTEN_RULES: readonly string[] = ['copilot'];
  * its entry and skip the generator check silently — the exact drift this suite exists
  * to catch. Adding to `AgentClient` is a compile error until it is declared here.
  */
-const RULES_TEMPLATES: Record<AgentClient | 'copilot', string | null> = {
+const RULES_TEMPLATES: Record<AgentClient | StandalonePlatform, string | null> = {
   codex: 'templates/codex/memory-rules.md',
   cursor: 'templates/cursor/automem.mdc.template',
   hermes: 'templates/hermes/memory-rules.md',
@@ -70,12 +74,22 @@ describe('host integration parity', () => {
     }
   });
 
-  it('routes every uninstall platform through the uninstall command', () => {
-    const source = readRepoFile('src/cli/uninstall.ts');
+  it('routes every uninstall platform through a registered handler', () => {
+    // Asserted against the real dispatch map, not a source substring: `options.platform
+    // === 'cursor'` (and 'claude-code', 'copilot') also appear in the --clean-all and
+    // next-steps blocks, so a grep stayed green even with the dispatch branch deleted.
+    const handled = new Set(uninstallHandlerPlatforms());
     for (const platform of UNINSTALL_PLATFORMS) {
       expect(
-        source.includes(`options.platform === '${platform}'`),
-        `uninstall accepts '${platform}' but runUninstall never dispatches it.`
+        handled.has(platform),
+        `uninstall accepts '${platform}' but no handler is registered for it.`
+      ).toBe(true);
+    }
+    // And nothing is reachable that the CLI does not accept.
+    for (const platform of handled) {
+      expect(
+        (UNINSTALL_PLATFORMS as readonly string[]).includes(platform),
+        `A handler exists for '${platform}' but parseUninstallArgs rejects it.`
       ).toBe(true);
     }
   });

--- a/tests/helpers/host-specs.ts
+++ b/tests/helpers/host-specs.ts
@@ -1,5 +1,18 @@
+import type { AgentClient } from '../../src/cli/clients.js';
+
 export interface HostSmokeSpec {
+  /**
+   * The MCP *registration surface*, not the installer client. One client can expose
+   * several (Copilot registers separately for its CLI and for VS Code), and the surface
+   * is what determines the tool-name mangling below.
+   */
   host: 'hermes' | 'codex' | 'claude-code' | 'cursor' | 'copilot-cli' | 'vscode-copilot' | 'grok';
+  /**
+   * The installer client this surface belongs to, or 'copilot' for the standalone
+   * platform. tests/docs/host-parity.test.ts uses this to prove every client has
+   * smoke coverage.
+   */
+  client: AgentClient | 'copilot';
   configPath: string;
   installCommand: string[];
   expectedToolNames: string[];
@@ -20,6 +33,7 @@ const HERMES_AUTOMEM_TOOLS = RAW_AUTOMEM_TOOLS.filter((name) => name !== 'delete
 export const HOST_SMOKE_SPECS: HostSmokeSpec[] = [
   {
     host: 'hermes',
+    client: 'hermes',
     configPath: '$HERMES_HOME/config.yaml',
     installCommand: ['mcp-automem', 'hermes', '--mode', 'mcp'],
     expectedToolNames: HERMES_AUTOMEM_TOOLS.map((name) => `mcp_automem_${name}`).sort(),
@@ -28,6 +42,7 @@ export const HOST_SMOKE_SPECS: HostSmokeSpec[] = [
   },
   {
     host: 'codex',
+    client: 'codex',
     configPath: '~/.codex/config.toml',
     installCommand: ['mcp-automem', 'codex'],
     expectedToolNames: RAW_AUTOMEM_TOOLS.map((name) => `mcp__memory__${name}`).sort(),
@@ -35,6 +50,7 @@ export const HOST_SMOKE_SPECS: HostSmokeSpec[] = [
   },
   {
     host: 'cursor',
+    client: 'cursor',
     configPath: '~/.cursor/mcp.json',
     installCommand: ['mcp-automem', 'cursor'],
     expectedToolNames: RAW_AUTOMEM_TOOLS.map((name) => `mcp_memory_${name}`).sort(),
@@ -42,6 +58,7 @@ export const HOST_SMOKE_SPECS: HostSmokeSpec[] = [
   },
   {
     host: 'claude-code',
+    client: 'claude-code',
     configPath: '~/.claude.json',
     installCommand: ['mcp-automem', 'claude-code'],
     expectedToolNames: RAW_AUTOMEM_TOOLS.map((name) => `mcp__memory__${name}`).sort(),
@@ -50,6 +67,7 @@ export const HOST_SMOKE_SPECS: HostSmokeSpec[] = [
   },
   {
     host: 'copilot-cli',
+    client: 'copilot',
     configPath: '$COPILOT_HOME/mcp-config.json',
     installCommand: ['mcp-automem', 'copilot', '--format', 'cli'],
     expectedToolNames: RAW_AUTOMEM_TOOLS.map((name) => `automem-${name}`).sort(),
@@ -57,6 +75,7 @@ export const HOST_SMOKE_SPECS: HostSmokeSpec[] = [
   },
   {
     host: 'vscode-copilot',
+    client: 'copilot',
     configPath: '.vscode/mcp.json',
     installCommand: ['mcp-automem', 'copilot', '--format', 'vscode'],
     expectedToolNames: RAW_AUTOMEM_TOOLS.map((name) => `mcp_automem_${name}`).sort(),
@@ -64,6 +83,7 @@ export const HOST_SMOKE_SPECS: HostSmokeSpec[] = [
   },
   {
     host: 'grok',
+    client: 'grok',
     configPath: '~/.grok/config.toml',
     installCommand: ['mcp-automem', 'grok'],
     expectedToolNames: RAW_AUTOMEM_TOOLS.map((name) => `memory__${name}`).sort(),

--- a/tests/helpers/host-specs.ts
+++ b/tests/helpers/host-specs.ts
@@ -6,7 +6,15 @@ export interface HostSmokeSpec {
    * several (Copilot registers separately for its CLI and for VS Code), and the surface
    * is what determines the tool-name mangling below.
    */
-  host: 'hermes' | 'codex' | 'claude-code' | 'cursor' | 'copilot-cli' | 'vscode-copilot' | 'grok';
+  host:
+    | 'hermes'
+    | 'codex'
+    | 'claude-code'
+    | 'cursor'
+    | 'copilot-cli'
+    | 'vscode-copilot'
+    | 'grok'
+    | 'openclaw';
   /**
    * The installer client this surface belongs to, or 'copilot' for the standalone
    * platform. tests/docs/host-parity.test.ts uses this to prove every client has
@@ -29,6 +37,15 @@ const RAW_AUTOMEM_TOOLS = [
   'check_database_health',
 ];
 const HERMES_AUTOMEM_TOOLS = RAW_AUTOMEM_TOOLS.filter((name) => name !== 'delete_memory');
+/**
+ * OpenClaw registers its tools in-process from src/openclaw-plugin.ts rather than over
+ * stdio MCP, and shortens one of them: `check_database_health` is exposed as
+ * `automem_check_health`. That rename is exactly the kind of per-host quirk these specs
+ * exist to pin down.
+ */
+const OPENCLAW_AUTOMEM_TOOLS = RAW_AUTOMEM_TOOLS.map((name) =>
+  name === 'check_database_health' ? 'automem_check_health' : `automem_${name}`
+);
 
 export const HOST_SMOKE_SPECS: HostSmokeSpec[] = [
   {
@@ -87,6 +104,14 @@ export const HOST_SMOKE_SPECS: HostSmokeSpec[] = [
     configPath: '~/.grok/config.toml',
     installCommand: ['mcp-automem', 'grok'],
     expectedToolNames: RAW_AUTOMEM_TOOLS.map((name) => `memory__${name}`).sort(),
+    realHostSmoke: 'config-and-mcp-contract',
+  },
+  {
+    host: 'openclaw',
+    client: 'openclaw',
+    configPath: '~/.openclaw/openclaw.json',
+    installCommand: ['mcp-automem', 'openclaw'],
+    expectedToolNames: [...OPENCLAW_AUTOMEM_TOOLS].sort(),
     realHostSmoke: 'config-and-mcp-contract',
   },
 ];

--- a/tests/host-smoke/host-specs.test.ts
+++ b/tests/host-smoke/host-specs.test.ts
@@ -11,6 +11,7 @@ describe('host smoke specs', () => {
       'cursor',
       'grok',
       'hermes',
+      'openclaw',
       'vscode-copilot',
     ]);
   });

--- a/tests/host-smoke/openclaw-real-host.test.ts
+++ b/tests/host-smoke/openclaw-real-host.test.ts
@@ -79,17 +79,36 @@ describe('OpenClaw plugin boundary', () => {
         strength: 0.7,
       });
 
-      const paths = fakeApi.requests.map((request) => request.path);
-      expect(paths).toContain('/health');
-      expect(paths.some((p) => p.startsWith('/recall'))).toBe(true);
-      expect(paths).toContain('/memory');
-      expect(paths).toContain('/memory/mem-1');
-      expect(paths).toContain('/associate');
+      // Route + method + auth, and the bodies: the fake API accepts any payload, so a
+      // dropped or renamed field would otherwise sail through every other assertion.
+      const find = (method: string, pathMatch: (p: string) => boolean) => {
+        const request = fakeApi.requests.find((r) => r.method === method && pathMatch(r.path));
+        expect(request, `no ${method} request matching`).toBeDefined();
+        return request!;
+      };
 
-      const methods = fakeApi.requests.map((request) => `${request.method} ${request.path}`);
-      expect(methods).toContain('POST /memory');
-      expect(methods).toContain('PATCH /memory/mem-1');
-      expect(methods).toContain('POST /associate');
+      expect(find('GET', (p) => p === '/health').path).toBe('/health');
+
+      // Recall is a GET, so its arguments live in the query string.
+      const recallRequest = find('GET', (p) => p.startsWith('/recall'));
+      const recallParams = new URLSearchParams(recallRequest.path.split('?')[1] ?? '');
+      expect(recallParams.get('query')).toBe('openclaw smoke');
+      expect(recallParams.get('limit')).toBe('1');
+
+      expect(find('POST', (p) => p === '/memory').body).toMatchObject({
+        content: 'openclaw host smoke memory',
+        tags: ['openclaw-smoke'],
+        importance: 0.6,
+      });
+
+      expect(find('PATCH', (p) => p === '/memory/mem-1').body).toMatchObject({ importance: 0.8 });
+
+      expect(find('POST', (p) => p === '/associate').body).toMatchObject({
+        memory1_id: 'mem-1',
+        memory2_id: 'mem-2',
+        type: 'RELATES_TO',
+        strength: 0.7,
+      });
 
       expect(
         fakeApi.requests.every((request) => request.authorization === 'Bearer openclaw-smoke-key')

--- a/tests/host-smoke/openclaw-real-host.test.ts
+++ b/tests/host-smoke/openclaw-real-host.test.ts
@@ -1,0 +1,73 @@
+/**
+ * OpenClaw plugin boundary: make the host spec executable rather than declarative.
+ *
+ * OpenClaw is the one supported host that does not speak stdio MCP — it loads
+ * src/openclaw-plugin.ts in-process and receives tools through `api.registerTool`.
+ * A spec entry in tests/helpers/host-specs.ts therefore proves nothing on its own:
+ * stale or invented names there would still satisfy the parity suite. This registers
+ * the real plugin and checks the names it actually hands OpenClaw against that spec,
+ * then drives one tool through the shared fake AutoMem API.
+ */
+
+import { describe, expect, it } from 'vitest';
+import openClawPlugin from '../../src/openclaw-plugin.js';
+import { HOST_SMOKE_SPECS } from '../helpers/host-specs.js';
+import { startFakeAutoMemApi } from '../helpers/host-smoke.js';
+
+interface RegisteredTool {
+  name: string;
+  execute: (toolCallId: string, params: unknown) => Promise<unknown>;
+}
+
+function registerPlugin(endpoint: string, apiKey?: string): RegisteredTool[] {
+  const tools: RegisteredTool[] = [];
+  openClawPlugin.register({
+    pluginConfig: {
+      endpoint,
+      ...(apiKey ? { apiKey } : {}),
+      autoRecall: false,
+    },
+    logger: { warn: () => {} },
+    registerTool: (tool) => {
+      tools.push({ name: tool.name, execute: tool.execute });
+    },
+    on: () => {},
+  });
+  return tools;
+}
+
+const openClawSpec = HOST_SMOKE_SPECS.find((spec) => spec.host === 'openclaw');
+
+describe('OpenClaw plugin boundary', () => {
+  it('has a host spec to validate against', () => {
+    expect(openClawSpec, 'HOST_SMOKE_SPECS is missing the openclaw entry').toBeDefined();
+  });
+
+  it('registers exactly the tool names the host spec declares', () => {
+    const registered = registerPlugin('http://127.0.0.1:8001')
+      .map((tool) => tool.name)
+      .sort();
+    // Ties the declaration to reality: renaming a tool in the plugin, or drifting the
+    // spec, now fails here instead of passing as "smoke-covered".
+    expect(registered).toEqual(openClawSpec!.expectedToolNames);
+  });
+
+  it('reaches AutoMem through a registered tool', async () => {
+    const fakeApi = await startFakeAutoMemApi();
+    try {
+      const tools = registerPlugin(fakeApi.url, 'openclaw-smoke-key');
+      const recall = tools.find((tool) => tool.name === 'automem_recall_memory');
+      expect(recall).toBeDefined();
+
+      await recall!.execute('call-1', { query: 'openclaw smoke', limit: 1 });
+
+      expect(fakeApi.requests.length).toBeGreaterThan(0);
+      expect(fakeApi.requests.some((request) => request.path.startsWith('/recall'))).toBe(true);
+      expect(
+        fakeApi.requests.every((request) => request.authorization === 'Bearer openclaw-smoke-key')
+      ).toBe(true);
+    } finally {
+      await fakeApi.close();
+    }
+  }, 20_000);
+});

--- a/tests/host-smoke/openclaw-real-host.test.ts
+++ b/tests/host-smoke/openclaw-real-host.test.ts
@@ -52,17 +52,45 @@ describe('OpenClaw plugin boundary', () => {
     expect(registered).toEqual(openClawSpec!.expectedToolNames);
   });
 
-  it('reaches AutoMem through a registered tool', async () => {
+  it('drives every AutoMem operation through the registered tools', async () => {
     const fakeApi = await startFakeAutoMemApi();
     try {
       const tools = registerPlugin(fakeApi.url, 'openclaw-smoke-key');
-      const recall = tools.find((tool) => tool.name === 'automem_recall_memory');
-      expect(recall).toBeDefined();
+      const call = async (name: string, params: unknown) => {
+        const tool = tools.find((candidate) => candidate.name === name);
+        expect(tool, `plugin did not register ${name}`).toBeDefined();
+        return tool!.execute(`call-${name}`, params);
+      };
 
-      await recall!.execute('call-1', { query: 'openclaw smoke', limit: 1 });
+      // Exercising only recall would leave wrong methods, payloads or auth on the other
+      // tools invisible — the host-integration contract names all five operations.
+      await call('automem_check_health', {});
+      await call('automem_recall_memory', { query: 'openclaw smoke', limit: 1 });
+      await call('automem_store_memory', {
+        content: 'openclaw host smoke memory',
+        tags: ['openclaw-smoke'],
+        importance: 0.6,
+      });
+      await call('automem_update_memory', { memory_id: 'mem-1', importance: 0.8 });
+      await call('automem_associate_memories', {
+        memory1_id: 'mem-1',
+        memory2_id: 'mem-2',
+        type: 'RELATES_TO',
+        strength: 0.7,
+      });
 
-      expect(fakeApi.requests.length).toBeGreaterThan(0);
-      expect(fakeApi.requests.some((request) => request.path.startsWith('/recall'))).toBe(true);
+      const paths = fakeApi.requests.map((request) => request.path);
+      expect(paths).toContain('/health');
+      expect(paths.some((p) => p.startsWith('/recall'))).toBe(true);
+      expect(paths).toContain('/memory');
+      expect(paths).toContain('/memory/mem-1');
+      expect(paths).toContain('/associate');
+
+      const methods = fakeApi.requests.map((request) => `${request.method} ${request.path}`);
+      expect(methods).toContain('POST /memory');
+      expect(methods).toContain('PATCH /memory/mem-1');
+      expect(methods).toContain('POST /associate');
+
       expect(
         fakeApi.requests.every((request) => request.authorization === 'Bearer openclaw-smoke-key')
       ).toBe(true);


### PR DESCRIPTION
Adding a host meant updating **six hand-maintained lists**, and only one of them was type-checked. Three had already drifted before anyone noticed:

- **OpenClaw** is installable but has no uninstall path.
- **Copilot** was imported and routed in `src/index.ts` but missing from `KNOWN_COMMANDS`, which gates dotenv-banner silencing and the stdio-server fallthrough.
- **Copilot's memory rules** are hand-written rather than generated — the drift behind #186.

## What this does

**Derives what can be derived.** New `src/cli/clients.ts` holds `AGENT_CLIENTS` plus the exclusion lists that record where a client is deliberately unsupported. It has no imports, so `uninstall.ts`, `src/index.ts`, and tests can name clients without pulling in the installer and its cloud-provisioning stack. Uninstall platforms and the per-host entries of `KNOWN_COMMANDS` now come from it — which fixes the missing `'copilot'` entry as a side effect.

**Guards what can't.** `tests/docs/host-parity.test.ts` covers the edges no type can reach: uninstall dispatch, host smoke specs, command routing, and policy-generator registration. Accepted gaps live in named exclusion lists with reasons (`UNINSTALL_UNSUPPORTED_CLIENTS`, `HAND_WRITTEN_RULES`), so debt is visible instead of silent. The `HAND_WRITTEN_RULES` assertion is inverted — it fails if a listed host *becomes* generated, forcing the entry's removal rather than letting it rot.

**Both guards were mutation-tested**: removing the OpenClaw exclusion and unregistering the Grok template each fail the suite with an actionable message.

## Host specs: surface vs client

`HostSmokeSpec.host` stays the MCP *registration surface* and gains a `client` field. These are deliberately not 1:1 — Copilot exposes two surfaces (CLI and VS Code) from one client, `copilot` is not an `AgentClient` at all, and the spec's `claude-code` `configPath` describes `~/.claude.json` while the installer writes `~/.claude/settings.json`. Forcing `host: AgentClient` would have misrepresented all three. The parity test asserts every client has at least one spec instead.

## Not in scope

The full host-adapter registry (collapsing install.ts's six per-client switches, the three copies of `upsertRulesWithMarkers`, the private `writeFileWithBackup` forks in cursor/claude-code/openclaw, and three different backup naming schemes) is deliberately deferred. This PR makes drift *detectable*; the refactor makes it structurally impossible, and is large enough to deserve its own review.

## Verification

`npm test` 784 passed; typecheck, lint (0 errors), `format:check` clean. `mcp-automem uninstall` with no args now prints the derived platform list, including the previously-missing `copilot`.

## Review note

#3 in a three-PR stack, based on #192. Merge #191 and #192 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

### Review round 1 (Codex)

2 findings (both P2), fixed in \`8ea9472\`. (1) Smoke coverage reused the uninstall exclusion, letting OpenClaw escape entirely — every installer client now requires a spec, and OpenClaw got a real one capturing its `automem_*` naming and the `check_database_health` → `automem_check_health` rename. (2) `RULES_TEMPLATES` was a `Partial<Record>`, so a new client could skip the generator check silently; it is now total with an explicit `null` sentinel. Both threads replied and resolved.


### Review round 2 (Codex)

No new findings; the round-1 fixes were re-reviewed clean. Rebased onto the updated `feat/grok-installer-client`.


### Review round 3 (Codex)

2 findings (both P2), fixed in `6ee8e5f`. (1) The uninstall-dispatch assertion was a source grep that could not fail — `options.platform === 'cursor'` also appears in the `--clean-all` and next-steps blocks — so `runUninstall`'s if-chain became a total `Record<UninstallPlatform, handler>`; a missing handler is now a **compile error**, and the test asserts the real map in both directions. (2) `RULES_TEMPLATES` hard-coded `'copilot'`; its key type is now derived from `STANDALONE_PLATFORMS`. Both threads replied and resolved.

**Budget note:** this was the third and final remediation push allowed for this PR.
