### PR TITLE
fix(copilot): print usage for --help instead of installing

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -716,6 +716,7 @@ Re-running the command also deletes the orphaned files from the retired session-
 | `--dry-run` | | Preview changes without writing files |
 | `--yes` | | Skip confirmation prompts |
 | `--quiet` | | Suppress output |
+| `--help`, `-h` | | Print the usage block and exit without installing |
 
 > **Nudge note:** Copilot's `agentStop` output contract is `{decision, reason}` -- a `block` decision re-prompts the agent using `reason`. Unlike Claude Code's `Stop` hook it cannot inject hidden, non-prompting context, so the storage nudge is opt-in (`--profile full`) only; the default `lean` install keeps session end silent. The nudge fires at most once per session and only after a substantive session (>= 5 `user.message` turns in the transcript).
 

--- a/src/cli/copilot.ts
+++ b/src/cli/copilot.ts
@@ -584,6 +584,25 @@ export async function applyCopilotSetup(cliOptions: CopilotSetupOptions): Promis
   }
 }
 
+/**
+ * Usage block for `mcp-automem copilot`. Single source of truth: printed by
+ * `copilot --help` and interpolated into the top-level `help` output in
+ * src/index.ts, so the two can't drift.
+ */
+export const COPILOT_USAGE = `COPILOT SETUP:
+  npx @verygoodplugins/mcp-automem copilot [options]
+
+  Options:
+    --format <cli|vscode|both>  Memory rules and hook event name casing. cli = camelCase
+                           hooks + CLI rules only. vscode = PascalCase hooks + VS Code
+                           rules only. both = camelCase hooks + both rule sets (default).
+    --profile <full|lean>  Hook profile. lean = session only (default); full = all hooks.
+    --dir <path>           Target directory (default: $COPILOT_HOME or ~/.copilot)
+    --dry-run             Show what would be changed
+    --yes, -y             Skip confirmation prompts
+    --quiet               Suppress non-error output
+    --help, -h            Print this usage block and exit without installing`;
+
 // T016: CLI argument parser
 function parseCopilotArgs(args: string[]): CopilotSetupOptions {
   const options: CopilotSetupOptions = {};
@@ -632,6 +651,15 @@ function parseCopilotArgs(args: string[]): CopilotSetupOptions {
 }
 
 export async function runCopilotSetup(args: string[] = []): Promise<void> {
+  // Short-circuit before parsing: --help must never touch the filesystem, and
+  // the value-flag guards in parseCopilotArgs exit(1) on a trailing --dir or
+  // --format, which would swallow the help request. Return rather than exit so
+  // the caller in src/index.ts still owns the exit code (0).
+  if (args.includes('--help') || args.includes('-h')) {
+    console.log(COPILOT_USAGE);
+    return;
+  }
+
   const options = parseCopilotArgs(args);
 
   // T027: Validate --format

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,14 +59,30 @@ const KNOWN_COMMANDS = new Set([
   "queue",
   "recall",
 ]);
+const commandArgs = process.argv.slice(3);
 const isMachineReadableCommand =
-  command === "config" && process.argv.slice(3).some(
+  command === "config" && commandArgs.some(
     (arg) => arg === "--json" || arg === "--format=json" || arg === "--format"
   );
+// Every host handler documents --quiet as "suppress output", and a help request
+// exists to print a usage block — in both cases the dotenv banner is exactly the
+// noise the caller asked us not to emit. Covers `help`/`--help`/`-h` as the
+// command and as a flag on a subcommand (e.g. `copilot --help`).
+const isHelpRequest =
+  command === "help" ||
+  command === "--help" ||
+  command === "-h" ||
+  commandArgs.some((arg) => arg === "--help" || arg === "-h");
+const wantsQuietOutput = commandArgs.some((arg) => arg === "--quiet");
 // The guided installer renders a branded splash + curated review; the dotenv
 // banner would corrupt that output, so silence it here too.
 const shouldSilenceDotenv =
-  isServerMode || isMachineReadableCommand || command === "install" || !KNOWN_COMMANDS.has(command);
+  isServerMode ||
+  isMachineReadableCommand ||
+  isHelpRequest ||
+  wantsQuietOutput ||
+  command === "install" ||
+  !KNOWN_COMMANDS.has(command);
 
 // Prevent dotenv from writing its banner to stdout when the caller expects clean
 // machine-readable output (stdio server mode, or `config --format=json`).

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { runClaudeCodeSetup } from "./cli/claude-code.js";
 import { runCursorSetup } from "./cli/cursor.js";
 import { runCodexSetup } from "./cli/codex.js";
 import { runOpenClawSetup } from "./cli/openclaw.js";
-import { runCopilotSetup } from "./cli/copilot.js";
+import { COPILOT_USAGE, runCopilotSetup } from "./cli/copilot.js";
 import { runHermesSetup } from "./cli/hermes.js";
 import { runMigrateCommand } from "./cli/migrate.js";
 import { runUninstallCommand } from "./cli/uninstall.js";
@@ -49,6 +49,7 @@ const KNOWN_COMMANDS = new Set([
   "install",
   "config",
   "claude-code",
+  "copilot",
   "cursor",
   "codex",
   "openclaw",
@@ -227,18 +228,7 @@ CLAUDE CODE SETUP:
     --quiet               Suppress output
     --yes, -y             Skip confirmation prompts
 
-COPILOT SETUP:
-  npx @verygoodplugins/mcp-automem copilot [options]
-  
-  Options:
-    --format <cli|vscode|both>  Memory rules and hook event name casing. cli = camelCase
-                           hooks + CLI rules only. vscode = PascalCase hooks + VS Code
-                           rules only. both = camelCase hooks + both rule sets (default).
-    --profile <full|lean>  Hook profile. lean = session only (default); full = all hooks.
-    --dir <path>           Target directory (default: $COPILOT_HOME or ~/.copilot)
-    --dry-run             Show what would be changed
-    --yes, -y             Skip confirmation prompts
-    --quiet               Suppress non-error output
+${COPILOT_USAGE}
 
 MIGRATION:
   npx @verygoodplugins/mcp-automem migrate --from <source> --to <target>

--- a/tests/cli/smoke.test.ts
+++ b/tests/cli/smoke.test.ts
@@ -98,6 +98,56 @@ describe('CLI Smoke Tests', () => {
     });
   });
 
+  describe('clean output contract', () => {
+    // A help request prints a usage block and --quiet is documented as
+    // "suppress output"; the dotenv banner is exactly the noise both opt out
+    // of. Regression guard for `copilot` joining KNOWN_COMMANDS, which flipped
+    // the banner on for every copilot invocation.
+    //
+    // Only `copilot` is exercised with a subcommand flag here. Every other host
+    // handler still ignores --help and installs (see parseCommonFlags), so
+    // `claude-code --help` would rewrite the developer's real ~/.claude during
+    // `npm test`, and `cursor`/`codex --help` would write into the repo. Those
+    // commands get a case here once they short-circuit on help too.
+    const helpInvocations = [['help'], ['--help'], ['copilot', '--help'], ['copilot', '-h']];
+
+    for (const args of helpInvocations) {
+      it(`\`${args.join(' ')}\` prints no dotenv banner`, () => {
+        // Isolated even though these paths write nothing today: if the help
+        // short-circuit ever regresses, the blast radius stays in the temp dir.
+        const copilotHome = fs.mkdtempSync(path.join(tempDir, 'banner-home-'));
+
+        const result = runCli(args, { env: { COPILOT_HOME: copilotHome } });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout + result.stderr).not.toContain('injected env');
+      });
+    }
+
+    it('`copilot --help` writes nothing to COPILOT_HOME', () => {
+      const copilotHome = fs.mkdtempSync(path.join(tempDir, 'copilot-home-'));
+
+      const result = runCli(['copilot', '--help'], { env: { COPILOT_HOME: copilotHome } });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('COPILOT SETUP:');
+      expect(fs.readdirSync(copilotHome)).toEqual([]);
+    });
+
+    it('`copilot --quiet` installs without emitting the dotenv banner', () => {
+      const copilotHome = fs.mkdtempSync(path.join(tempDir, 'copilot-quiet-home-'));
+
+      const result = runCli(['copilot', '--quiet', '--yes'], {
+        env: { COPILOT_HOME: copilotHome },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout + result.stderr).not.toContain('injected env');
+      // --quiet suppresses progress output but must not suppress the install.
+      expect(fs.existsSync(path.join(copilotHome, 'hooks'))).toBe(true);
+    });
+  });
+
   describe('config command', () => {
     it('should output config with MCP server snippet', () => {
       const output = runCliExpectSuccess(['config']);

--- a/tests/copilot-setup.test.ts
+++ b/tests/copilot-setup.test.ts
@@ -4,12 +4,12 @@
  * event name remapping), installMemoryRules, and --format validation.
  */
 
-import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { spawnSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { applyCopilotSetup, EVENT_NAMES } from '../src/cli/copilot.js';
+import { applyCopilotSetup, COPILOT_USAGE, EVENT_NAMES, runCopilotSetup } from '../src/cli/copilot.js';
 import type { CopilotHookFile } from '../src/cli/copilot.js';
 
 function createTempDir(): string {
@@ -568,5 +568,63 @@ describe('session-start bash script', () => {
     expect(parsed.additionalContext).toContain(projectName);
 
     try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* best effort */ }
+  });
+});
+
+describe('copilot --help', () => {
+  let tempDir: string;
+  let previousCopilotHome: string | undefined;
+  let stdout: string[];
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    // runCopilotSetup resolves its target from COPILOT_HOME when --dir is absent,
+    // so point it at an empty temp dir: a --help run that still installs will
+    // leave evidence here instead of writing to the developer's ~/.copilot.
+    previousCopilotHome = process.env.COPILOT_HOME;
+    process.env.COPILOT_HOME = tempDir;
+
+    stdout = [];
+    logSpy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      stdout.push(args.map(String).join(' '));
+    });
+    // --help returns rather than exiting (src/index.ts owns the exit code), and
+    // the arg parser exits(1) on a value flag with no value. Throwing here turns
+    // either exit into a clean failure instead of tearing down the vitest worker.
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit');
+    });
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+    if (previousCopilotHome === undefined) {
+      delete process.env.COPILOT_HOME;
+    } else {
+      process.env.COPILOT_HOME = previousCopilotHome;
+    }
+    cleanupDir(tempDir);
+  });
+
+  for (const flag of ['--help', '-h']) {
+    it(`${flag} prints the usage block and writes nothing`, async () => {
+      await runCopilotSetup([flag]);
+
+      expect(fs.readdirSync(tempDir)).toEqual([]);
+      expect(stdout.join('\n')).toBe(COPILOT_USAGE);
+      expect(stdout.join('\n')).toContain('COPILOT SETUP:');
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+  }
+
+  it('short-circuits before the parser can reject a valueless flag', async () => {
+    await runCopilotSetup(['--help', '--format']);
+
+    expect(fs.readdirSync(tempDir)).toEqual([]);
+    expect(stdout.join('\n')).toBe(COPILOT_USAGE);
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Problem

`node dist/index.js copilot --help` (and `-h`) ran a **real install** against `$COPILOT_HOME` (default `~/.copilot`) instead of printing usage — 10 files written: hook JSON, bash + PowerShell support scripts, and a rewrite of the AutoMem block in `copilot-instructions.md`.

Reproduced before the fix:

```
$ COPILOT_HOME=$tmp node dist/index.js copilot --help
exit=0 — 10 files written
```

## Changes

**1. `copilot --help` / `-h` short-circuits** (`src/cli/copilot.ts`)

The guard sits at the top of `runCopilotSetup`, *before* `parseCopilotArgs`. That placement is load-bearing: the parser's value-flag guards call `process.exit(1)` on a trailing `--dir`/`--format`, so a help check after a full parse would swallow `copilot --help --format`. It `return`s rather than exits, so `src/index.ts` keeps ownership of the exit code.

The usage text moved into an exported `COPILOT_USAGE` constant that the top-level `help` output now interpolates, so the two can't drift.

**2. `"copilot"` added to `KNOWN_COMMANDS`** (`src/index.ts`)

It was missing despite the command being imported and routed. Note the "stdio-server fallthrough" concern is moot — `copilot` is explicitly routed and exits, so it never reached the fallthrough.

**3. Keep dotenv silent for help and `--quiet`** (`src/index.ts`)

Fixing #2 flipped `shouldSilenceDotenv` to `false` for `copilot`, so `copilot --help` and `copilot --quiet` started emitting dotenv's `injected env ...` banner on stdout — a regression against the documented `--quiet` ("suppress output") contract. `shouldSilenceDotenv` now also covers a help request and an explicit `--quiet`, completing the predicate's existing intent rather than special-casing copilot.

This also silences the banner for `mcp-automem help` and `--help`, which printed it before this PR.

## Verification

| Invocation | exit | files written |
|---|---|---|
| `copilot --help` *(before)* | 0 | **10** |
| `copilot --help` / `-h` *(after)* | 0 | 0 |
| `copilot --yes --quiet` | 0 | 10 (install intact) |

Both new test groups were confirmed to **fail without their fix** before being kept:

- Disabling the copilot short-circuit → `expected [ 'copilot-instructions.md', 'hooks', 'instructions', 'scripts' ] to deeply equal []`, plus `Error: process.exit` on the `--help --format` case.
- Disabling the dotenv predicate → all banner cases fail with `expected '◇ injected env (0) from .env …' not to contain 'injected env'`.

`npm test`: 744 passing. Three failures are pre-existing on `main` (verified by stashing): the `sync-memory-policy` idempotency check, and two `hermes-real-host` cases that expect the `mcp-automem` tag but get the worktree directory name. Typecheck clean; eslint 0 errors (3 pre-existing `no-explicit-any` warnings, untouched).

## Notes for review

- **The CLI-level tests are deliberately narrow.** Only `copilot` is exercised with a subcommand `--help` flag. Every other host handler still ignores `--help` and installs, so a `claude-code --help` test case would rewrite the developer's real `~/.claude` during `npm test`, and `cursor`/`codex --help` would write into the repo. The banner cases run with an isolated `COPILOT_HOME` so a future regression of the short-circuit stays in a temp dir.
- **Adjacent gap, not fixed here:** `parseCommonFlags` (`src/cli/host-toolkit.ts`) has no `--help` handling either, so `cursor`, `codex`, `claude-code`, and `hermes` all still install on `--help`. Worth a follow-up; deliberately out of scope for this PR.