### PR TITLE
fix: pair inherited API keys with their endpoint across all installer hosts

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -78,6 +78,17 @@ the plan.
 > Without a TTY and without `--yes`/`--dry-run`, `install` prints the review
 > plan and stops without writing — re-run with `--yes` to apply.
 
+**API keys are paired with their endpoint.** A key belongs to the AutoMem
+instance it was issued for, so the installers never carry one to a different
+host. If you re-run against a new `--endpoint` without passing `--api-key`, any
+key inherited from your shell (`AUTOMEM_API_KEY` / `AUTOMEM_API_TOKEN`) or from
+the agent's existing config is dropped rather than reused, and a key already
+persisted in the project `.env` is removed — the MCP server loads that file at
+startup, so leaving it would send the old credential to the new host. Pass
+`--api-key` to set the credential for the new endpoint. A key exported with no
+endpoint alongside it is not bound to anything and is still used; a re-run at
+the *same* endpoint keeps the key it already has.
+
 **Removing AutoMem:** uninstall is per-agent —
 `npx @verygoodplugins/mcp-automem uninstall <cursor|claude-code|codex|hermes|grok>`
 (add `--clean-all` to also drop the MCP server config). OpenClaw owns its own

--- a/src/cli/grok-config.test.ts
+++ b/src/cli/grok-config.test.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { parse as parseToml } from 'smol-toml';
 import {
   buildGrokAutoMemServerEntry,
+  readExistingGrokCredentials,
   removeGrokMemoryServer,
   resolveGrokPaths,
   upsertGrokMemoryServer,
@@ -564,6 +565,112 @@ describe('grok-config', () => {
         mcp_servers: Record<string, unknown>;
       };
       expect(parsed.mcp_servers.memory).toBeDefined();
+    });
+  });
+
+  // The AutoMem service still accepts AUTOMEM_API_TOKEN (Railway template, SSE
+  // sidecar, existing deploys), so every reader has to. Reading only the canonical
+  // name turned a working authenticated install into an unauthenticated one on a
+  // flagless re-run, and left a live token in a world-readable backup.
+  describe('legacy AUTOMEM_API_TOKEN alias', () => {
+    const writeLegacyConfig = (configPath: string): void => {
+      fs.writeFileSync(
+        configPath,
+        [
+          '[mcp_servers.memory]',
+          'command = "npx"',
+          'args = ["-y", "@verygoodplugins/mcp-automem"]',
+          'enabled = true',
+          '',
+          '[mcp_servers.memory.env]',
+          'AUTOMEM_API_URL = "https://legacy.example.test"',
+          'AUTOMEM_API_TOKEN = "sk-legacy"',
+          '',
+        ].join('\n')
+      );
+    };
+
+    it('reads a token-authenticated entry and reports it under the canonical name', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      writeLegacyConfig(configPath);
+
+      expect(readExistingGrokCredentials(configPath)).toEqual({
+        endpoint: 'https://legacy.example.test',
+        apiKey: 'sk-legacy',
+      });
+    });
+
+    it('reads the deprecated AUTOMEM_ENDPOINT alias as the endpoint', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      fs.writeFileSync(
+        configPath,
+        [
+          '[mcp_servers.memory.env]',
+          'AUTOMEM_ENDPOINT = "https://legacy.example.test"',
+          'AUTOMEM_API_KEY = "sk-x"',
+          '',
+        ].join('\n')
+      );
+
+      expect(readExistingGrokCredentials(configPath).endpoint).toBe('https://legacy.example.test');
+    });
+
+    it('treats a token-bearing entry as secret-bearing when tightening the backup', () => {
+      if (process.platform === 'win32') return;
+      const configPath = path.join(tmpDir, 'config.toml');
+      writeLegacyConfig(configPath);
+      fs.chmodSync(configPath, 0o644);
+
+      removeGrokMemoryServer(configPath, { quiet: true });
+
+      const backup = fs
+        .readdirSync(tmpDir)
+        .filter((name) => name.startsWith('config.toml.bak'))
+        .map((name) => path.join(tmpDir, name));
+      expect(backup.length).toBeGreaterThan(0);
+      for (const file of backup) {
+        // The backup still holds the live token, so it must not stay world-readable.
+        expect(fs.readFileSync(file, 'utf8')).toContain('sk-legacy');
+        expect(fs.statSync(file).mode & 0o777).toBe(0o600);
+      }
+    });
+  });
+
+  // The ownership predicate used to serialize the whole entry — env values included —
+  // and search it for "mcp-automem", so an unrelated server merely pointing at a host
+  // with that name was overwritable by setup and deletable by uninstall.
+  describe('foreign server ownership', () => {
+    const foreign = [
+      '[mcp_servers.memory]',
+      'command = "other-server"',
+      'args = ["--start"]',
+      '',
+      '[mcp_servers.memory.env]',
+      'UPSTREAM_URL = "https://mcp-automem.internal"',
+      '',
+    ].join('\n');
+
+    it('refuses to overwrite a foreign entry that merely mentions mcp-automem in env', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      fs.writeFileSync(configPath, foreign);
+
+      expect(() =>
+        upsertGrokMemoryServer(
+          configPath,
+          buildGrokAutoMemServerEntry('https://automem.example.test'),
+          { quiet: true }
+        )
+      ).toThrow();
+      expect(fs.readFileSync(configPath, 'utf8')).toBe(foreign);
+    });
+
+    it('leaves that foreign entry alone on uninstall', () => {
+      const configPath = path.join(tmpDir, 'config.toml');
+      fs.writeFileSync(configPath, foreign);
+
+      removeGrokMemoryServer(configPath, { quiet: true, onlyIfAutoMem: true });
+
+      expect(fs.readFileSync(configPath, 'utf8')).toBe(foreign);
     });
   });
 });

--- a/src/cli/grok-config.test.ts
+++ b/src/cli/grok-config.test.ts
@@ -62,9 +62,13 @@ describe('grok-config', () => {
       });
     });
 
-    it('omits the API key when not provided', () => {
+    it('writes blank credential overrides when no key is provided', () => {
       const entry = buildGrokAutoMemServerEntry('https://api.example.com');
-      expect(entry.env).not.toHaveProperty('AUTOMEM_API_KEY');
+      // Blank, not absent: the host layers this env over its own, so an omitted
+      // key leaves a shell-exported one inherited by the child. A blank shadows it
+      // and reads as absent to the server.
+      expect(entry.env.AUTOMEM_API_KEY).toBe('');
+      expect(entry.env.AUTOMEM_API_TOKEN).toBe('');
       expect(entry.env.AUTOMEM_PROCESS_TAG).toBe('grok:memory');
     });
   });

--- a/src/cli/grok-config.ts
+++ b/src/cli/grok-config.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import { parse as parseToml, stringify as stringifyToml } from 'smol-toml';
 import {
+  AUTOMEM_API_KEY_NAMES,
   backupPath,
   isAutoMemServerEntry,
   log,
@@ -57,6 +58,15 @@ export function buildGrokAutoMemServerEntry(
   };
   if (apiKey) {
     env.AUTOMEM_API_KEY = apiKey;
+  } else {
+    // Rejection has to be written, not merely omitted. The host launches the server
+    // with the entry's env layered over its own (`{...process.env, ...entry.env}`), so
+    // omitting the key leaves a shell-exported one — issued for whatever endpoint that
+    // shell names — inherited by a child whose URL this entry just pointed somewhere
+    // else. An explicit blank shadows it; readAutoMemApiKeyFromEnv treats blank as
+    // absent, so the server runs unauthenticated instead of authenticating to the
+    // wrong host. Both names, since either one authenticates.
+    for (const name of AUTOMEM_API_KEY_NAMES) env[name] = '';
   }
   return {
     command: 'npx',

--- a/src/cli/grok-config.ts
+++ b/src/cli/grok-config.ts
@@ -2,7 +2,13 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { parse as parseToml, stringify as stringifyToml } from 'smol-toml';
-import { backupPath, log } from './host-toolkit.js';
+import {
+  backupPath,
+  isAutoMemServerEntry,
+  log,
+  readApiKeyFrom,
+  readEndpointFrom,
+} from './host-toolkit.js';
 
 export const GROK_MCP_SERVER_NAME = 'memory';
 
@@ -101,19 +107,14 @@ function restrictToOwner(filePath: string): void {
  */
 function entryHasApiKey(entry: unknown): boolean {
   if (!isRecord(entry)) return false;
-  const env = entry.env;
-  return isRecord(env) && typeof env.AUTOMEM_API_KEY === 'string' && env.AUTOMEM_API_KEY.length > 0;
+  // Both supported credential names count. Reading only the canonical one reported
+  // "no secret" for an entry authenticated with the deprecated AUTOMEM_API_TOKEN
+  // alias, so its config and backups were left world-readable with a live token in
+  // them.
+  return isRecord(entry.env) && readApiKeyFrom(entry.env) !== undefined;
 }
 
-function isAutoMemMcpEntry(entry: unknown): boolean {
-  if (!isRecord(entry)) return false;
-  const haystack = JSON.stringify({
-    command: entry.command,
-    args: entry.args,
-    env: entry.env,
-  });
-  return haystack.includes('@verygoodplugins/mcp-automem') || haystack.includes('mcp-automem');
-}
+const isAutoMemMcpEntry = isAutoMemServerEntry;
 
 function parseGrokDocument(raw: string, configPath: string): Record<string, unknown> {
   try {
@@ -409,12 +410,6 @@ export interface GrokCredentials {
   apiKey?: string;
 }
 
-function normalizeCred(value: unknown): string | undefined {
-  if (typeof value !== 'string') return undefined;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
-}
-
 /**
  * Read AutoMem credentials already installed for Grok so a re-run with no
  * explicit flags preserves them rather than overwriting with defaults.
@@ -437,7 +432,12 @@ export function readExistingGrokCredentials(configPath: string): GrokCredentials
   const env = entry && isRecord(entry.env) ? (entry.env as Record<string, unknown>) : null;
   if (!env) return {};
   return {
-    endpoint: normalizeCred(env.AUTOMEM_API_URL) ?? normalizeCred(env.AUTOMEM_ENDPOINT),
-    apiKey: normalizeCred(env.AUTOMEM_API_KEY),
+    // Both supported names are read, and the result is canonical: the entry this
+    // install rewrites always writes AUTOMEM_API_KEY. Reading only the canonical name
+    // meant a flagless re-run over an install authenticated with the deprecated
+    // AUTOMEM_API_TOKEN alias found no key and replaced the entry without one,
+    // silently turning a working install into an unauthenticated one.
+    endpoint: readEndpointFrom(env),
+    apiKey: readApiKeyFrom(env),
   };
 }

--- a/src/cli/grok.test.ts
+++ b/src/cli/grok.test.ts
@@ -11,6 +11,7 @@ describe('grok setup', () => {
   let originalApiUrl: string | undefined;
   let originalApiKey: string | undefined;
   let originalEndpoint: string | undefined;
+  let originalApiToken: string | undefined;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'grok-setup-'));
@@ -18,10 +19,12 @@ describe('grok setup', () => {
     originalApiUrl = process.env.AUTOMEM_API_URL;
     originalApiKey = process.env.AUTOMEM_API_KEY;
     originalEndpoint = process.env.AUTOMEM_ENDPOINT;
+    originalApiToken = process.env.AUTOMEM_API_TOKEN;
     process.env.GROK_HOME = tmpDir;
     delete process.env.AUTOMEM_API_URL;
     delete process.env.AUTOMEM_API_KEY;
     delete process.env.AUTOMEM_ENDPOINT;
+    delete process.env.AUTOMEM_API_TOKEN;
   });
 
   afterEach(() => {
@@ -34,6 +37,8 @@ describe('grok setup', () => {
     else process.env.AUTOMEM_API_KEY = originalApiKey;
     if (originalEndpoint === undefined) delete process.env.AUTOMEM_ENDPOINT;
     else process.env.AUTOMEM_ENDPOINT = originalEndpoint;
+    if (originalApiToken === undefined) delete process.env.AUTOMEM_API_TOKEN;
+    else process.env.AUTOMEM_API_TOKEN = originalApiToken;
   });
 
   it('writes mcp_servers.memory and AGENTS.md rules', async () => {
@@ -268,7 +273,7 @@ describe('grok setup', () => {
 
     await expect(
       applyGrokSetup({ endpoint: 'https://automem.example.test', quiet: true })
-    ).rejects.toThrow(/without a matching/);
+    ).rejects.toThrow(/does not contain exactly one/);
 
     // The user's file is left exactly as it was.
     expect(fs.readFileSync(rulesPath, 'utf8')).toBe(handWritten);
@@ -291,7 +296,7 @@ describe('grok setup', () => {
 
     await expect(
       applyGrokSetup({ endpoint: 'https://other.example.test', apiKey: 'sk-other', quiet: true })
-    ).rejects.toThrow(/without a matching/);
+    ).rejects.toThrow(/does not contain exactly one/);
 
     // Neither file moved: no partial install.
     expect(fs.readFileSync(configPath, 'utf8')).toBe(configBefore);
@@ -306,7 +311,7 @@ describe('grok setup', () => {
 
     await expect(
       applyGrokSetup({ endpoint: 'https://automem.example.test', quiet: true })
-    ).rejects.toThrow(/without a matching/);
+    ).rejects.toThrow(/does not contain exactly one/);
   });
 
   it('dry-run does not write files', async () => {
@@ -406,5 +411,98 @@ describe('grok setup', () => {
     }
 
     expect(lines.join('\n')).not.toContain('disabled_mcp_servers');
+  });
+
+  // Both markers are present, so a one-sided check sees a well-formed file and
+  // replaces from the first start through the end — deleting the second marker and
+  // everything the user wrote between them. Counting is what catches it.
+  it('refuses when the rules file has two start markers and one end', async () => {
+    const rulesPath = path.join(tmpDir, 'AGENTS.md');
+    const handWritten = [
+      '# My notes',
+      GROK_RULES_START,
+      'first block',
+      GROK_RULES_START,
+      'content the user wrote and must not lose',
+      GROK_RULES_END,
+      '',
+    ].join('\n');
+    fs.writeFileSync(rulesPath, handWritten);
+
+    await expect(
+      applyGrokSetup({ endpoint: 'https://automem.example.test', quiet: true })
+    ).rejects.toThrow(/does not contain exactly one/);
+
+    expect(fs.readFileSync(rulesPath, 'utf8')).toBe(handWritten);
+  });
+
+  it('refuses when the end marker precedes the start marker', async () => {
+    const rulesPath = path.join(tmpDir, 'AGENTS.md');
+    const handWritten = ['# notes', GROK_RULES_END, 'inverted', GROK_RULES_START, ''].join('\n');
+    fs.writeFileSync(rulesPath, handWritten);
+
+    await expect(
+      applyGrokSetup({ endpoint: 'https://automem.example.test', quiet: true })
+    ).rejects.toThrow(/precedes/);
+
+    expect(fs.readFileSync(rulesPath, 'utf8')).toBe(handWritten);
+  });
+
+  // A flagless re-run over an install authenticated with the deprecated alias used to
+  // find no key and rewrite the entry without one, silently unauthenticating it.
+  it('preserves a legacy AUTOMEM_API_TOKEN credential across a flagless re-run', async () => {
+    const configPath = path.join(tmpDir, 'config.toml');
+    fs.writeFileSync(
+      configPath,
+      [
+        '[mcp_servers.memory]',
+        'command = "npx"',
+        'args = ["-y", "@verygoodplugins/mcp-automem"]',
+        'enabled = true',
+        '',
+        '[mcp_servers.memory.env]',
+        'AUTOMEM_API_URL = "https://legacy.example.test"',
+        'AUTOMEM_API_TOKEN = "sk-legacy"',
+        '',
+      ].join('\n')
+    );
+
+    await applyGrokSetup({ quiet: true, projectName: 'demo' });
+
+    const parsed = parseToml(fs.readFileSync(configPath, 'utf8')) as {
+      mcp_servers: { memory: { env: Record<string, string> } };
+    };
+    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_URL).toBe('https://legacy.example.test');
+    // Carried forward, and canonicalized to the name the installer writes.
+    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_KEY).toBe('sk-legacy');
+  });
+
+  it('does not carry a stored key to a different endpoint', async () => {
+    const configPath = path.join(tmpDir, 'config.toml');
+    await applyGrokSetup({
+      endpoint: 'https://first.example.test',
+      apiKey: 'sk-first',
+      quiet: true,
+    });
+
+    await applyGrokSetup({ endpoint: 'https://second.example.test', quiet: true });
+
+    const parsed = parseToml(fs.readFileSync(configPath, 'utf8')) as {
+      mcp_servers: { memory: { env: Record<string, string> } };
+    };
+    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_URL).toBe('https://second.example.test');
+    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_KEY).toBeUndefined();
+  });
+
+  it('does not carry a shell key exported for another endpoint', async () => {
+    process.env.AUTOMEM_API_URL = 'https://shell.example.test';
+    process.env.AUTOMEM_API_KEY = 'sk-shell';
+
+    await applyGrokSetup({ endpoint: 'https://chosen.example.test', quiet: true });
+
+    const parsed = parseToml(fs.readFileSync(path.join(tmpDir, 'config.toml'), 'utf8')) as {
+      mcp_servers: { memory: { env: Record<string, string> } };
+    };
+    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_KEY).toBeUndefined();
   });
 });

--- a/src/cli/grok.test.ts
+++ b/src/cli/grok.test.ts
@@ -4,6 +4,7 @@ import os from 'os';
 import path from 'path';
 import { parse as parseToml } from 'smol-toml';
 import { applyGrokSetup, GROK_RULES_END, GROK_RULES_START } from './grok.js';
+import { readAutoMemApiKeyFromEnv } from '../env.js';
 
 describe('grok setup', () => {
   let tmpDir: string;
@@ -136,7 +137,7 @@ describe('grok setup', () => {
       mcp_servers: { memory: { env: Record<string, string> } };
     };
     expect(parsed.mcp_servers.memory.env.AUTOMEM_API_URL).toBe('https://second.example.test');
-    expect(parsed.mcp_servers.memory.env).not.toHaveProperty('AUTOMEM_API_KEY');
+    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_KEY).toBe('');
   });
 
   it('treats a trailing slash as the same endpoint and keeps the key', async () => {
@@ -186,7 +187,7 @@ describe('grok setup', () => {
       mcp_servers: { memory: { env: Record<string, string> } };
     };
     expect(parsed.mcp_servers.memory.env.AUTOMEM_API_URL).toBe('https://elsewhere.example.test');
-    expect(parsed.mcp_servers.memory.env).not.toHaveProperty('AUTOMEM_API_KEY');
+    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_KEY).toBe('');
   });
 
   it('uses a shell-exported key when it belongs to the chosen endpoint', async () => {
@@ -491,7 +492,10 @@ describe('grok setup', () => {
       mcp_servers: { memory: { env: Record<string, string> } };
     };
     expect(parsed.mcp_servers.memory.env.AUTOMEM_API_URL).toBe('https://second.example.test');
-    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_KEY).toBeUndefined();
+    // Blank rather than absent, so a shell-exported key cannot be inherited by the
+    // child process the host launches with this env layered over its own.
+    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_KEY).toBe('');
+    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_TOKEN).toBe('');
   });
 
   it('does not carry a shell key exported for another endpoint', async () => {
@@ -503,6 +507,54 @@ describe('grok setup', () => {
     const parsed = parseToml(fs.readFileSync(path.join(tmpDir, 'config.toml'), 'utf8')) as {
       mcp_servers: { memory: { env: Record<string, string> } };
     };
-    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_KEY).toBeUndefined();
+    // Blank rather than absent, so a shell-exported key cannot be inherited by the
+    // child process the host launches with this env layered over its own.
+    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_KEY).toBe('');
+    expect(parsed.mcp_servers.memory.env.AUTOMEM_API_TOKEN).toBe('');
+  });
+
+  // The boundary that matters: the host launches the server with the entry's env
+  // layered over its own. Omitting the key from the entry does not stop a
+  // shell-exported one — issued for a different endpoint — from reaching the child.
+  it('shadows a shell key so the launched server cannot inherit it', async () => {
+    process.env.AUTOMEM_API_URL = 'https://shell.example.test';
+    process.env.AUTOMEM_API_KEY = 'sk-shell';
+
+    await applyGrokSetup({ endpoint: 'https://chosen.example.test', quiet: true });
+
+    const parsed = parseToml(fs.readFileSync(path.join(tmpDir, 'config.toml'), 'utf8')) as {
+      mcp_servers: { memory: { env: Record<string, string> } };
+    };
+    // Exactly how the host spawns it.
+    const childEnv = { ...process.env, ...parsed.mcp_servers.memory.env };
+    expect(childEnv.AUTOMEM_API_URL).toBe('https://chosen.example.test');
+    expect(readAutoMemApiKeyFromEnv(childEnv)).toBeUndefined();
+  });
+
+  it('shadows a shell key exported under the deprecated alias too', async () => {
+    process.env.AUTOMEM_ENDPOINT = 'https://shell.example.test';
+    process.env.AUTOMEM_API_TOKEN = 'sk-shell-legacy';
+
+    await applyGrokSetup({ endpoint: 'https://chosen.example.test', quiet: true });
+
+    const parsed = parseToml(fs.readFileSync(path.join(tmpDir, 'config.toml'), 'utf8')) as {
+      mcp_servers: { memory: { env: Record<string, string> } };
+    };
+    const childEnv = { ...process.env, ...parsed.mcp_servers.memory.env };
+    expect(readAutoMemApiKeyFromEnv(childEnv)).toBeUndefined();
+  });
+
+  it('still hands a resolved key to the launched server', async () => {
+    await applyGrokSetup({
+      endpoint: 'https://chosen.example.test',
+      apiKey: 'sk-real',
+      quiet: true,
+    });
+
+    const parsed = parseToml(fs.readFileSync(path.join(tmpDir, 'config.toml'), 'utf8')) as {
+      mcp_servers: { memory: { env: Record<string, string> } };
+    };
+    const childEnv = { ...process.env, ...parsed.mcp_servers.memory.env };
+    expect(readAutoMemApiKeyFromEnv(childEnv)).toBe('sk-real');
   });
 });

--- a/src/cli/grok.ts
+++ b/src/cli/grok.ts
@@ -7,7 +7,7 @@ import {
   log,
   parseCommonFlags,
   replaceTemplateVars,
-  sameEndpoint,
+  resolveInheritedApiKey,
   writeFileWithBackup,
 } from './host-toolkit.js';
 import {
@@ -18,7 +18,6 @@ import {
   resolveGrokPaths,
   upsertGrokMemoryServer,
 } from './grok-config.js';
-import { readAutoMemApiKeyFromEnv } from '../env.js';
 import { DEFAULT_AUTOMEM_API_URL } from './templates.js';
 
 export interface GrokSetupOptions extends CommonOptions {
@@ -68,34 +67,60 @@ function sameFile(a: string, b: string): boolean {
   return real(a) === real(b);
 }
 
+function countOccurrences(haystack: string, needle: string): number {
+  let count = 0;
+  let from = 0;
+  for (;;) {
+    const idx = haystack.indexOf(needle, from);
+    if (idx === -1) return count;
+    count += 1;
+    from = idx + needle.length;
+  }
+}
+
 function upsertRulesWithMarkers(existing: string | null, block: string, rulesPath: string): string {
   const normalize = (s: string) => `${s.replace(/\n+$/, '')}\n`;
   if (!existing) {
     return normalize(block);
   }
+  const starts = countOccurrences(existing, GROK_RULES_START);
+  const ends = countOccurrences(existing, GROK_RULES_END);
+
+  if (starts === 0 && ends === 0) {
+    const sep = existing.endsWith('\n') ? '\n' : '\n\n';
+    return normalize(`${existing}${sep}${block}`);
+  }
+
+  // Anything other than exactly one correctly ordered pair is refused rather than
+  // repaired. Every malformed shape here destroys user content if we replace anyway:
+  //
+  //  - One-sided (an interrupted run, or a hand edit that deleted half the block):
+  //    appending leaves one start and two ends, so the *next* run replaces everything
+  //    from the original start to the appended end.
+  //  - Two starts before one end: replacing from the first start through the end
+  //    deletes the second marker and whatever the user wrote between them — and the
+  //    file looks well-formed to a one-sided check, which is why counting is the test.
+  //
+  // Repairing these means guessing which side of a stray marker the user's content
+  // belongs to. That is their judgement to make, not ours.
   const startIdx = existing.indexOf(GROK_RULES_START);
   const endIdx = existing.indexOf(GROK_RULES_END);
-  if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
-    const before = existing.slice(0, startIdx);
-    const after = existing.slice(endIdx + GROK_RULES_END.length);
-    return normalize(`${before}${block}${after}`);
-  }
-  // One-sided markers (an interrupted run, or a hand edit that deleted half the block)
-  // used to fall through to "append". That is quietly destructive: the file then holds
-  // one start marker and two ends, so the *next* run replaces everything between the
-  // original start and the appended end — deleting whatever the user wrote in between.
-  // Refuse instead; the repair is a judgement call about their content, not ours.
-  if (startIdx !== -1 || endIdx !== -1) {
-    const present = startIdx !== -1 ? GROK_RULES_START : GROK_RULES_END;
-    const missing = startIdx !== -1 ? GROK_RULES_END : GROK_RULES_START;
+  const wellFormed = starts === 1 && ends === 1 && startIdx !== -1 && endIdx > startIdx;
+  if (!wellFormed) {
+    const detail =
+      starts === 1 && ends === 1
+        ? `its ${GROK_RULES_END} precedes its ${GROK_RULES_START}`
+        : `found ${starts} start and ${ends} end marker${ends === 1 ? '' : 's'}`;
     throw new Error(
-      `${rulesPath} has ${present} without a matching ${missing}. ` +
-        'Appending would let a later run delete the content between them. ' +
-        `Restore or remove the stray marker (or point --rules elsewhere), then re-run.`
+      `${rulesPath} does not contain exactly one ${GROK_RULES_START} … ${GROK_RULES_END} block ` +
+        `(${detail}). Rewriting it would delete the content between the stray markers. ` +
+        'Restore or remove them (or point --rules elsewhere), then re-run.'
     );
   }
-  const sep = existing.endsWith('\n') ? '\n' : '\n\n';
-  return normalize(`${existing}${sep}${block}`);
+
+  const before = existing.slice(0, startIdx);
+  const after = existing.slice(endIdx + GROK_RULES_END.length);
+  return normalize(`${before}${block}${after}`);
 }
 
 export function stripGrokRulesMarkers(existing: string): string {
@@ -116,25 +141,15 @@ export async function applyGrokSetup(cliOptions: GrokSetupOptions): Promise<void
     process.env.AUTOMEM_ENDPOINT ||
     existingCreds.endpoint ||
     DEFAULT_AUTOMEM_API_URL;
-  // A key belongs to the endpoint it was issued for. Handing it to a different host
-  // discloses the secret to a server that was never meant to have it, so every
-  // inherited key is paired with the endpoint it came from before being reused.
-  // Compared the way the client compares endpoints, since AutoMemClient strips a
-  // trailing slash and `https://x` and `https://x/` are the same server.
-  const matchesChosenEndpoint = (candidate?: string): boolean => sameEndpoint(candidate, endpoint);
-
-  // The shell's key belongs to the shell's endpoint. `--endpoint other` with
-  // AUTOMEM_API_URL/AUTOMEM_API_KEY exported would otherwise ship that key to `other`.
-  // An exported key with no exported endpoint is not bound to anything, so it stands.
-  const envEndpoint = process.env.AUTOMEM_API_URL || process.env.AUTOMEM_ENDPOINT;
-  const envKey = readAutoMemApiKeyFromEnv();
-  const reusableEnvKey = !envEndpoint || matchesChosenEndpoint(envEndpoint) ? envKey : undefined;
-
-  const reusableStoredKey = matchesChosenEndpoint(existingCreds.endpoint)
-    ? existingCreds.apiKey
-    : undefined;
-
-  const apiKey = cliOptions.apiKey ?? reusableEnvKey ?? reusableStoredKey;
+  // A key belongs to the endpoint it was issued for. Pairing every inherited key with
+  // its own endpoint lives in the shared resolver, which all hosts use — the same
+  // disclosure was filed separately against three of them.
+  const apiKey = resolveInheritedApiKey({
+    endpoint,
+    explicitKey: cliOptions.apiKey,
+    storedEndpoint: existingCreds.endpoint,
+    storedKey: existingCreds.apiKey,
+  });
   const rulesPath = cliOptions.rulesPath ?? paths.agentsPath;
 
   // `--rules` pointing at config.toml (directly or through a symlink) would write the

--- a/src/cli/hermes-config.test.ts
+++ b/src/cli/hermes-config.test.ts
@@ -76,9 +76,13 @@ describe('hermes-config', () => {
       });
     });
 
-    it('omits the API key when not provided', () => {
+    it('writes blank credential overrides when no key is provided', () => {
       const entry = buildAutoMemServerEntry('https://api.example.com');
-      expect(entry.env).not.toHaveProperty('AUTOMEM_API_KEY');
+      // Blank, not absent: the host layers this env over its own, so an omitted
+      // key leaves a shell-exported one inherited by the child. A blank shadows it
+      // and reads as absent to the server.
+      expect(entry.env.AUTOMEM_API_KEY).toBe('');
+      expect(entry.env.AUTOMEM_API_TOKEN).toBe('');
     });
   });
 

--- a/src/cli/hermes-config.test.ts
+++ b/src/cli/hermes-config.test.ts
@@ -358,6 +358,21 @@ describe('hermes-config', () => {
 
     // The normal case: `both` mode writes config.yaml and .env with identical values,
     // so the .env key must still be recovered when the config entry omits it.
+    // Valid dotenv spellings of the SAME endpoint. Hand-parsing unwrapped only double
+    // quotes and never stripped comments, so a same-endpoint re-run compared raw text,
+    // saw a mismatch, and deleted a working credential.
+    it.each([
+      ['single quotes', "AUTOMEM_API_URL='https://same.automem.test'"],
+      ['a trailing comment', 'AUTOMEM_API_URL=https://same.automem.test # production'],
+      ['an export prefix', 'export AUTOMEM_API_URL=https://same.automem.test'],
+    ])('reads a .env endpoint written with %s', (_label, line) => {
+      fs.writeFileSync(path.join(tmpDir, '.env'), `${line}\nAUTOMEM_API_KEY=sk-env\n`);
+
+      const creds = readExistingHermesCredentials(paths(tmpDir));
+      expect(creds.endpoint).toBe('https://same.automem.test');
+      expect(creds.apiKey).toBe('sk-env');
+    });
+
     it('reuses the .env key when both sources name the same endpoint', () => {
       fs.writeFileSync(
         path.join(tmpDir, 'config.yaml'),

--- a/src/cli/hermes-config.test.ts
+++ b/src/cli/hermes-config.test.ts
@@ -306,6 +306,76 @@ describe('hermes-config', () => {
       expect(creds.apiKey).toBe('sk-remote');
     });
 
+    // config.yaml and the provider .env can describe different installs. Merging them
+    // field-wise produced {config endpoint, .env key}, which resolveInheritedApiKey
+    // then treats as a valid stored pair — writing the .env host's token into the
+    // config host's registration.
+    it('does not pair a config endpoint with a key written for a different endpoint', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'config.yaml'),
+        [
+          'mcp_servers:',
+          '  automem:',
+          '    command: npx',
+          '    env:',
+          '      AUTOMEM_API_URL: https://host-a.automem.test',
+          '',
+        ].join('\n')
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, '.env'),
+        'AUTOMEM_API_URL=https://host-b.automem.test\nAUTOMEM_API_KEY=sk-host-b\n'
+      );
+
+      const creds = readExistingHermesCredentials(paths(tmpDir));
+      expect(creds.endpoint).toBe('https://host-a.automem.test');
+      expect(creds.apiKey).toBeUndefined();
+    });
+
+    it('does not pair a config endpoint with a legacy token written for another endpoint', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'config.yaml'),
+        [
+          'mcp_servers:',
+          '  automem:',
+          '    command: npx',
+          '    env:',
+          '      AUTOMEM_API_URL: https://host-a.automem.test',
+          '',
+        ].join('\n')
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, '.env'),
+        'AUTOMEM_ENDPOINT=https://host-b.automem.test\nAUTOMEM_API_TOKEN=sk-host-b\n'
+      );
+
+      expect(readExistingHermesCredentials(paths(tmpDir)).apiKey).toBeUndefined();
+    });
+
+    // The normal case: `both` mode writes config.yaml and .env with identical values,
+    // so the .env key must still be recovered when the config entry omits it.
+    it('reuses the .env key when both sources name the same endpoint', () => {
+      fs.writeFileSync(
+        path.join(tmpDir, 'config.yaml'),
+        [
+          'mcp_servers:',
+          '  automem:',
+          '    command: npx',
+          '    env:',
+          '      AUTOMEM_API_URL: https://same.automem.test',
+          '',
+        ].join('\n')
+      );
+      fs.writeFileSync(
+        path.join(tmpDir, '.env'),
+        'AUTOMEM_API_URL=https://same.automem.test/\nAUTOMEM_API_KEY=sk-shared\n'
+      );
+
+      const creds = readExistingHermesCredentials(paths(tmpDir));
+      expect(creds.endpoint).toBe('https://same.automem.test');
+      expect(creds.apiKey).toBe('sk-shared');
+    });
+
     it('falls back to ~/.hermes/.env and strips quotes', () => {
       fs.writeFileSync(
         path.join(tmpDir, '.env'),

--- a/src/cli/hermes-config.ts
+++ b/src/cli/hermes-config.ts
@@ -9,6 +9,7 @@ import {
   log,
   readApiKeyFrom,
   readEndpointFrom,
+  sameEndpoint,
 } from './host-toolkit.js';
 
 export interface HermesPaths {
@@ -188,14 +189,35 @@ function readCredentialsFromEnvFile(envPath: string): HermesCredentials {
  * (config.yaml `mcp_servers.automem.env`) first, then the provider `.env`;
  * both are written with identical values in `both` mode. Empty strings
  * normalize to `undefined` so they never satisfy a `??` fallback.
+ *
+ * Endpoint and key are returned **as a pair from one source**. Merging them
+ * field-wise used to be possible — config endpoint plus `.env` key — and the two
+ * files can describe different installs: switch the MCP config to endpoint A and a
+ * provider `.env` still holding endpoint B's token makes `{A, B's key}` look like a
+ * credential issued for A. `resolveInheritedApiKey` would then treat it as a valid
+ * stored pair and write B's token into A's registration, which is precisely the
+ * disclosure the pairing exists to prevent.
  */
 export function readExistingHermesCredentials(paths: HermesPaths): HermesCredentials {
   const fromConfig = readCredentialsFromConfig(paths.configPath);
   const fromEnv = readCredentialsFromEnvFile(path.join(paths.home, '.env'));
-  return {
-    endpoint: fromConfig.endpoint ?? fromEnv.endpoint,
-    apiKey: fromConfig.apiKey ?? fromEnv.apiKey,
-  };
+
+  if (fromConfig.endpoint) {
+    return {
+      endpoint: fromConfig.endpoint,
+      // The `.env` key is only the same credential when it was written for the same
+      // endpoint — which is the normal case, since `both` mode writes both files with
+      // identical values.
+      apiKey:
+        fromConfig.apiKey ??
+        (sameEndpoint(fromEnv.endpoint, fromConfig.endpoint) ? fromEnv.apiKey : undefined),
+    };
+  }
+  if (fromEnv.endpoint) return fromEnv;
+
+  // Neither source names an endpoint, so there is no pair to keep whole. A stored key
+  // with no stored endpoint is dropped downstream regardless.
+  return { endpoint: undefined, apiKey: fromConfig.apiKey ?? fromEnv.apiKey };
 }
 
 function deepEqual(a: unknown, b: unknown): boolean {

--- a/src/cli/hermes-config.ts
+++ b/src/cli/hermes-config.ts
@@ -2,7 +2,14 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { parse as parseYaml, parseDocument } from 'yaml';
-import { backupPath, log } from './host-toolkit.js';
+import {
+  AUTOMEM_API_KEY_NAMES,
+  backupPath,
+  isAutoMemServerEntry,
+  log,
+  readApiKeyFrom,
+  readEndpointFrom,
+} from './host-toolkit.js';
 
 export interface HermesPaths {
   home: string;
@@ -145,11 +152,12 @@ function readCredentialsFromConfig(configPath: string): HermesCredentials {
   const env = entry && isRecord(entry.env) ? (entry.env as Record<string, unknown>) : null;
   if (!env) return {};
   return {
-    // The runtime provider still honors the deprecated AUTOMEM_ENDPOINT, so a
-    // hand-migrated config must survive a setup re-run instead of being reset
-    // to the default endpoint.
-    endpoint: normalizeCred(env.AUTOMEM_API_URL) ?? normalizeCred(env.AUTOMEM_ENDPOINT),
-    apiKey: normalizeCred(env.AUTOMEM_API_KEY),
+    // Both deprecated aliases are honored on read — the runtime still accepts
+    // AUTOMEM_ENDPOINT and AUTOMEM_API_TOKEN, so a hand-migrated or Railway-templated
+    // config must survive a setup re-run instead of being reset to the default
+    // endpoint or rewritten without its credential.
+    endpoint: readEndpointFrom(env),
+    apiKey: readApiKeyFrom(env),
   };
 }
 
@@ -158,15 +166,19 @@ function readCredentialsFromEnvFile(envPath: string): HermesCredentials {
   let endpoint: string | undefined;
   let legacyEndpoint: string | undefined;
   let apiKey: string | undefined;
+  let legacyApiKey: string | undefined;
   for (const line of fs.readFileSync(envPath, 'utf8').split(/\r?\n/)) {
     const match = line.match(/^\s*([A-Za-z0-9_]+)\s*=\s*(.*)$/);
     if (!match) continue;
     const value = normalizeCred(unquoteEnvValue(match[2]));
     if (match[1] === 'AUTOMEM_API_URL') endpoint = value;
     else if (match[1] === 'AUTOMEM_ENDPOINT') legacyEndpoint = value;
-    else if (match[1] === 'AUTOMEM_API_KEY') apiKey = value;
+    else if (match[1] === AUTOMEM_API_KEY_NAMES[0]) apiKey = value;
+    // The deprecated alias, kept as a fallback so a provider .env written from the
+    // Railway template still yields its credential on a flagless re-run.
+    else if (match[1] === AUTOMEM_API_KEY_NAMES[1]) legacyApiKey = value;
   }
-  return { endpoint: endpoint ?? legacyEndpoint, apiKey };
+  return { endpoint: endpoint ?? legacyEndpoint, apiKey: apiKey ?? legacyApiKey };
 }
 
 /**
@@ -207,15 +219,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
 
-function isAutoMemMcpEntry(entry: unknown): boolean {
-  if (!isRecord(entry)) return false;
-  const haystack = JSON.stringify({
-    command: entry.command,
-    args: entry.args,
-    env: entry.env,
-  });
-  return haystack.includes('@verygoodplugins/mcp-automem') || haystack.includes('mcp-automem');
-}
+const isAutoMemMcpEntry = isAutoMemServerEntry;
 
 /**
  * Merge an MCP server entry into ~/.hermes/config.yaml under `mcp_servers.<name>`,

--- a/src/cli/hermes-config.ts
+++ b/src/cli/hermes-config.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { parse as parseDotenv } from 'dotenv';
 import os from 'os';
 import path from 'path';
 import { parse as parseYaml, parseDocument } from 'yaml';
@@ -118,26 +119,6 @@ export interface HermesCredentials {
   apiKey?: string;
 }
 
-/**
- * Normalize an env/config value to `undefined` when it is missing or blank.
- * Critical for the `??` fallback chain in hermes setup: `??` only falls
- * through on null/undefined, so an empty string would otherwise pin a blank
- * endpoint/key and defeat the default.
- */
-function normalizeCred(value: unknown): string | undefined {
-  if (typeof value !== 'string') return undefined;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
-}
-
-function unquoteEnvValue(raw: string): string {
-  const trimmed = raw.trim();
-  if (trimmed.length >= 2 && trimmed.startsWith('"') && trimmed.endsWith('"')) {
-    return trimmed.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
-  }
-  return trimmed;
-}
-
 function readCredentialsFromConfig(configPath: string): HermesCredentials {
   if (!fs.existsSync(configPath)) return {};
   let parsed: Record<string, unknown> | null;
@@ -167,24 +148,21 @@ function readCredentialsFromConfig(configPath: string): HermesCredentials {
   };
 }
 
+/**
+ * Read the provider `.env`'s effective credentials.
+ *
+ * Parsed by dotenv, which is what Hermes itself loads this file with. The invariant
+ * across this repo: a reader whose values drive a decision uses dotenv semantics,
+ * while the writers stay line-based so comments and formatting survive a partial
+ * update. Hand-parsing here unwrapped only double quotes and never stripped comments,
+ * so `AUTOMEM_API_URL='https://x'` or a trailing `# comment` compared as a different
+ * endpoint and a same-endpoint re-run deleted a valid key. Both deprecated aliases are
+ * still honoured on read via the shared both-name readers.
+ */
 function readCredentialsFromEnvFile(envPath: string): HermesCredentials {
   if (!fs.existsSync(envPath)) return {};
-  let endpoint: string | undefined;
-  let legacyEndpoint: string | undefined;
-  let apiKey: string | undefined;
-  let legacyApiKey: string | undefined;
-  for (const line of fs.readFileSync(envPath, 'utf8').split(/\r?\n/)) {
-    const match = line.match(/^\s*([A-Za-z0-9_]+)\s*=\s*(.*)$/);
-    if (!match) continue;
-    const value = normalizeCred(unquoteEnvValue(match[2]));
-    if (match[1] === 'AUTOMEM_API_URL') endpoint = value;
-    else if (match[1] === 'AUTOMEM_ENDPOINT') legacyEndpoint = value;
-    else if (match[1] === AUTOMEM_API_KEY_NAMES[0]) apiKey = value;
-    // The deprecated alias, kept as a fallback so a provider .env written from the
-    // Railway template still yields its credential on a flagless re-run.
-    else if (match[1] === AUTOMEM_API_KEY_NAMES[1]) legacyApiKey = value;
-  }
-  return { endpoint: endpoint ?? legacyEndpoint, apiKey: apiKey ?? legacyApiKey };
+  const values = parseDotenv(fs.readFileSync(envPath, 'utf8'));
+  return { endpoint: readEndpointFrom(values), apiKey: readApiKeyFrom(values) };
 }
 
 /**

--- a/src/cli/hermes-config.ts
+++ b/src/cli/hermes-config.ts
@@ -86,6 +86,11 @@ export function buildAutoMemServerEntry(endpoint: string, apiKey?: string): Auto
   };
   if (apiKey) {
     env.AUTOMEM_API_KEY = apiKey;
+  } else {
+    // Explicit blanks, not omission — the host layers this env over its own when it
+    // launches the server, so an omitted key leaves a shell-exported one inherited by
+    // a child pointed at a different endpoint. See buildGrokAutoMemServerEntry.
+    for (const name of AUTOMEM_API_KEY_NAMES) env[name] = '';
   }
   return {
     command: 'npx',

--- a/src/cli/hermes.test.ts
+++ b/src/cli/hermes.test.ts
@@ -500,6 +500,80 @@ describe('hermes setup handler', () => {
       expect(env.AUTOMEM_API_KEY).toBe('sk-keep');
     });
 
+    // mergeHermesEnvFile drops undefined updates so unrelated settings survive a
+    // partial write — which meant an unresolved key left the previous one in place
+    // while AUTOMEM_API_URL moved to the new host.
+    it('removes the provider .env key when the endpoint changes', async () => {
+      const envPath = path.join(tmpDir, '.env');
+      await applyHermesSetup({
+        targetDir: tmpDir,
+        mode: 'provider',
+        endpoint: 'https://host-a.example.test',
+        apiKey: 'sk-host-a',
+        quiet: true,
+        projectName: 'demo',
+      });
+      expect(fs.readFileSync(envPath, 'utf8')).toContain('sk-host-a');
+
+      await applyHermesSetup({
+        targetDir: tmpDir,
+        mode: 'provider',
+        endpoint: 'https://host-b.example.test',
+        quiet: true,
+        projectName: 'demo',
+      });
+
+      const written = fs.readFileSync(envPath, 'utf8');
+      expect(written).toContain('AUTOMEM_API_URL=https://host-b.example.test');
+      expect(written).not.toContain('sk-host-a');
+      expect(written).not.toMatch(/^AUTOMEM_API_KEY=/m);
+      expect(written).not.toMatch(/^AUTOMEM_API_TOKEN=/m);
+    });
+
+    it('keeps the provider .env key on a flagless re-run at the same endpoint', async () => {
+      const envPath = path.join(tmpDir, '.env');
+      await applyHermesSetup({
+        targetDir: tmpDir,
+        mode: 'provider',
+        endpoint: 'https://same.example.test',
+        apiKey: 'sk-keep',
+        quiet: true,
+        projectName: 'demo',
+      });
+
+      await applyHermesSetup({
+        targetDir: tmpDir,
+        mode: 'provider',
+        quiet: true,
+        projectName: 'demo',
+      });
+
+      const written = fs.readFileSync(envPath, 'utf8');
+      expect(written).toContain('AUTOMEM_API_KEY=sk-keep');
+      expect(written).toContain('AUTOMEM_API_URL=https://same.example.test');
+    });
+
+    it('removes a legacy provider token when the endpoint changes', async () => {
+      const envPath = path.join(tmpDir, '.env');
+      fs.mkdirSync(tmpDir, { recursive: true });
+      fs.writeFileSync(
+        envPath,
+        'AUTOMEM_API_URL=https://host-a.example.test\nAUTOMEM_API_TOKEN=sk-legacy\nUNRELATED=keep\n'
+      );
+
+      await applyHermesSetup({
+        targetDir: tmpDir,
+        mode: 'provider',
+        endpoint: 'https://host-b.example.test',
+        quiet: true,
+        projectName: 'demo',
+      });
+
+      const written = fs.readFileSync(envPath, 'utf8');
+      expect(written).not.toContain('sk-legacy');
+      expect(written).toContain('UNRELATED=keep');
+    });
+
     it('recovers a credential stored under the deprecated AUTOMEM_API_TOKEN alias', async () => {
       const configPath = path.join(tmpDir, 'config.yaml');
       fs.mkdirSync(tmpDir, { recursive: true });

--- a/src/cli/hermes.test.ts
+++ b/src/cli/hermes.test.ts
@@ -556,6 +556,27 @@ describe('hermes setup handler', () => {
       expect(written).toContain('AUTOMEM_API_URL=https://same.example.test');
     });
 
+    it('removes an export-prefixed provider key when the endpoint changes', async () => {
+      const envPath = path.join(tmpDir, '.env');
+      fs.mkdirSync(tmpDir, { recursive: true });
+      fs.writeFileSync(
+        envPath,
+        'export AUTOMEM_API_URL=https://host-a.example.test\nexport AUTOMEM_API_KEY=sk-old\nKEEP=1\n'
+      );
+
+      await applyHermesSetup({
+        targetDir: tmpDir,
+        mode: 'provider',
+        endpoint: 'https://host-b.example.test',
+        quiet: true,
+        projectName: 'demo',
+      });
+
+      const written = fs.readFileSync(envPath, 'utf8');
+      expect(written).not.toContain('sk-old');
+      expect(written).toContain('KEEP=1');
+    });
+
     it('removes a legacy provider token when the endpoint changes', async () => {
       const envPath = path.join(tmpDir, '.env');
       fs.mkdirSync(tmpDir, { recursive: true });

--- a/src/cli/hermes.test.ts
+++ b/src/cli/hermes.test.ts
@@ -451,7 +451,8 @@ describe('hermes setup handler', () => {
         projectName: 'demo',
       });
 
-      expect(readEntryEnv().AUTOMEM_API_KEY).toBeUndefined();
+      // Blank rather than absent — see buildAutoMemServerEntry.
+      expect(readEntryEnv().AUTOMEM_API_KEY).toBe('');
     });
 
     it('reuses a shell key exported for the chosen endpoint', async () => {
@@ -481,7 +482,9 @@ describe('hermes setup handler', () => {
 
       const env = readEntryEnv();
       expect(env.AUTOMEM_API_URL).toBe('https://second.example.test');
-      expect(env.AUTOMEM_API_KEY).toBeUndefined();
+      // Blank rather than absent — see buildAutoMemServerEntry.
+      expect(env.AUTOMEM_API_KEY).toBe('');
+      expect(env.AUTOMEM_API_TOKEN).toBe('');
     });
 
     it('preserves the installed key on a flagless re-run at the same endpoint', async () => {
@@ -572,6 +575,34 @@ describe('hermes setup handler', () => {
       const written = fs.readFileSync(envPath, 'utf8');
       expect(written).not.toContain('sk-legacy');
       expect(written).toContain('UNRELATED=keep');
+    });
+
+    // Switching to mcp mode uninstalls the provider but used to leave its dotenv
+    // credentials behind. Hermes loads that file before MCP discovery, so the key for
+    // the previous endpoint was inherited by a server pointed at the new one.
+    it('clears provider dotenv credentials when switching to mcp mode', async () => {
+      const envPath = path.join(tmpDir, '.env');
+      await applyHermesSetup({
+        targetDir: tmpDir,
+        mode: 'provider',
+        endpoint: 'https://host-a.example.test',
+        apiKey: 'sk-host-a',
+        quiet: true,
+        projectName: 'demo',
+      });
+      expect(fs.readFileSync(envPath, 'utf8')).toContain('sk-host-a');
+
+      await applyHermesSetup({
+        targetDir: tmpDir,
+        mode: 'mcp',
+        endpoint: 'https://host-b.example.test',
+        quiet: true,
+        projectName: 'demo',
+      });
+
+      const written = fs.readFileSync(envPath, 'utf8');
+      expect(written).not.toContain('sk-host-a');
+      expect(written).not.toContain('https://host-a.example.test');
     });
 
     it('recovers a credential stored under the deprecated AUTOMEM_API_TOKEN alias', async () => {

--- a/src/cli/hermes.test.ts
+++ b/src/cli/hermes.test.ts
@@ -21,6 +21,7 @@ describe('hermes setup handler', () => {
   let originalApiUrl: string | undefined;
   let originalApiKey: string | undefined;
   let originalEndpoint: string | undefined;
+  let originalApiToken: string | undefined;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-handler-'));
@@ -28,12 +29,14 @@ describe('hermes setup handler', () => {
     originalApiUrl = process.env.AUTOMEM_API_URL;
     originalApiKey = process.env.AUTOMEM_API_KEY;
     originalEndpoint = process.env.AUTOMEM_ENDPOINT;
+    originalApiToken = process.env.AUTOMEM_API_TOKEN;
     delete process.env.HERMES_HOME;
     delete process.env.AUTOMEM_API_URL;
     delete process.env.AUTOMEM_API_KEY;
     // Clear the legacy alias too — a developer shell exporting it would
     // otherwise win over recovered credentials and make these tests flaky.
     delete process.env.AUTOMEM_ENDPOINT;
+    delete process.env.AUTOMEM_API_TOKEN;
   });
 
   afterEach(() => {
@@ -46,6 +49,7 @@ describe('hermes setup handler', () => {
     restore('AUTOMEM_API_URL', originalApiUrl);
     restore('AUTOMEM_API_KEY', originalApiKey);
     restore('AUTOMEM_ENDPOINT', originalEndpoint);
+    restore('AUTOMEM_API_TOKEN', originalApiToken);
     vi.clearAllMocks();
   });
 
@@ -423,5 +427,103 @@ describe('hermes setup handler', () => {
     expect(agents).toContain('Provider-only mode');
     expect(agents).not.toContain('<!-- BEGIN AUTOMEM CODEX RULES -->');
     expect(agents).not.toContain('mcp__memory__recall_memory');
+  });
+
+  // Hermes carried the same defect the Grok PR filed three times: an inherited key was
+  // written for whatever endpoint this run chose, with no check that the key was issued
+  // for it. No finding named Hermes — it was found by sweeping the callers.
+  describe('credential/endpoint pairing', () => {
+    const readEntryEnv = (): Record<string, string> => {
+      const parsed = parseYaml(fs.readFileSync(path.join(tmpDir, 'config.yaml'), 'utf8')) as {
+        mcp_servers: { automem: { env: Record<string, string> } };
+      };
+      return parsed.mcp_servers.automem.env;
+    };
+
+    it('does not carry a shell key exported for a different endpoint', async () => {
+      process.env.AUTOMEM_API_URL = 'https://shell.example.test';
+      process.env.AUTOMEM_API_KEY = 'sk-shell';
+
+      await applyHermesSetup({
+        targetDir: tmpDir,
+        endpoint: 'https://chosen.example.test',
+        quiet: true,
+        projectName: 'demo',
+      });
+
+      expect(readEntryEnv().AUTOMEM_API_KEY).toBeUndefined();
+    });
+
+    it('reuses a shell key exported for the chosen endpoint', async () => {
+      process.env.AUTOMEM_API_URL = 'https://chosen.example.test';
+      process.env.AUTOMEM_API_KEY = 'sk-shell';
+
+      await applyHermesSetup({ targetDir: tmpDir, quiet: true, projectName: 'demo' });
+
+      expect(readEntryEnv().AUTOMEM_API_KEY).toBe('sk-shell');
+    });
+
+    it('does not carry the installed key to a different endpoint on re-run', async () => {
+      await applyHermesSetup({
+        targetDir: tmpDir,
+        endpoint: 'https://first.example.test',
+        apiKey: 'sk-first',
+        quiet: true,
+        projectName: 'demo',
+      });
+
+      await applyHermesSetup({
+        targetDir: tmpDir,
+        endpoint: 'https://second.example.test',
+        quiet: true,
+        projectName: 'demo',
+      });
+
+      const env = readEntryEnv();
+      expect(env.AUTOMEM_API_URL).toBe('https://second.example.test');
+      expect(env.AUTOMEM_API_KEY).toBeUndefined();
+    });
+
+    it('preserves the installed key on a flagless re-run at the same endpoint', async () => {
+      await applyHermesSetup({
+        targetDir: tmpDir,
+        endpoint: 'https://same.example.test',
+        apiKey: 'sk-keep',
+        quiet: true,
+        projectName: 'demo',
+      });
+
+      await applyHermesSetup({ targetDir: tmpDir, quiet: true, projectName: 'demo' });
+
+      const env = readEntryEnv();
+      expect(env.AUTOMEM_API_URL).toBe('https://same.example.test');
+      expect(env.AUTOMEM_API_KEY).toBe('sk-keep');
+    });
+
+    it('recovers a credential stored under the deprecated AUTOMEM_API_TOKEN alias', async () => {
+      const configPath = path.join(tmpDir, 'config.yaml');
+      fs.mkdirSync(tmpDir, { recursive: true });
+      fs.writeFileSync(
+        configPath,
+        [
+          'mcp_servers:',
+          '  automem:',
+          '    command: npx',
+          '    args:',
+          '      - -y',
+          '      - "@verygoodplugins/mcp-automem"',
+          '    env:',
+          '      AUTOMEM_API_URL: https://legacy.example.test',
+          '      AUTOMEM_API_TOKEN: sk-legacy',
+          '',
+        ].join('\n')
+      );
+
+      await applyHermesSetup({ targetDir: tmpDir, quiet: true, projectName: 'demo' });
+
+      const env = readEntryEnv();
+      expect(env.AUTOMEM_API_URL).toBe('https://legacy.example.test');
+      expect(env.AUTOMEM_API_KEY).toBe('sk-legacy');
+    });
   });
 });

--- a/src/cli/hermes.ts
+++ b/src/cli/hermes.ts
@@ -9,6 +9,7 @@ import {
   replaceTemplateVars,
   AUTOMEM_API_KEY_NAMES,
   AUTOMEM_ENDPOINT_NAMES,
+  parseEnvAssignment,
   resolveInheritedApiKey,
   writeFileWithBackup,
 } from './host-toolkit.js';
@@ -93,22 +94,26 @@ function mergeHermesEnvFile(
     return;
   }
 
-  const lines: Array<{ key?: string; line: string }> = [];
+  const lines: Array<{ key?: string; exported?: boolean; line: string }> = [];
   if (fs.existsSync(envPath)) {
     for (const line of fs.readFileSync(envPath, 'utf8').split(/\r?\n/)) {
       if (!line.trim()) {
         lines.push({ line });
         continue;
       }
-      const match = line.match(/^\s*([A-Za-z0-9_]+)\s*=\s*(.*)$/);
-      lines.push(match ? { key: match[1].trim(), line } : { line });
+      const assignment = parseEnvAssignment(line);
+      lines.push(
+        assignment ? { key: assignment.key, exported: assignment.exported, line } : { line }
+      );
     }
   }
 
   const updatedKeys = new Set<string>();
   for (const entry of lines) {
     if (entry.key && Object.prototype.hasOwnProperty.call(filtered, entry.key)) {
-      entry.line = `${entry.key}=${formatEnvValue(filtered[entry.key])}`;
+      // Put the `export ` prefix back rather than silently changing what the line
+      // means to a shell sourcing this file.
+      entry.line = `${entry.exported ? 'export ' : ''}${entry.key}=${formatEnvValue(filtered[entry.key])}`;
       updatedKeys.add(entry.key);
     }
   }
@@ -144,8 +149,8 @@ function removeHermesEnvKeys(
   const keySet = new Set(keys);
   const lines = fs.readFileSync(envPath, 'utf8').split(/\r?\n/);
   const filtered = lines.filter((line) => {
-    const match = line.match(/^\s*([A-Za-z0-9_]+)\s*=/);
-    return !match || !keySet.has(match[1]);
+    const assignment = parseEnvAssignment(line);
+    return !assignment || !keySet.has(assignment.key);
   });
   if (filtered.join('\n') === lines.join('\n')) return false;
 

--- a/src/cli/hermes.ts
+++ b/src/cli/hermes.ts
@@ -7,6 +7,7 @@ import {
   log,
   parseCommonFlags,
   replaceTemplateVars,
+  AUTOMEM_API_KEY_NAMES,
   resolveInheritedApiKey,
   writeFileWithBackup,
 } from './host-toolkit.js';
@@ -182,8 +183,17 @@ function installHermesProvider(
     writeFileWithBackup(targetPath, content, options);
   }
 
+  const envPath = path.join(paths.home, '.env');
+  // An absent update is not a deletion — mergeHermesEnvFile drops undefined values so
+  // unrelated settings survive a partial write. So when no key resolved for this run,
+  // the persisted one has to be removed explicitly: rewriting AUTOMEM_API_URL to a new
+  // endpoint while leaving the old credential in place makes the provider send that
+  // credential to the new host. Both supported names go, since either authenticates.
+  if (!apiKey) {
+    removeHermesEnvKeys(envPath, [...AUTOMEM_API_KEY_NAMES], options);
+  }
   mergeHermesEnvFile(
-    path.join(paths.home, '.env'),
+    envPath,
     {
       AUTOMEM_API_URL: endpoint,
       AUTOMEM_API_KEY: apiKey,

--- a/src/cli/hermes.ts
+++ b/src/cli/hermes.ts
@@ -7,6 +7,7 @@ import {
   log,
   parseCommonFlags,
   replaceTemplateVars,
+  resolveInheritedApiKey,
   writeFileWithBackup,
 } from './host-toolkit.js';
 import {
@@ -18,7 +19,6 @@ import {
   upsertHermesMemoryProvider,
   upsertMcpServer,
 } from './hermes-config.js';
-import { readAutoMemApiKeyFromEnv } from '../env.js';
 import { renderHermesModeRules } from '../memory-policy/shared.js';
 import { DEFAULT_AUTOMEM_API_URL } from './templates.js';
 
@@ -211,7 +211,15 @@ export async function applyHermesSetup(cliOptions: HermesSetupOptions): Promise<
     process.env.AUTOMEM_ENDPOINT ||
     existing.endpoint ||
     DEFAULT_AUTOMEM_API_URL;
-  const apiKey = cliOptions.apiKey ?? readAutoMemApiKeyFromEnv() ?? existing.apiKey;
+  // A key belongs to the endpoint it was issued for: an exported key must not follow
+  // `--endpoint <other>` to a host it was never issued for, and neither must the key
+  // already installed for Hermes when the endpoint changes underneath it.
+  const apiKey = resolveInheritedApiKey({
+    endpoint,
+    explicitKey: cliOptions.apiKey,
+    storedEndpoint: existing.endpoint,
+    storedKey: existing.apiKey,
+  });
   const rulesPath = cliOptions.rulesPath ?? paths.agentsPath;
 
   log(`\n🔧 Setting up Hermes AutoMem for: ${projectName}`, cliOptions.quiet);

--- a/src/cli/hermes.ts
+++ b/src/cli/hermes.ts
@@ -8,6 +8,7 @@ import {
   parseCommonFlags,
   replaceTemplateVars,
   AUTOMEM_API_KEY_NAMES,
+  AUTOMEM_ENDPOINT_NAMES,
   resolveInheritedApiKey,
   writeFileWithBackup,
 } from './host-toolkit.js';
@@ -263,9 +264,14 @@ export async function applyHermesSetup(cliOptions: HermesSetupOptions): Promise<
       dryRun: cliOptions.dryRun,
       quiet: cliOptions.quiet,
     });
+    // The provider was just uninstalled, so its dotenv credentials are dead config —
+    // and worse than dead: Hermes loads this file before MCP discovery, so a key left
+    // here for the previous endpoint is inherited by the MCP server whose entry now
+    // names a different one. Removing the endpoint names too, since they belong to the
+    // provider that is going away; a later re-run recovers both from config.yaml.
     removeHermesEnvKeys(
       path.join(paths.home, '.env'),
-      ['AUTOMEM_HERMES_PROVIDER_TOOLS'],
+      ['AUTOMEM_HERMES_PROVIDER_TOOLS', ...AUTOMEM_API_KEY_NAMES, ...AUTOMEM_ENDPOINT_NAMES],
       cliOptions
     );
   }

--- a/src/cli/host-toolkit.test.ts
+++ b/src/cli/host-toolkit.test.ts
@@ -6,10 +6,15 @@ import {
   backupPath,
   detectProjectName,
   formatEnvValue,
+  isAutoMemServerEntry,
   mergeEnvContent,
   parseCommonFlags,
+  readApiKeyFrom,
+  readEndpointFrom,
   readJsonFile,
+  removeEnvContentKeys,
   replaceTemplateVars,
+  resolveInheritedApiKey,
   writeFileWithBackup,
 } from './host-toolkit.js';
 
@@ -260,5 +265,248 @@ describe('host-toolkit', () => {
         expect(fs.statSync(backup).mode & 0o777).toBe(0o600);
       }
     );
+  });
+});
+
+describe('resolveInheritedApiKey', () => {
+  const ENDPOINT = 'https://chosen.example.test';
+
+  it('takes an explicit --api-key over everything, whatever the endpoints say', () => {
+    expect(
+      resolveInheritedApiKey({
+        endpoint: ENDPOINT,
+        explicitKey: 'sk-flag',
+        storedEndpoint: ENDPOINT,
+        storedKey: 'sk-stored',
+        env: { AUTOMEM_API_URL: ENDPOINT, AUTOMEM_API_KEY: 'sk-env' },
+      })
+    ).toBe('sk-flag');
+  });
+
+  it('reuses an env key whose env endpoint is the chosen one', () => {
+    expect(
+      resolveInheritedApiKey({
+        endpoint: ENDPOINT,
+        env: { AUTOMEM_API_URL: ENDPOINT, AUTOMEM_API_KEY: 'sk-env' },
+      })
+    ).toBe('sk-env');
+  });
+
+  // The whole point of the sweep: a key must not follow --endpoint to a host it was
+  // never issued for. Filed separately against grok, hermes and the guided installer.
+  it('drops an env key when the env endpoint is a different host', () => {
+    expect(
+      resolveInheritedApiKey({
+        endpoint: ENDPOINT,
+        env: { AUTOMEM_API_URL: 'https://elsewhere.example.test', AUTOMEM_API_KEY: 'sk-env' },
+      })
+    ).toBeUndefined();
+  });
+
+  it('treats a trailing slash as the same endpoint, not a different host', () => {
+    expect(
+      resolveInheritedApiKey({
+        endpoint: 'https://chosen.example.test',
+        env: { AUTOMEM_API_URL: 'https://chosen.example.test/', AUTOMEM_API_KEY: 'sk-env' },
+      })
+    ).toBe('sk-env');
+  });
+
+  // The two inherited sources are asymmetric on purpose; both halves are pinned here
+  // so a later "simplification" that collapses them fails loudly.
+  it('keeps an env key that has no env endpoint — it is bound to nothing', () => {
+    expect(resolveInheritedApiKey({ endpoint: ENDPOINT, env: { AUTOMEM_API_KEY: 'sk-env' } })).toBe(
+      'sk-env'
+    );
+  });
+
+  it('drops a stored key that has no stored endpoint — a keyed entry with no URL is malformed', () => {
+    expect(
+      resolveInheritedApiKey({ endpoint: ENDPOINT, storedKey: 'sk-stored', env: {} })
+    ).toBeUndefined();
+  });
+
+  it('reuses a stored key when the stored endpoint is the chosen one', () => {
+    expect(
+      resolveInheritedApiKey({
+        endpoint: ENDPOINT,
+        storedEndpoint: ENDPOINT,
+        storedKey: 'sk-stored',
+        env: {},
+      })
+    ).toBe('sk-stored');
+  });
+
+  it('drops a stored key when the endpoint changed underneath it', () => {
+    expect(
+      resolveInheritedApiKey({
+        endpoint: ENDPOINT,
+        storedEndpoint: 'https://old.example.test',
+        storedKey: 'sk-stored',
+        env: {},
+      })
+    ).toBeUndefined();
+  });
+
+  it('prefers the env key over the stored key when both are valid', () => {
+    expect(
+      resolveInheritedApiKey({
+        endpoint: ENDPOINT,
+        storedEndpoint: ENDPOINT,
+        storedKey: 'sk-stored',
+        env: { AUTOMEM_API_URL: ENDPOINT, AUTOMEM_API_KEY: 'sk-env' },
+      })
+    ).toBe('sk-env');
+  });
+
+  it('falls back to the stored key when the env key is rejected', () => {
+    expect(
+      resolveInheritedApiKey({
+        endpoint: ENDPOINT,
+        storedEndpoint: ENDPOINT,
+        storedKey: 'sk-stored',
+        env: { AUTOMEM_API_URL: 'https://elsewhere.example.test', AUTOMEM_API_KEY: 'sk-env' },
+      })
+    ).toBe('sk-stored');
+  });
+
+  it('reads the deprecated AUTOMEM_API_TOKEN alias and pairs it the same way', () => {
+    expect(
+      resolveInheritedApiKey({
+        endpoint: ENDPOINT,
+        env: { AUTOMEM_ENDPOINT: ENDPOINT, AUTOMEM_API_TOKEN: 'sk-legacy' },
+      })
+    ).toBe('sk-legacy');
+    expect(
+      resolveInheritedApiKey({
+        endpoint: ENDPOINT,
+        env: { AUTOMEM_ENDPOINT: 'https://elsewhere.example.test', AUTOMEM_API_TOKEN: 'sk-legacy' },
+      })
+    ).toBeUndefined();
+  });
+
+  // Those variables are exported by Claude Code into the plugin's own MCP subprocess
+  // for src/index.ts to resolve. An installer that inherited the key never consulted
+  // the CLAUDE_PLUGIN_OPTION_API_URL it was issued against, so it could not pair it.
+  it('ignores CLAUDE_PLUGIN_OPTION_* entirely', () => {
+    expect(
+      resolveInheritedApiKey({
+        endpoint: ENDPOINT,
+        env: {
+          CLAUDE_PLUGIN_OPTION_API_URL: ENDPOINT,
+          CLAUDE_PLUGIN_OPTION_API_KEY: 'sk-plugin',
+        },
+      })
+    ).toBeUndefined();
+  });
+
+  it('ignores blank and whitespace-only values', () => {
+    expect(
+      resolveInheritedApiKey({
+        endpoint: ENDPOINT,
+        explicitKey: '   ',
+        env: { AUTOMEM_API_KEY: '  ' },
+        storedEndpoint: ENDPOINT,
+        storedKey: '',
+      })
+    ).toBeUndefined();
+  });
+});
+
+describe('readApiKeyFrom / readEndpointFrom', () => {
+  it('prefers the canonical name over the deprecated alias', () => {
+    expect(readApiKeyFrom({ AUTOMEM_API_KEY: 'canonical', AUTOMEM_API_TOKEN: 'legacy' })).toBe(
+      'canonical'
+    );
+    expect(readEndpointFrom({ AUTOMEM_API_URL: 'canonical', AUTOMEM_ENDPOINT: 'legacy' })).toBe(
+      'canonical'
+    );
+  });
+
+  it('falls back to the alias when the canonical name is absent or blank', () => {
+    expect(readApiKeyFrom({ AUTOMEM_API_TOKEN: 'legacy' })).toBe('legacy');
+    expect(readApiKeyFrom({ AUTOMEM_API_KEY: '   ', AUTOMEM_API_TOKEN: 'legacy' })).toBe('legacy');
+    expect(readEndpointFrom({ AUTOMEM_ENDPOINT: 'legacy' })).toBe('legacy');
+  });
+
+  it('returns undefined for an empty or absent source', () => {
+    expect(readApiKeyFrom(undefined)).toBeUndefined();
+    expect(readApiKeyFrom({})).toBeUndefined();
+  });
+});
+
+describe('isAutoMemServerEntry', () => {
+  it('matches the entry the installers write', () => {
+    expect(
+      isAutoMemServerEntry({ command: 'npx', args: ['-y', '@verygoodplugins/mcp-automem'] })
+    ).toBe(true);
+  });
+
+  it('matches a linked dev checkout launched by absolute path', () => {
+    expect(
+      isAutoMemServerEntry({
+        command: 'node',
+        args: ['/Users/dev/Projects/mcp-automem/dist/index.js'],
+      })
+    ).toBe(true);
+  });
+
+  it('matches a hand-written entry by AutoMem env var names', () => {
+    expect(
+      isAutoMemServerEntry({
+        command: 'some-wrapper',
+        args: ['--serve'],
+        env: { AUTOMEM_API_URL: 'https://automem.example.test' },
+      })
+    ).toBe(true);
+  });
+
+  // The filed defect: the predicate used to stringify the whole entry, env values
+  // included, so an unrelated server that merely *pointed at* a host named
+  // mcp-automem was classified as ours — overwritable by setup, deletable by
+  // uninstall.
+  it('does not claim a foreign server whose env values merely mention mcp-automem', () => {
+    expect(
+      isAutoMemServerEntry({
+        command: 'other-server',
+        args: ['--start'],
+        env: { UPSTREAM_URL: 'https://mcp-automem.internal', NOTE: 'talks to mcp-automem' },
+      })
+    ).toBe(false);
+  });
+
+  it('does not claim a foreign server whose args merely mention a similar host', () => {
+    expect(
+      isAutoMemServerEntry({ command: 'other', args: ['--url', 'https://mcp-automem.internal'] })
+    ).toBe(false);
+  });
+
+  it('rejects non-entries', () => {
+    expect(isAutoMemServerEntry(null)).toBe(false);
+    expect(isAutoMemServerEntry('mcp-automem')).toBe(false);
+    expect(isAutoMemServerEntry(['mcp-automem'])).toBe(false);
+    expect(isAutoMemServerEntry({ command: 'other', args: ['--start'] })).toBe(false);
+  });
+});
+
+describe('removeEnvContentKeys', () => {
+  it('drops only the named keys, leaving comments and neighbours byte-identical', () => {
+    const existing = ['# header', 'KEEP=1', 'AUTOMEM_API_KEY=secret', '', 'TRAILING=2'].join('\n');
+    const result = removeEnvContentKeys(existing, ['AUTOMEM_API_KEY']);
+    expect(result).not.toContain('AUTOMEM_API_KEY');
+    expect(result).toContain('# header');
+    expect(result).toContain('KEEP=1');
+    expect(result).toContain('TRAILING=2');
+  });
+
+  it('removes every supported alias when both are present', () => {
+    const existing = ['AUTOMEM_API_KEY=a', 'AUTOMEM_API_TOKEN=b', 'OTHER=c'].join('\n');
+    const result = removeEnvContentKeys(existing, ['AUTOMEM_API_KEY', 'AUTOMEM_API_TOKEN']);
+    expect(result).toBe(`OTHER=c${os.EOL}`);
+  });
+
+  it('is a no-op for an empty body or an empty key list', () => {
+    expect(removeEnvContentKeys('', ['AUTOMEM_API_KEY'])).toBe('');
+    expect(removeEnvContentKeys('KEEP=1', [])).toBe('KEEP=1');
   });
 });

--- a/src/cli/host-toolkit.test.ts
+++ b/src/cli/host-toolkit.test.ts
@@ -14,6 +14,7 @@ import {
   readJsonFile,
   removeEnvContentKeys,
   replaceTemplateVars,
+  parseEnvAssignment,
   resolveInheritedApiKey,
   writeFileWithBackup,
 } from './host-toolkit.js';
@@ -530,5 +531,44 @@ describe('removeEnvContentKeys', () => {
   it('is a no-op for an empty body or an empty key list', () => {
     expect(removeEnvContentKeys('', ['AUTOMEM_API_KEY'])).toBe('');
     expect(removeEnvContentKeys('KEEP=1', [])).toBe('KEEP=1');
+  });
+});
+
+describe('parseEnvAssignment', () => {
+  // The writers must recognise exactly what the dotenv-based readers accept. Missing
+  // the `export` prefix meant a reader saw a stale key, asked for its removal, and the
+  // remover silently kept the line — leaving the credential live against a new host.
+  it.each([
+    ['plain', 'AUTOMEM_API_KEY=secret', 'AUTOMEM_API_KEY', false],
+    ['export-prefixed', 'export AUTOMEM_API_KEY=secret', 'AUTOMEM_API_KEY', true],
+    ['indented export', '   export  AUTOMEM_API_KEY=secret', 'AUTOMEM_API_KEY', true],
+    ['spaced equals', 'AUTOMEM_API_KEY = secret', 'AUTOMEM_API_KEY', false],
+  ])('reads the key from a %s assignment', (_label, line, key, exported) => {
+    expect(parseEnvAssignment(line)).toEqual({ key, exported });
+  });
+
+  it('returns undefined for comments and blank lines', () => {
+    expect(parseEnvAssignment('# AUTOMEM_API_KEY=secret')).toBeUndefined();
+    expect(parseEnvAssignment('   ')).toBeUndefined();
+    expect(parseEnvAssignment('not an assignment')).toBeUndefined();
+  });
+});
+
+describe('export-prefixed assignments in the writers', () => {
+  it('removeEnvContentKeys drops an export-prefixed credential', () => {
+    const body = 'export AUTOMEM_API_URL=https://old.test\nexport AUTOMEM_API_KEY=sk-old\nKEEP=1\n';
+    const result = removeEnvContentKeys(body, ['AUTOMEM_API_KEY', 'AUTOMEM_API_TOKEN']);
+    expect(result).not.toContain('sk-old');
+    expect(result).toContain('KEEP=1');
+    expect(result).toContain('export AUTOMEM_API_URL=https://old.test');
+  });
+
+  it('mergeEnvContent rewrites an export-prefixed line in place, prefix intact', () => {
+    const body = 'export AUTOMEM_API_URL=https://old.test\n';
+    const result = mergeEnvContent(body, { AUTOMEM_API_URL: 'https://new.test' });
+    expect(result).toContain('export AUTOMEM_API_URL=https://new.test');
+    // Rewritten, not appended — a second assignment would leave the old host named.
+    expect(result).not.toContain('https://old.test');
+    expect(result.match(/AUTOMEM_API_URL=/g)).toHaveLength(1);
   });
 });

--- a/src/cli/host-toolkit.test.ts
+++ b/src/cli/host-toolkit.test.ts
@@ -442,6 +442,21 @@ describe('isAutoMemServerEntry', () => {
     ).toBe(true);
   });
 
+  // `npm exec -- <pkg>[@<version>]` is the documented spec, so a pinned entry is the
+  // same package. Rejecting it made setup refuse to update it and uninstall skip it.
+  it('matches a version-pinned package spec', () => {
+    expect(
+      isAutoMemServerEntry({ command: 'npx', args: ['-y', '@verygoodplugins/mcp-automem@0.15.0'] })
+    ).toBe(true);
+  });
+
+  it('matches a dist-tag package spec', () => {
+    expect(
+      isAutoMemServerEntry({ command: 'npx', args: ['-y', '@verygoodplugins/mcp-automem@latest'] })
+    ).toBe(true);
+    expect(isAutoMemServerEntry({ command: 'npx', args: ['-y', 'mcp-automem@next'] })).toBe(true);
+  });
+
   it('matches a linked dev checkout launched by absolute path', () => {
     expect(
       isAutoMemServerEntry({
@@ -478,6 +493,13 @@ describe('isAutoMemServerEntry', () => {
   it('does not claim a foreign server whose args merely mention a similar host', () => {
     expect(
       isAutoMemServerEntry({ command: 'other', args: ['--url', 'https://mcp-automem.internal'] })
+    ).toBe(false);
+    // The version suffix must not open a hole for lookalike hostnames.
+    expect(
+      isAutoMemServerEntry({
+        command: 'other',
+        args: ['--url', 'https://mcp-automem.internal/v1', 'https://user@mcp-automem.example'],
+      })
     ).toBe(false);
   });
 

--- a/src/cli/host-toolkit.ts
+++ b/src/cli/host-toolkit.ts
@@ -135,12 +135,15 @@ export function resolveInheritedApiKey(inputs: InheritedApiKeyInputs): string | 
  *  - the package in `command`/`args` — `npx -y @verygoodplugins/mcp-automem`, what we
  *    write, and `node /path/to/mcp-automem/dist/index.js`, what a linked dev checkout
  *    looks like. Matched as a whole path segment, so `mcp-automem.internal` does not
- *    qualify.
+ *    qualify. An npm version or dist-tag suffix is part of the spec npm documents
+ *    (`npm exec -- <pkg>[@<version>]`), so a pinned `…/mcp-automem@0.15.0` is the same
+ *    package — without this, setup refuses to update a pinned entry and uninstall
+ *    skips it.
  *  - AutoMem's own env var *names*. Hand-written entries legitimately vary the
  *    command, and a foreign server that sets `AUTOMEM_API_URL` itself is
  *    indistinguishable from AutoMem anyway. Names only — never values.
  */
-const AUTOMEM_PACKAGE_SEGMENT = /(^|[/\\])(@verygoodplugins[/\\])?mcp-automem([/\\]|$)/;
+const AUTOMEM_PACKAGE_SEGMENT = /(^|[/\\])(@verygoodplugins[/\\])?mcp-automem(@[^/\\]+)?([/\\]|$)/;
 
 const AUTOMEM_ENV_KEYS: readonly string[] = [
   ...AUTOMEM_ENDPOINT_NAMES,

--- a/src/cli/host-toolkit.ts
+++ b/src/cli/host-toolkit.ts
@@ -236,6 +236,25 @@ export function writeFileWithBackup(
   return { status: existed ? 'updated' : 'created' };
 }
 
+/**
+ * The key a `.env` line assigns, or undefined if the line is not an assignment —
+ * recognising the same syntax dotenv does, including an optional `export` prefix.
+ *
+ * The line-based writers must match exactly what the dotenv-based readers accept.
+ * Widening the readers to dotenv without widening this is what let an
+ * `export AUTOMEM_API_KEY=...` line survive a removal request: the reader saw the
+ * stale key and asked for it to go, the remover did not recognise the line, and the
+ * credential stayed live against the new endpoint. Shared by every writer so the two
+ * halves cannot drift apart again.
+ *
+ * `exported` is reported so a rewrite can put the prefix back rather than silently
+ * changing the meaning of the user's file.
+ */
+export function parseEnvAssignment(line: string): { key: string; exported: boolean } | undefined {
+  const match = line.match(/^\s*(export\s+)?([A-Za-z0-9_]+)\s*=/);
+  return match ? { key: match[2], exported: Boolean(match[1]) } : undefined;
+}
+
 // Quote .env values that would otherwise break dotenv parsing — empty strings and
 // anything outside a conservative safe set (so whitespace, #, quotes, and shell
 // metacharacters like $ ; {} stay inert). Shared by the setup and install writers
@@ -254,16 +273,16 @@ export function formatEnvValue(value: string): string {
 // key collides with an Object.prototype member (e.g. `constructor`, `toString`) is
 // preserved verbatim instead of corrupted. Pure (no I/O) so callers own the write.
 export function mergeEnvContent(existing: string, updates: Record<string, string>): string {
-  const lines: Array<{ key?: string; line: string }> = [];
+  const lines: Array<{ key?: string; exported?: boolean; line: string }> = [];
   if (existing) {
     for (const line of existing.split(/\r?\n/)) {
       if (!line.trim()) {
         lines.push({ line });
         continue;
       }
-      const match = line.match(/^\s*([A-Za-z0-9_]+)\s*=/);
-      if (match) {
-        lines.push({ key: match[1], line });
+      const assignment = parseEnvAssignment(line);
+      if (assignment) {
+        lines.push({ key: assignment.key, exported: assignment.exported, line });
       } else {
         lines.push({ line });
       }
@@ -273,7 +292,10 @@ export function mergeEnvContent(existing: string, updates: Record<string, string
   const updatedKeys = new Set<string>();
   for (const entry of lines) {
     if (entry.key && Object.prototype.hasOwnProperty.call(updates, entry.key)) {
-      entry.line = `${entry.key}=${formatEnvValue(updates[entry.key])}`;
+      // The `export ` prefix is put back: dropping it would change what the line means
+      // to a shell sourcing this file.
+      const prefix = entry.exported ? 'export ' : '';
+      entry.line = `${prefix}${entry.key}=${formatEnvValue(updates[entry.key])}`;
       updatedKeys.add(entry.key);
     }
   }
@@ -300,8 +322,8 @@ export function removeEnvContentKeys(existing: string, keys: readonly string[]):
   if (!existing || keys.length === 0) return existing;
   const doomed = new Set(keys);
   const kept = existing.split(/\r?\n/).filter((line) => {
-    const match = line.match(/^\s*([A-Za-z0-9_]+)\s*=/);
-    return !match || !doomed.has(match[1]);
+    const assignment = parseEnvAssignment(line);
+    return !assignment || !doomed.has(assignment.key);
   });
   const content = kept.join(os.EOL).replace(/\s+$/, '');
   return content.length ? `${content}${os.EOL}` : '';

--- a/src/cli/host-toolkit.ts
+++ b/src/cli/host-toolkit.ts
@@ -32,6 +32,144 @@ export function sameEndpoint(a?: string, b?: string): boolean {
   return Boolean(a) && Boolean(b) && normalizeEndpoint(a!) === normalizeEndpoint(b!);
 }
 
+/**
+ * The two names AutoMem accepts for the same credential. `AUTOMEM_API_KEY` is
+ * canonical (the service and its docs standardized on `_KEY`); `AUTOMEM_API_TOKEN`
+ * is the deprecated alias the Railway template, the SSE sidecar, and existing
+ * deploys still set, so every reader has to accept it — see `src/env.ts`. Ordered:
+ * callers take the first match, so the canonical name wins when both are present.
+ */
+export const AUTOMEM_API_KEY_NAMES = ['AUTOMEM_API_KEY', 'AUTOMEM_API_TOKEN'] as const;
+
+/** The two names AutoMem accepts for the endpoint, canonical first. */
+export const AUTOMEM_ENDPOINT_NAMES = ['AUTOMEM_API_URL', 'AUTOMEM_ENDPOINT'] as const;
+
+function firstNonEmpty(
+  source: Record<string, unknown> | undefined,
+  names: readonly string[]
+): string | undefined {
+  if (!source) return undefined;
+  for (const name of names) {
+    const value = String(source[name] ?? '').trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+/** The API key an env-like record carries, under either supported name. */
+export function readApiKeyFrom(source?: Record<string, unknown>): string | undefined {
+  return firstNonEmpty(source, AUTOMEM_API_KEY_NAMES);
+}
+
+/** The endpoint an env-like record carries, under either supported name. */
+export function readEndpointFrom(source?: Record<string, unknown>): string | undefined {
+  return firstNonEmpty(source, AUTOMEM_ENDPOINT_NAMES);
+}
+
+export interface InheritedApiKeyInputs {
+  /** The endpoint this run will write. */
+  endpoint: string;
+  /** `--api-key`. An explicit flag is the operator naming the credential for this run. */
+  explicitKey?: string;
+  /** Endpoint already registered for this host, if any. */
+  storedEndpoint?: string;
+  /** Key already registered for this host, if any. */
+  storedKey?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Resolve which API key a host install should write, pairing every *inherited* key
+ * with the endpoint it was issued for.
+ *
+ * A key belongs to its endpoint. Handing one to a different server discloses the
+ * secret to a host that was never meant to have it, and this has now been filed
+ * against three separate callers, so the rule lives here rather than in each host.
+ *
+ * Precedence: explicit flag, then environment, then whatever is already installed.
+ *
+ * The two inherited sources are deliberately *not* symmetric:
+ *
+ *  - An env key with **no** env endpoint stands. A bare `export AUTOMEM_API_KEY` is
+ *    a normal way to carry a credential; it is bound to nothing, so it cannot be
+ *    bound to the wrong thing.
+ *  - A stored key with **no** stored endpoint is dropped. A host config entry that
+ *    names a key but no URL is malformed, and guessing that it meant the endpoint
+ *    chosen for *this* run is exactly the disclosure this function exists to prevent.
+ *
+ * `CLAUDE_PLUGIN_OPTION_*` is intentionally not read here. Those variables are
+ * exported by Claude Code into the plugin's own MCP subprocess for `src/index.ts`
+ * to resolve; an installer that inherits them picks up a key whose paired
+ * `CLAUDE_PLUGIN_OPTION_API_URL` it never consults. No installer flow sets them.
+ */
+export function resolveInheritedApiKey(inputs: InheritedApiKeyInputs): string | undefined {
+  const explicit = inputs.explicitKey?.trim();
+  if (explicit) return explicit;
+
+  const env = inputs.env ?? process.env;
+  const envKey = readApiKeyFrom(env);
+  if (envKey) {
+    const envEndpoint = readEndpointFrom(env);
+    // Unbound key: nothing to mismatch against.
+    if (!envEndpoint) return envKey;
+    if (sameEndpoint(envEndpoint, inputs.endpoint)) return envKey;
+  }
+
+  const storedKey = inputs.storedKey?.trim();
+  if (storedKey && sameEndpoint(inputs.storedEndpoint, inputs.endpoint)) {
+    return storedKey;
+  }
+
+  return undefined;
+}
+
+/**
+ * Whether an MCP server entry is AutoMem's, and therefore ours to replace or remove.
+ *
+ * Matched on identity, never on free text: an earlier version serialized the whole
+ * entry (env values included) and searched it for `mcp-automem`, so an unrelated
+ * server pointing at a host like `https://mcp-automem.internal` was classified as
+ * ours and could be overwritten by setup or deleted by uninstall.
+ *
+ * Two things count as identity:
+ *  - the package in `command`/`args` — `npx -y @verygoodplugins/mcp-automem`, what we
+ *    write, and `node /path/to/mcp-automem/dist/index.js`, what a linked dev checkout
+ *    looks like. Matched as a whole path segment, so `mcp-automem.internal` does not
+ *    qualify.
+ *  - AutoMem's own env var *names*. Hand-written entries legitimately vary the
+ *    command, and a foreign server that sets `AUTOMEM_API_URL` itself is
+ *    indistinguishable from AutoMem anyway. Names only — never values.
+ */
+const AUTOMEM_PACKAGE_SEGMENT = /(^|[/\\])(@verygoodplugins[/\\])?mcp-automem([/\\]|$)/;
+
+const AUTOMEM_ENV_KEYS: readonly string[] = [
+  ...AUTOMEM_ENDPOINT_NAMES,
+  ...AUTOMEM_API_KEY_NAMES,
+  'AUTOMEM_PROCESS_TAG',
+];
+
+export function isAutoMemServerEntry(entry: unknown): boolean {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return false;
+  const record = entry as Record<string, unknown>;
+
+  const candidates: string[] = [];
+  if (typeof record.command === 'string') candidates.push(record.command);
+  if (Array.isArray(record.args)) {
+    for (const arg of record.args) {
+      if (typeof arg === 'string') candidates.push(arg);
+    }
+  }
+  if (candidates.some((value) => AUTOMEM_PACKAGE_SEGMENT.test(value))) return true;
+
+  const env = record.env;
+  if (env && typeof env === 'object' && !Array.isArray(env)) {
+    return AUTOMEM_ENV_KEYS.some((name) =>
+      Object.prototype.hasOwnProperty.call(env as Record<string, unknown>, name)
+    );
+  }
+  return false;
+}
+
 export function backupPath(filePath: string): string {
   let candidate = `${filePath}.bak`;
   let counter = 1;
@@ -147,6 +285,22 @@ export function mergeEnvContent(existing: string, updates: Record<string, string
     .map((entry) => entry.line)
     .join(os.EOL)
     .replace(/\s+$/, '');
+  return content.length ? `${content}${os.EOL}` : '';
+}
+
+// Drop KEY=value lines from an existing .env body, leaving every other line — including
+// comments, blank lines, and unrelated keys — byte-identical. Deletion is a separate
+// operation from mergeEnvContent on purpose: writing `KEY=` would work (the readers
+// treat blank as absent) but leaves a confusing artifact that reads like a
+// deliberately-emptied credential. Pure (no I/O) so callers own the write.
+export function removeEnvContentKeys(existing: string, keys: readonly string[]): string {
+  if (!existing || keys.length === 0) return existing;
+  const doomed = new Set(keys);
+  const kept = existing.split(/\r?\n/).filter((line) => {
+    const match = line.match(/^\s*([A-Za-z0-9_]+)\s*=/);
+    return !match || !doomed.has(match[1]);
+  });
+  const content = kept.join(os.EOL).replace(/\s+$/, '');
   return content.length ? `${content}${os.EOL}` : '';
 }
 

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import fs from 'fs';
+import { parse as parseDotenvForTest } from 'dotenv';
 import os from 'os';
 import path from 'path';
 import {
@@ -1257,6 +1258,24 @@ describe('writeProjectEnv credential pairing', () => {
     expect(result.previousEndpoint).toBe('https://same.example.test');
     expect(result.removedKeys).toEqual([]);
     expect(fs.readFileSync(envPath, 'utf8')).toContain('sk-keep');
+  });
+
+  // The reader (dotenv) accepts `export KEY=value`; the remover did not. So the key was
+  // correctly identified as stale, removal was requested, and the line survived —
+  // leaving the old credential live against the new endpoint.
+  it('removes an export-prefixed key when the endpoint changes', () => {
+    fs.writeFileSync(
+      envPath,
+      'export AUTOMEM_API_URL=https://old.example.test\nexport AUTOMEM_API_KEY=sk-old\n'
+    );
+
+    const result = writeProjectEnv({ envPath, endpoint: 'https://new.example.test' });
+
+    expect(result.removedKeys).toEqual(['AUTOMEM_API_KEY']);
+    // Asserted through the parser that actually loads this file, not against raw text.
+    const effective = parseDotenvForTest(fs.readFileSync(envPath, 'utf8'));
+    expect(effective.AUTOMEM_API_KEY).toBeUndefined();
+    expect(effective.AUTOMEM_API_URL).toBe('https://new.example.test');
   });
 
   it('still removes the key when a quoted endpoint genuinely differs', () => {

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -1240,6 +1240,28 @@ describe('writeProjectEnv credential pairing', () => {
     expect(result.removedKeys).toEqual([]);
   });
 
+  // dotenv applies the LAST assignment, and dotenv is what loads this file at server
+  // startup. Reading the first one reported a stale endpoint, so a key issued for the
+  // effective endpoint looked paired with the earlier line and survived a real change.
+  it('uses the last endpoint assignment when .env has duplicates', () => {
+    fs.writeFileSync(
+      envPath,
+      [
+        'AUTOMEM_API_URL=https://first.example.test',
+        'AUTOMEM_API_URL=https://effective.example.test',
+        'AUTOMEM_API_KEY=sk-effective',
+        '',
+      ].join('\n')
+    );
+
+    const result = writeProjectEnv({ envPath, endpoint: 'https://first.example.test' });
+
+    const written = fs.readFileSync(envPath, 'utf8');
+    expect(result.previousEndpoint).toBe('https://effective.example.test');
+    expect(result.removedKeys).toEqual(['AUTOMEM_API_KEY']);
+    expect(written).not.toContain('sk-effective');
+  });
+
   it('compares against the deprecated AUTOMEM_ENDPOINT spelling as well', () => {
     fs.writeFileSync(
       envPath,

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -21,6 +21,7 @@ import {
   validateInstallPrerequisites,
   verifyAutoMemEndpoint,
   waitForAutoMemEndpoint,
+  writeProjectEnv,
 } from './install.js';
 
 describe('guided install helpers', () => {
@@ -1123,5 +1124,131 @@ describe('claude plugin auto-install', () => {
     });
     const action = plan.actions.find((a) => a.client === 'claude-code');
     expect(action?.kind).toBe('manual-step');
+  });
+});
+
+// The stdio server loads the project .env at startup, so a credential left behind
+// there is live regardless of what the installer resolved in memory. These assert the
+// file contents for exactly that reason.
+describe('writeProjectEnv credential pairing', () => {
+  let tmpDir: string;
+  let envPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'automem-project-env-'));
+    envPath = path.join(tmpDir, '.env');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('removes a persisted key when the endpoint changes and no new key was resolved', () => {
+    fs.writeFileSync(
+      envPath,
+      'AUTOMEM_API_URL=https://old.example.test\nAUTOMEM_API_KEY=sk-old\nOTHER=keep\n'
+    );
+
+    const result = writeProjectEnv({ envPath, endpoint: 'https://new.example.test' });
+
+    const written = fs.readFileSync(envPath, 'utf8');
+    expect(written).not.toContain('sk-old');
+    expect(written).not.toMatch(/^AUTOMEM_API_KEY=/m);
+    expect(written).toContain('AUTOMEM_API_URL=https://new.example.test');
+    expect(written).toContain('OTHER=keep');
+    expect(result.removedKeys).toEqual(['AUTOMEM_API_KEY']);
+    expect(result.previousEndpoint).toBe('https://old.example.test');
+  });
+
+  it('removes the deprecated AUTOMEM_API_TOKEN alias too', () => {
+    fs.writeFileSync(
+      envPath,
+      'AUTOMEM_API_URL=https://old.example.test\nAUTOMEM_API_TOKEN=sk-legacy\n'
+    );
+
+    writeProjectEnv({ envPath, endpoint: 'https://new.example.test' });
+
+    const written = fs.readFileSync(envPath, 'utf8');
+    expect(written).not.toContain('sk-legacy');
+    expect(written).not.toMatch(/^AUTOMEM_API_TOKEN=/m);
+  });
+
+  it('removes both alias spellings when the file carries both', () => {
+    fs.writeFileSync(
+      envPath,
+      [
+        'AUTOMEM_API_URL=https://old.example.test',
+        'AUTOMEM_API_KEY=sk-old',
+        'AUTOMEM_API_TOKEN=sk-old',
+        '',
+      ].join('\n')
+    );
+
+    const result = writeProjectEnv({ envPath, endpoint: 'https://new.example.test' });
+
+    expect(fs.readFileSync(envPath, 'utf8')).not.toContain('sk-old');
+    expect(result.removedKeys).toEqual(['AUTOMEM_API_KEY', 'AUTOMEM_API_TOKEN']);
+  });
+
+  // The common re-run. Dropping the key here would break every unflagged re-install.
+  it('keeps the persisted key when the endpoint is unchanged', () => {
+    fs.writeFileSync(
+      envPath,
+      'AUTOMEM_API_URL=https://same.example.test\nAUTOMEM_API_KEY=sk-keep\n'
+    );
+
+    const result = writeProjectEnv({ envPath, endpoint: 'https://same.example.test' });
+
+    expect(fs.readFileSync(envPath, 'utf8')).toContain('AUTOMEM_API_KEY=sk-keep');
+    expect(result.removedKeys).toEqual([]);
+  });
+
+  it('treats a trailing slash as the same endpoint', () => {
+    fs.writeFileSync(
+      envPath,
+      'AUTOMEM_API_URL=https://same.example.test/\nAUTOMEM_API_KEY=sk-keep\n'
+    );
+
+    writeProjectEnv({ envPath, endpoint: 'https://same.example.test' });
+
+    expect(fs.readFileSync(envPath, 'utf8')).toContain('AUTOMEM_API_KEY=sk-keep');
+  });
+
+  it('overwrites rather than removes when a new key was resolved for the new endpoint', () => {
+    fs.writeFileSync(envPath, 'AUTOMEM_API_URL=https://old.example.test\nAUTOMEM_API_KEY=sk-old\n');
+
+    const result = writeProjectEnv({
+      envPath,
+      endpoint: 'https://new.example.test',
+      apiKey: 'sk-new',
+    });
+
+    const written = fs.readFileSync(envPath, 'utf8');
+    expect(written).toContain('AUTOMEM_API_KEY=sk-new');
+    expect(written).not.toContain('sk-old');
+    expect(result.removedKeys).toEqual([]);
+  });
+
+  // A .env naming a key but no URL is not evidence of a mismatch, so it is left alone
+  // rather than guessed at.
+  it('leaves a key alone when the file has no endpoint to compare against', () => {
+    fs.writeFileSync(envPath, 'AUTOMEM_API_KEY=sk-unbound\n');
+
+    const result = writeProjectEnv({ envPath, endpoint: 'https://new.example.test' });
+
+    expect(fs.readFileSync(envPath, 'utf8')).toContain('AUTOMEM_API_KEY=sk-unbound');
+    expect(result.removedKeys).toEqual([]);
+  });
+
+  it('compares against the deprecated AUTOMEM_ENDPOINT spelling as well', () => {
+    fs.writeFileSync(
+      envPath,
+      'AUTOMEM_ENDPOINT=https://old.example.test\nAUTOMEM_API_KEY=sk-old\n'
+    );
+
+    const result = writeProjectEnv({ envPath, endpoint: 'https://new.example.test' });
+
+    expect(fs.readFileSync(envPath, 'utf8')).not.toContain('sk-old');
+    expect(result.removedKeys).toEqual(['AUTOMEM_API_KEY']);
   });
 });

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -1240,6 +1240,37 @@ describe('writeProjectEnv credential pairing', () => {
     expect(result.removedKeys).toEqual([]);
   });
 
+  // Every one of these is valid dotenv syntax naming the SAME endpoint. A hand-rolled
+  // reader that unwrapped only double quotes and ignored comments compared the raw text
+  // and removed a still-valid key, leaving the project unauthenticated.
+  it.each([
+    ['single quotes', "AUTOMEM_API_URL='https://same.example.test'"],
+    ['double quotes', 'AUTOMEM_API_URL="https://same.example.test"'],
+    ['a trailing comment', 'AUTOMEM_API_URL=https://same.example.test # production'],
+    ['an export prefix', 'export AUTOMEM_API_URL=https://same.example.test'],
+    ['surrounding whitespace', 'AUTOMEM_API_URL=   https://same.example.test   '],
+  ])('keeps the key when the endpoint is written with %s', (_label, line) => {
+    fs.writeFileSync(envPath, `${line}\nAUTOMEM_API_KEY=sk-keep\n`);
+
+    const result = writeProjectEnv({ envPath, endpoint: 'https://same.example.test' });
+
+    expect(result.previousEndpoint).toBe('https://same.example.test');
+    expect(result.removedKeys).toEqual([]);
+    expect(fs.readFileSync(envPath, 'utf8')).toContain('sk-keep');
+  });
+
+  it('still removes the key when a quoted endpoint genuinely differs', () => {
+    fs.writeFileSync(
+      envPath,
+      "AUTOMEM_API_URL='https://old.example.test'\nAUTOMEM_API_KEY=sk-old\n"
+    );
+
+    const result = writeProjectEnv({ envPath, endpoint: 'https://new.example.test' });
+
+    expect(result.removedKeys).toEqual(['AUTOMEM_API_KEY']);
+    expect(fs.readFileSync(envPath, 'utf8')).not.toContain('sk-old');
+  });
+
   // dotenv applies the LAST assignment, and dotenv is what loads this file at server
   // startup. Reading the first one reported a stale endpoint, so a key issued for the
   // effective endpoint looked paired with the earlier line and survived a real change.

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { parse as parseDotenv } from 'dotenv';
 import os from 'os';
 import path from 'path';
 import { execFileSync, spawnSync } from 'child_process';
@@ -962,26 +963,20 @@ function randomToken(): string {
     .join('');
 }
 
-// Read a single KEY's value from an existing .env (unwrapping a quoted value) so a
-// re-run can reuse previously-written secrets instead of regenerating them. `key`
-// is always a fixed literal here, so embedding it in the regex is safe.
+// Read a single KEY's effective value from an existing .env, so a re-run can reuse
+// previously-written secrets instead of regenerating them — and so the credential
+// pairing compares against the endpoint that is actually in effect.
+//
+// Delegates to dotenv, which is literally the parser that loads this file at server
+// startup. A hand-rolled reader kept disagreeing with it in ways that matter here:
+// it took the *first* assignment where dotenv takes the last, and it unwrapped only
+// double quotes, so `KEY='value'` or a trailing `# comment` compared as a different
+// endpoint and removed a still-valid key. Matching the real parser retires that whole
+// class rather than the two spellings that were reported.
 function readEnvFileValue(filePath: string, key: string): string | undefined {
   if (!fs.existsSync(filePath)) return undefined;
-  // Last assignment wins, matching dotenv — which is what actually loads this file at
-  // server startup. Taking the first match reported a stale endpoint for a .env with
-  // duplicate assignments, so a key issued for the *effective* endpoint looked paired
-  // with the earlier one and was preserved across a real endpoint change.
-  const matches = fs
-    .readFileSync(filePath, 'utf8')
-    .split(/\r?\n/)
-    .filter((candidate) => new RegExp(`^\\s*${key}\\s*=`).test(candidate));
-  const line = matches.length ? matches[matches.length - 1] : undefined;
-  if (!line) return undefined;
-  let value = line.slice(line.indexOf('=') + 1).trim();
-  if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
-    value = value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
-  }
-  return value || undefined;
+  const value = parseDotenv(fs.readFileSync(filePath, 'utf8'))[key];
+  return value ? value : undefined;
 }
 
 function defaultRunCommand(

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -11,7 +11,13 @@ import { applyGrokSetup } from './grok.js';
 import { applyOpenClawSetup } from './openclaw.js';
 import { resolveGrokPaths } from './grok-config.js';
 import { DEFAULT_AUTOMEM_API_URL } from './templates.js';
-import { mergeEnvContent, sameEndpoint, writeFileWithBackup } from './host-toolkit.js';
+import {
+  AUTOMEM_API_KEY_NAMES,
+  mergeEnvContent,
+  removeEnvContentKeys,
+  sameEndpoint,
+  writeFileWithBackup,
+} from './host-toolkit.js';
 import { provisionViaInstaPodsLink, provisionViaRailway } from './cloud/installer-bridge.js';
 // Re-exported so existing importers (and install.test.ts) keep a stable path.
 export { formatEnvValue } from './host-toolkit.js';
@@ -878,16 +884,76 @@ export async function waitForAutoMemEndpoint(
   };
 }
 
-function mergeEnvFile(filePath: string, updates: Record<string, string>, dryRun: boolean): void {
+function mergeEnvFile(
+  filePath: string,
+  updates: Record<string, string>,
+  dryRun: boolean,
+  removeKeys: readonly string[] = []
+): void {
   const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : '';
+  const merged = mergeEnvContent(existing, updates);
   // .env files written by the installer carry secrets — the project .env can hold
   // AUTOMEM_API_KEY and the local server .env holds AUTOMEM_API_TOKEN/ADMIN_API_TOKEN
   // — so restrict them to 0o600, matching the uninstall path's perms.
-  writeFileWithBackup(filePath, mergeEnvContent(existing, updates), {
+  writeFileWithBackup(filePath, removeEnvContentKeys(merged, removeKeys), {
     dryRun,
     quiet: true,
     secret: true,
   });
+}
+
+/**
+ * Write the project `.env` for a resolved endpoint/key pair.
+ *
+ * Split out of the install flow so the credential rule below is reachable from a
+ * test with a real file — the defect it fixes is only visible in what the file
+ * still contains afterwards, not in any in-memory value.
+ *
+ * Returns the key names it removed (and the endpoint they belonged to) so the
+ * caller can say so out loud; silently deleting a user's credential is worse than
+ * the bug.
+ */
+export function writeProjectEnv(params: {
+  envPath: string;
+  endpoint: string;
+  apiKey?: string;
+  dryRun?: boolean;
+}): { removedKeys: string[]; previousEndpoint?: string } {
+  const { envPath, endpoint, apiKey } = params;
+  const existingEnv = fs.existsSync(envPath) ? fs.readFileSync(envPath, 'utf8') : '';
+  const envUpdates: Record<string, string> = {
+    AUTOMEM_API_URL: endpoint,
+    // Canonical name is AUTOMEM_API_KEY (the service/docs are standardizing on
+    // _KEY); the server still reads the AUTOMEM_API_TOKEN alias.
+    ...(apiKey ? { AUTOMEM_API_KEY: apiKey } : {}),
+  };
+  // Keep deprecated aliases in sync only if the file already uses them, so they
+  // can't diverge from the canonical names (and we don't add them on fresh files).
+  if (/^AUTOMEM_ENDPOINT=/m.test(existingEnv)) envUpdates.AUTOMEM_ENDPOINT = endpoint;
+  if (apiKey && /^AUTOMEM_API_TOKEN=/m.test(existingEnv)) envUpdates.AUTOMEM_API_TOKEN = apiKey;
+
+  // A key persisted in .env belongs to the endpoint it was written for, and the stdio
+  // server loads this file at startup. Rewriting AUTOMEM_API_URL while leaving the old
+  // credential in place would send that bearer token to the new host on every request,
+  // so it is removed under both supported names.
+  //
+  // Derived from the file rather than from a parse-time flag: this is reached whenever
+  // no key resolved for this run — an unset shell environment gets here without ever
+  // taking the --endpoint/--api-key mismatch branch. Removal needs a persisted endpoint
+  // to compare against; a .env holding a key and no URL is not evidence of a mismatch,
+  // so it is left alone.
+  const previousEndpoint =
+    readEnvFileValue(envPath, 'AUTOMEM_API_URL') ?? readEnvFileValue(envPath, 'AUTOMEM_ENDPOINT');
+  const persistedKeyNames = apiKey
+    ? []
+    : AUTOMEM_API_KEY_NAMES.filter((name) => readEnvFileValue(envPath, name));
+  const removedKeys =
+    persistedKeyNames.length > 0 && previousEndpoint && !sameEndpoint(previousEndpoint, endpoint)
+      ? [...persistedKeyNames]
+      : [];
+
+  mergeEnvFile(envPath, envUpdates, params.dryRun ?? false, removedKeys);
+  return { removedKeys, previousEndpoint };
 }
 
 function randomToken(): string {
@@ -1642,19 +1708,13 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
 
       list.start('env');
       const envPath = path.join(environment.cwd, '.env');
-      const existingEnv = fs.existsSync(envPath) ? fs.readFileSync(envPath, 'utf8') : '';
-      const envUpdates: Record<string, string> = {
-        AUTOMEM_API_URL: endpoint,
-        // Canonical name is AUTOMEM_API_KEY (the service/docs are standardizing on
-        // _KEY); the server still reads the AUTOMEM_API_TOKEN alias.
-        ...(apiKey ? { AUTOMEM_API_KEY: apiKey } : {}),
-      };
-      // Keep deprecated aliases in sync only if the file already uses them, so they
-      // can't diverge from the canonical names (and we don't add them on fresh files).
-      if (/^AUTOMEM_ENDPOINT=/m.test(existingEnv)) envUpdates.AUTOMEM_ENDPOINT = endpoint;
-      if (apiKey && /^AUTOMEM_API_TOKEN=/m.test(existingEnv)) envUpdates.AUTOMEM_API_TOKEN = apiKey;
-      mergeEnvFile(envPath, envUpdates, false);
-      list.done('env', `Wrote ${tildify(envPath)}`);
+      const envResult = writeProjectEnv({ envPath, endpoint, apiKey });
+      list.done(
+        'env',
+        envResult.removedKeys.length
+          ? `Wrote ${tildify(envPath)} (removed ${envResult.removedKeys.join(', ')} — issued for ${envResult.previousEndpoint})`
+          : `Wrote ${tildify(envPath)}`
+      );
 
       // Each agent installs independently: a failure (e.g. the openclaw CLI hanging
       // or absent) marks just that step ✗ and is collected for a manual-fix note —

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -967,10 +967,15 @@ function randomToken(): string {
 // is always a fixed literal here, so embedding it in the regex is safe.
 function readEnvFileValue(filePath: string, key: string): string | undefined {
   if (!fs.existsSync(filePath)) return undefined;
-  const line = fs
+  // Last assignment wins, matching dotenv — which is what actually loads this file at
+  // server startup. Taking the first match reported a stale endpoint for a .env with
+  // duplicate assignments, so a key issued for the *effective* endpoint looked paired
+  // with the earlier one and was preserved across a real endpoint change.
+  const matches = fs
     .readFileSync(filePath, 'utf8')
     .split(/\r?\n/)
-    .find((candidate) => new RegExp(`^\\s*${key}\\s*=`).test(candidate));
+    .filter((candidate) => new RegExp(`^\\s*${key}\\s*=`).test(candidate));
+  const line = matches.length ? matches[matches.length - 1] : undefined;
   if (!line) return undefined;
   let value = line.slice(line.indexOf('=') + 1).trim();
   if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {

--- a/src/cli/openclaw.test.ts
+++ b/src/cli/openclaw.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import {
   allowAutoMemTools,
   allowPluginWhenAllowlistExists,
@@ -19,6 +19,7 @@ import {
   probeBootstrapBypass,
   redactConfigForOutput,
   replaceOpenClawMemorySystem,
+  resolveApiKey,
 } from './openclaw.js';
 import fs from 'fs';
 import os from 'os';
@@ -523,5 +524,49 @@ describe('openclaw cli helpers', () => {
     });
 
     expect(profile).toContain('Call me Jack');
+  });
+});
+
+describe('openclaw credential/endpoint pairing', () => {
+  const ENDPOINT = 'https://chosen.example.test';
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    for (const key of [
+      'AUTOMEM_API_URL',
+      'AUTOMEM_ENDPOINT',
+      'AUTOMEM_API_KEY',
+      'AUTOMEM_API_TOKEN',
+    ]) {
+      if (originalEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = originalEnv[key];
+    }
+  });
+
+  it('takes --api-key over the environment', () => {
+    process.env.AUTOMEM_API_URL = ENDPOINT;
+    process.env.AUTOMEM_API_KEY = 'sk-env';
+    expect(resolveApiKey({ apiKey: 'sk-flag' }, ENDPOINT)).toBe('sk-flag');
+  });
+
+  it('reuses a shell key exported for the chosen endpoint', () => {
+    process.env.AUTOMEM_API_URL = ENDPOINT;
+    process.env.AUTOMEM_API_KEY = 'sk-env';
+    expect(resolveApiKey({}, ENDPOINT)).toBe('sk-env');
+  });
+
+  // OpenClaw reads no previously installed credential, so this is the only half that
+  // applies to it — but it is the half that discloses a secret.
+  it('does not carry a shell key exported for a different endpoint', () => {
+    process.env.AUTOMEM_API_URL = 'https://elsewhere.example.test';
+    process.env.AUTOMEM_API_KEY = 'sk-env';
+    expect(resolveApiKey({}, ENDPOINT)).toBeUndefined();
+  });
+
+  it('keeps an unbound shell key', () => {
+    delete process.env.AUTOMEM_API_URL;
+    delete process.env.AUTOMEM_ENDPOINT;
+    process.env.AUTOMEM_API_KEY = 'sk-env';
+    expect(resolveApiKey({}, ENDPOINT)).toBe('sk-env');
   });
 });

--- a/src/cli/openclaw.test.ts
+++ b/src/cli/openclaw.test.ts
@@ -24,6 +24,7 @@ import {
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { readAutoMemApiKeyFromEnv } from '../env.js';
 
 describe('openclaw cli helpers', () => {
   it('parses the new openclaw flags with plugin defaults', () => {
@@ -651,7 +652,42 @@ describe('openclaw stored-key pairing in config builders', () => {
       defaultTags: [],
     });
     expect(JSON.stringify(entry)).not.toContain('sk-host-a');
-    expect(entry.env as Record<string, unknown>).not.toHaveProperty('AUTOMEM_API_KEY');
+    // Blank, not absent: this env block is layered over the host's own, so an absent
+    // name lets a shell-exported key pass through to the repointed server.
+    expect((entry.env as Record<string, unknown>).AUTOMEM_API_KEY).toBe('');
+    expect((entry.env as Record<string, unknown>).AUTOMEM_API_TOKEN).toBe('');
+  });
+
+  // The boundary itself: OpenClaw layers this env over its own for the skill's curl
+  // commands and the mcporter subprocess, so a rejected key must be shadowed, not
+  // merely removed. Same treatment as the Grok and Hermes entries.
+  it('shadows a rejected key so an inherited one cannot reach the repointed server', () => {
+    const entry = buildSkillConfigEntry({
+      existing: { apiKey: 'sk-host-a', env: { AUTOMEM_API_URL: 'https://host-a.test' } },
+      endpoint: 'https://host-b.test',
+      defaultTags: [],
+    });
+    const env = entry.env as Record<string, string>;
+    const childEnv = {
+      AUTOMEM_API_URL: 'https://host-a.test',
+      AUTOMEM_API_KEY: 'sk-inherited',
+      ...env,
+    };
+    expect(childEnv.AUTOMEM_API_URL).toBe('https://host-b.test');
+    expect(readAutoMemApiKeyFromEnv(childEnv)).toBeUndefined();
+  });
+
+  it('shadows an inherited legacy token too', () => {
+    const entry = buildSkillConfigEntry({
+      existing: { apiKey: 'sk-host-a', env: { AUTOMEM_API_URL: 'https://host-a.test' } },
+      endpoint: 'https://host-b.test',
+      defaultTags: [],
+    });
+    const childEnv = {
+      AUTOMEM_API_TOKEN: 'sk-inherited-legacy',
+      ...(entry.env as Record<string, string>),
+    };
+    expect(readAutoMemApiKeyFromEnv(childEnv)).toBeUndefined();
   });
 
   it('drops an env-block legacy token stored for a different endpoint', () => {
@@ -682,7 +718,8 @@ describe('openclaw stored-key pairing in config builders', () => {
       apiKey: 'sk-new',
       defaultTags: [],
     });
-    expect(entry.env as Record<string, unknown>).not.toHaveProperty('AUTOMEM_API_KEY');
+    // A resolved key lives in the top-level field; no env copy is introduced.
+    expect((entry.env as Record<string, unknown>).AUTOMEM_API_KEY).toBeUndefined();
     expect(entry.apiKey).toBe('sk-new');
   });
 

--- a/src/cli/openclaw.test.ts
+++ b/src/cli/openclaw.test.ts
@@ -640,6 +640,52 @@ describe('openclaw stored-key pairing in config builders', () => {
   // An entry written before the AUTOMEM_ENDPOINT -> AUTOMEM_API_URL rename still names
   // its endpoint. Reading only the canonical name called a matching pair unpaired and
   // deleted the key out of a working authenticated install.
+  // Pre-#77 installs wrote the credential INSIDE the env block, next to the legacy
+  // endpoint name — the same object literal set both. Guarding only the top-level
+  // apiKey let `...existingEnv` carry that copy forward while the endpoint names
+  // beside it were rewritten to the new host.
+  it('drops an env-block key stored for a different endpoint', () => {
+    const entry = buildSkillConfigEntry({
+      existing: { env: { AUTOMEM_ENDPOINT: 'https://host-a.test', AUTOMEM_API_KEY: 'sk-host-a' } },
+      endpoint: 'https://host-b.test',
+      defaultTags: [],
+    });
+    expect(JSON.stringify(entry)).not.toContain('sk-host-a');
+    expect(entry.env as Record<string, unknown>).not.toHaveProperty('AUTOMEM_API_KEY');
+  });
+
+  it('drops an env-block legacy token stored for a different endpoint', () => {
+    const entry = buildSkillConfigEntry({
+      existing: {
+        env: { AUTOMEM_API_URL: 'https://host-a.test', AUTOMEM_API_TOKEN: 'sk-legacy' },
+      },
+      endpoint: 'https://host-b.test',
+      defaultTags: [],
+    });
+    expect(JSON.stringify(entry)).not.toContain('sk-legacy');
+  });
+
+  it('keeps and syncs an env-block key when the endpoint is unchanged', () => {
+    const entry = buildSkillConfigEntry({
+      existing: { env: { AUTOMEM_API_URL: 'https://same.test', AUTOMEM_API_KEY: 'sk-same' } },
+      endpoint: 'https://same.test',
+      defaultTags: [],
+    });
+    expect((entry.env as Record<string, unknown>).AUTOMEM_API_KEY).toBe('sk-same');
+    expect(entry.apiKey).toBe('sk-same');
+  });
+
+  it('does not introduce an env-block key where none existed', () => {
+    const entry = buildSkillConfigEntry({
+      existing: { env: { AUTOMEM_API_URL: 'https://same.test' } },
+      endpoint: 'https://same.test',
+      apiKey: 'sk-new',
+      defaultTags: [],
+    });
+    expect(entry.env as Record<string, unknown>).not.toHaveProperty('AUTOMEM_API_KEY');
+    expect(entry.apiKey).toBe('sk-new');
+  });
+
   it('keeps a skill key paired via the deprecated AUTOMEM_ENDPOINT alias', () => {
     const entry = buildSkillConfigEntry({
       existing: { apiKey: 'sk-legacy', env: { AUTOMEM_ENDPOINT: 'https://same.test' } },

--- a/src/cli/openclaw.test.ts
+++ b/src/cli/openclaw.test.ts
@@ -570,3 +570,79 @@ describe('openclaw credential/endpoint pairing', () => {
     expect(resolveApiKey({}, ENDPOINT)).toBe('sk-env');
   });
 });
+
+// The resolver correctly returned undefined for a mismatched endpoint, but these
+// builders then put the stored key straight back — and `...existingConfig` copied it
+// forward even before the explicit fallback ran.
+describe('openclaw stored-key pairing in config builders', () => {
+  it('drops a plugin key stored for a different endpoint', () => {
+    const entry = buildPluginConfigEntry({
+      existing: { config: { endpoint: 'https://host-a.test', apiKey: 'sk-host-a' } },
+      endpoint: 'https://host-b.test',
+      defaultTags: [],
+    });
+    const config = entry.config as Record<string, unknown>;
+    expect(config.endpoint).toBe('https://host-b.test');
+    expect(config.apiKey).toBeUndefined();
+    expect(JSON.stringify(entry)).not.toContain('sk-host-a');
+  });
+
+  it('keeps a plugin key stored for the same endpoint', () => {
+    const entry = buildPluginConfigEntry({
+      existing: { config: { endpoint: 'https://same.test/', apiKey: 'sk-same' } },
+      endpoint: 'https://same.test',
+      defaultTags: [],
+    });
+    expect((entry.config as Record<string, unknown>).apiKey).toBe('sk-same');
+  });
+
+  it('lets an explicit key win over a mismatched stored one', () => {
+    const entry = buildPluginConfigEntry({
+      existing: { config: { endpoint: 'https://host-a.test', apiKey: 'sk-host-a' } },
+      endpoint: 'https://host-b.test',
+      apiKey: 'sk-explicit',
+      defaultTags: [],
+    });
+    expect((entry.config as Record<string, unknown>).apiKey).toBe('sk-explicit');
+  });
+
+  it('preserves unrelated plugin config while dropping the stale key', () => {
+    const entry = buildPluginConfigEntry({
+      existing: {
+        config: {
+          endpoint: 'https://host-a.test',
+          apiKey: 'sk-host-a',
+          autoRecall: false,
+          autoRecallLimit: 7,
+          exposure: 'all',
+        },
+      },
+      endpoint: 'https://host-b.test',
+      defaultTags: [],
+    });
+    const config = entry.config as Record<string, unknown>;
+    expect(config.apiKey).toBeUndefined();
+    expect(config.autoRecall).toBe(false);
+    expect(config.autoRecallLimit).toBe(7);
+    expect(config.exposure).toBe('all');
+  });
+
+  it('drops a skill key stored for a different endpoint', () => {
+    const entry = buildSkillConfigEntry({
+      existing: { apiKey: 'sk-host-a', env: { AUTOMEM_API_URL: 'https://host-a.test' } },
+      endpoint: 'https://host-b.test',
+      defaultTags: [],
+    });
+    expect(entry.apiKey).toBeUndefined();
+    expect(JSON.stringify(entry)).not.toContain('sk-host-a');
+  });
+
+  it('keeps a skill key stored for the same endpoint', () => {
+    const entry = buildSkillConfigEntry({
+      existing: { apiKey: 'sk-same', env: { AUTOMEM_API_URL: 'https://same.test' } },
+      endpoint: 'https://same.test',
+      defaultTags: [],
+    });
+    expect(entry.apiKey).toBe('sk-same');
+  });
+});

--- a/src/cli/openclaw.test.ts
+++ b/src/cli/openclaw.test.ts
@@ -637,6 +637,49 @@ describe('openclaw stored-key pairing in config builders', () => {
     expect(JSON.stringify(entry)).not.toContain('sk-host-a');
   });
 
+  // An entry written before the AUTOMEM_ENDPOINT -> AUTOMEM_API_URL rename still names
+  // its endpoint. Reading only the canonical name called a matching pair unpaired and
+  // deleted the key out of a working authenticated install.
+  it('keeps a skill key paired via the deprecated AUTOMEM_ENDPOINT alias', () => {
+    const entry = buildSkillConfigEntry({
+      existing: { apiKey: 'sk-legacy', env: { AUTOMEM_ENDPOINT: 'https://same.test' } },
+      endpoint: 'https://same.test',
+      defaultTags: [],
+    });
+    expect(entry.apiKey).toBe('sk-legacy');
+  });
+
+  it('still drops a legacy-aliased key when the endpoint actually changed', () => {
+    const entry = buildSkillConfigEntry({
+      existing: { apiKey: 'sk-host-a', env: { AUTOMEM_ENDPOINT: 'https://host-a.test' } },
+      endpoint: 'https://host-b.test',
+      defaultTags: [],
+    });
+    expect(entry.apiKey).toBeUndefined();
+  });
+
+  // The spread carried a pre-rename alias forward untouched, leaving it naming the old
+  // host after an endpoint change.
+  it('keeps a pre-existing AUTOMEM_ENDPOINT in sync with the new endpoint', () => {
+    const entry = buildSkillConfigEntry({
+      existing: { env: { AUTOMEM_ENDPOINT: 'https://host-a.test' } },
+      endpoint: 'https://host-b.test',
+      defaultTags: [],
+    });
+    const env = entry.env as Record<string, unknown>;
+    expect(env.AUTOMEM_API_URL).toBe('https://host-b.test');
+    expect(env.AUTOMEM_ENDPOINT).toBe('https://host-b.test');
+  });
+
+  it('does not add the deprecated alias to an entry that does not use it', () => {
+    const entry = buildSkillConfigEntry({
+      existing: { env: { AUTOMEM_API_URL: 'https://host-a.test' } },
+      endpoint: 'https://host-b.test',
+      defaultTags: [],
+    });
+    expect(entry.env as Record<string, unknown>).not.toHaveProperty('AUTOMEM_ENDPOINT');
+  });
+
   it('keeps a skill key stored for the same endpoint', () => {
     const entry = buildSkillConfigEntry({
       existing: { apiKey: 'sk-same', env: { AUTOMEM_API_URL: 'https://same.test' } },

--- a/src/cli/openclaw.ts
+++ b/src/cli/openclaw.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'url';
 import { AutoMemClient } from '../automem-client.js';
 import { buildDefaultProjectTags } from '../memory-policy/shared.js';
 import { buildStartupProfileFromResults } from '../openclaw-startup-profile.js';
-import { resolveInheritedApiKey } from './host-toolkit.js';
+import { resolveInheritedApiKey, sameEndpoint } from './host-toolkit.js';
 import { DEFAULT_AUTOMEM_API_URL } from './templates.js';
 
 export type OpenClawSetupMode = 'plugin' | 'mcp' | 'skill';
@@ -486,6 +486,11 @@ function renderConfigEntryForOutput(label: string, entry: unknown, options: Open
   log(`${label}: ${JSON.stringify(redactConfigForOutput(entry), null, 2)}`, options.quiet);
 }
 
+/** A non-blank string key, or undefined. */
+function reusableKey(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
 export function buildPluginConfigEntry(params: {
   existing?: Record<string, unknown>;
   endpoint: string;
@@ -495,47 +500,55 @@ export function buildPluginConfigEntry(params: {
 }): Record<string, unknown> {
   const existing = isRecord(params.existing) ? params.existing : {};
   const existingConfig = isRecord(existing.config) ? existing.config : {};
-  const existingApiKey =
-    typeof existingConfig.apiKey === 'string' && existingConfig.apiKey.trim()
-      ? existingConfig.apiKey.trim()
-      : undefined;
+  // The installed key is reused on a flagless re-run, but only when it was issued for
+  // the endpoint being written. Without the pairing check, `--endpoint B` with no
+  // --api-key kept A's key here and the plugin sent A's credential to B — the resolver
+  // correctly returned undefined and this fallback put it straight back.
+  const existingApiKey = sameEndpoint(
+    typeof existingConfig.endpoint === 'string' ? existingConfig.endpoint : undefined,
+    params.endpoint
+  )
+    ? reusableKey(existingConfig.apiKey)
+    : undefined;
+  const apiKey = params.apiKey?.trim() || existingApiKey;
 
-  return {
-    ...existing,
-    enabled: true,
-    config: {
-      ...existingConfig,
-      endpoint: params.endpoint,
-      ...(params.apiKey || existingApiKey ? { apiKey: params.apiKey || existingApiKey } : {}),
-      autoRecall: typeof existingConfig.autoRecall === 'boolean' ? existingConfig.autoRecall : true,
-      ...(typeof existingConfig.autoRecallLimit === 'number' &&
-      Number.isFinite(existingConfig.autoRecallLimit)
-        ? { autoRecallLimit: existingConfig.autoRecallLimit }
-        : {}),
-      ...(typeof existingConfig.preferenceRecallLimit === 'number' &&
-      Number.isFinite(existingConfig.preferenceRecallLimit)
-        ? { preferenceRecallLimit: existingConfig.preferenceRecallLimit }
-        : {}),
-      ...(typeof existingConfig.contextRecallLimit === 'number' &&
-      Number.isFinite(existingConfig.contextRecallLimit)
-        ? { contextRecallLimit: existingConfig.contextRecallLimit }
-        : {}),
-      ...(typeof existingConfig.debugRecallLimit === 'number' &&
-      Number.isFinite(existingConfig.debugRecallLimit)
-        ? { debugRecallLimit: existingConfig.debugRecallLimit }
-        : {}),
-      ...(typeof existingConfig.contextRecallWindowDays === 'number' &&
-      Number.isFinite(existingConfig.contextRecallWindowDays)
-        ? { contextRecallWindowDays: existingConfig.contextRecallWindowDays }
-        : {}),
-      exposure:
-        typeof existingConfig.exposure === 'string' && existingConfig.exposure.trim()
-          ? existingConfig.exposure
-          : 'dm-only',
-      ...(params.defaultTags.length > 0 ? { defaultTags: params.defaultTags } : {}),
-      ...(params.startupProfile ? { startupProfile: params.startupProfile } : {}),
-    },
+  const config: Record<string, unknown> = {
+    ...existingConfig,
+    endpoint: params.endpoint,
+    autoRecall: typeof existingConfig.autoRecall === 'boolean' ? existingConfig.autoRecall : true,
+    ...(typeof existingConfig.autoRecallLimit === 'number' &&
+    Number.isFinite(existingConfig.autoRecallLimit)
+      ? { autoRecallLimit: existingConfig.autoRecallLimit }
+      : {}),
+    ...(typeof existingConfig.preferenceRecallLimit === 'number' &&
+    Number.isFinite(existingConfig.preferenceRecallLimit)
+      ? { preferenceRecallLimit: existingConfig.preferenceRecallLimit }
+      : {}),
+    ...(typeof existingConfig.contextRecallLimit === 'number' &&
+    Number.isFinite(existingConfig.contextRecallLimit)
+      ? { contextRecallLimit: existingConfig.contextRecallLimit }
+      : {}),
+    ...(typeof existingConfig.debugRecallLimit === 'number' &&
+    Number.isFinite(existingConfig.debugRecallLimit)
+      ? { debugRecallLimit: existingConfig.debugRecallLimit }
+      : {}),
+    ...(typeof existingConfig.contextRecallWindowDays === 'number' &&
+    Number.isFinite(existingConfig.contextRecallWindowDays)
+      ? { contextRecallWindowDays: existingConfig.contextRecallWindowDays }
+      : {}),
+    exposure:
+      typeof existingConfig.exposure === 'string' && existingConfig.exposure.trim()
+        ? existingConfig.exposure
+        : 'dm-only',
+    ...(params.defaultTags.length > 0 ? { defaultTags: params.defaultTags } : {}),
+    ...(params.startupProfile ? { startupProfile: params.startupProfile } : {}),
   };
+  // Explicit delete, not an omitted spread: `...existingConfig` above already copied
+  // the old key forward, so leaving it out of the literal would not remove it.
+  if (apiKey) config.apiKey = apiKey;
+  else delete config.apiKey;
+
+  return { ...existing, enabled: true, config };
 }
 
 export function buildSkillConfigEntry(params: {
@@ -546,15 +559,19 @@ export function buildSkillConfigEntry(params: {
 }): Record<string, unknown> {
   const existing = isRecord(params.existing) ? params.existing : {};
   const existingEnv = isRecord(existing.env) ? existing.env : {};
-  const existingApiKey =
-    typeof existing.apiKey === 'string' && existing.apiKey.trim()
-      ? existing.apiKey.trim()
-      : undefined;
+  // Same pairing rule as the plugin entry; here the previously written endpoint lives
+  // in the entry's own env block.
+  const existingApiKey = sameEndpoint(
+    typeof existingEnv.AUTOMEM_API_URL === 'string' ? existingEnv.AUTOMEM_API_URL : undefined,
+    params.endpoint
+  )
+    ? reusableKey(existing.apiKey)
+    : undefined;
+  const apiKey = params.apiKey?.trim() || existingApiKey;
 
-  return {
+  const entry: Record<string, unknown> = {
     ...existing,
     enabled: true,
-    ...(params.apiKey || existingApiKey ? { apiKey: params.apiKey || existingApiKey } : {}),
     env: {
       ...existingEnv,
       AUTOMEM_API_URL: params.endpoint,
@@ -563,6 +580,9 @@ export function buildSkillConfigEntry(params: {
         : {}),
     },
   };
+  if (apiKey) entry.apiKey = apiKey;
+  else delete entry.apiKey;
+  return entry;
 }
 
 export function buildMcporterConfig(params: {
@@ -1105,9 +1125,10 @@ function resolveEndpoint(options: OpenClawSetupOptions): string {
   );
 }
 
-// A key belongs to the endpoint it was issued for. OpenClaw reads no previously
-// installed credential, so only the environment half applies: an exported key with an
-// exported endpoint must not follow `--endpoint <other>` to a different host.
+// A key belongs to the endpoint it was issued for: an exported key with an exported
+// endpoint must not follow `--endpoint <other>` to a different host. The *stored* half
+// is enforced in buildPluginConfigEntry/buildSkillConfigEntry instead, because the
+// previously written endpoint lives in the config entry those functions already read.
 export function resolveApiKey(options: OpenClawSetupOptions, endpoint: string): string | undefined {
   return resolveInheritedApiKey({ endpoint, explicitKey: options.apiKey });
 }

--- a/src/cli/openclaw.ts
+++ b/src/cli/openclaw.ts
@@ -596,11 +596,20 @@ export function buildSkillConfigEntry(params: {
       ? { AUTOMEM_DEFAULT_TAGS: params.defaultTags.join(',') }
       : {}),
   };
-  // Explicit deletes, not omitted spreads: `...existingEnv` and `...existing` already
-  // copied both credential locations forward.
-  for (const name of AUTOMEM_API_KEY_NAMES) {
-    if (apiKey && Object.prototype.hasOwnProperty.call(env, name)) env[name] = apiKey;
-    else delete env[name];
+  // Blank overrides, not deletes. Deleting clears the value the spread copied forward,
+  // but this env block is layered over the host's own when the skill's curl commands
+  // and the mcporter subprocess run — so an absent name lets a shell-exported key,
+  // issued for a different endpoint, pass through to a server this entry just
+  // repointed. Same boundary, and the same treatment, as the Grok and Hermes entries.
+  if (apiKey) {
+    // A resolved key lives in the top-level `apiKey` field, which is what OpenClaw maps
+    // into the skill's environment; an env copy is only synced when the entry already
+    // carried one, so the entry shape does not change.
+    for (const name of AUTOMEM_API_KEY_NAMES) {
+      if (Object.prototype.hasOwnProperty.call(env, name)) env[name] = apiKey;
+    }
+  } else {
+    for (const name of AUTOMEM_API_KEY_NAMES) env[name] = '';
   }
 
   const entry: Record<string, unknown> = { ...existing, enabled: true, env };

--- a/src/cli/openclaw.ts
+++ b/src/cli/openclaw.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'url';
 import { AutoMemClient } from '../automem-client.js';
 import { buildDefaultProjectTags } from '../memory-policy/shared.js';
 import { buildStartupProfileFromResults } from '../openclaw-startup-profile.js';
-import { resolveInheritedApiKey, sameEndpoint } from './host-toolkit.js';
+import { readEndpointFrom, resolveInheritedApiKey, sameEndpoint } from './host-toolkit.js';
 import { DEFAULT_AUTOMEM_API_URL } from './templates.js';
 
 export type OpenClawSetupMode = 'plugin' | 'mcp' | 'skill';
@@ -560,11 +560,12 @@ export function buildSkillConfigEntry(params: {
   const existing = isRecord(params.existing) ? params.existing : {};
   const existingEnv = isRecord(existing.env) ? existing.env : {};
   // Same pairing rule as the plugin entry; here the previously written endpoint lives
-  // in the entry's own env block.
-  const existingApiKey = sameEndpoint(
-    typeof existingEnv.AUTOMEM_API_URL === 'string' ? existingEnv.AUTOMEM_API_URL : undefined,
-    params.endpoint
-  )
+  // in the entry's own env block. Read under both supported names — an entry written
+  // before the AUTOMEM_ENDPOINT → AUTOMEM_API_URL rename still names its endpoint, and
+  // reading only the canonical one would call a matching pair unpaired and delete the
+  // key out of a working authenticated install.
+  const existingEndpoint = readEndpointFrom(existingEnv);
+  const existingApiKey = sameEndpoint(existingEndpoint, params.endpoint)
     ? reusableKey(existing.apiKey)
     : undefined;
   const apiKey = params.apiKey?.trim() || existingApiKey;
@@ -575,6 +576,13 @@ export function buildSkillConfigEntry(params: {
     env: {
       ...existingEnv,
       AUTOMEM_API_URL: params.endpoint,
+      // The spread carries a pre-rename AUTOMEM_ENDPOINT forward untouched, which would
+      // leave it naming the *old* host after an endpoint change. Kept in sync when the
+      // entry already uses it, never added when it does not — matching how install.ts
+      // treats the same alias in .env.
+      ...(typeof existingEnv.AUTOMEM_ENDPOINT === 'string'
+        ? { AUTOMEM_ENDPOINT: params.endpoint }
+        : {}),
       ...(params.defaultTags.length > 0
         ? { AUTOMEM_DEFAULT_TAGS: params.defaultTags.join(',') }
         : {}),

--- a/src/cli/openclaw.ts
+++ b/src/cli/openclaw.ts
@@ -4,15 +4,15 @@ import path from 'path';
 import { execFileSync, execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { AutoMemClient } from '../automem-client.js';
-import { readAutoMemApiKeyFromEnv } from '../env.js';
 import { buildDefaultProjectTags } from '../memory-policy/shared.js';
 import { buildStartupProfileFromResults } from '../openclaw-startup-profile.js';
+import { resolveInheritedApiKey } from './host-toolkit.js';
 import { DEFAULT_AUTOMEM_API_URL } from './templates.js';
 
 export type OpenClawSetupMode = 'plugin' | 'mcp' | 'skill';
 export type OpenClawSetupScope = 'workspace' | 'shared';
 
-interface OpenClawSetupOptions {
+export interface OpenClawSetupOptions {
   workspace?: string;
   projectName?: string;
   dryRun?: boolean;
@@ -1105,14 +1105,17 @@ function resolveEndpoint(options: OpenClawSetupOptions): string {
   );
 }
 
-function resolveApiKey(options: OpenClawSetupOptions): string | undefined {
-  return options.apiKey?.trim() || readAutoMemApiKeyFromEnv();
+// A key belongs to the endpoint it was issued for. OpenClaw reads no previously
+// installed credential, so only the environment half applies: an exported key with an
+// exported endpoint must not follow `--endpoint <other>` to a different host.
+export function resolveApiKey(options: OpenClawSetupOptions, endpoint: string): string | undefined {
+  return resolveInheritedApiKey({ endpoint, explicitKey: options.apiKey });
 }
 
 export async function applyOpenClawSetup(cliOptions: OpenClawSetupOptions): Promise<void> {
   const projectName = cliOptions.projectName ?? detectProjectName();
   const endpoint = resolveEndpoint(cliOptions);
-  const apiKey = resolveApiKey(cliOptions);
+  const apiKey = resolveApiKey(cliOptions, endpoint);
   const defaultTags = buildDefaultTags(projectName);
   const workspaceDir = resolveWorkspaceDir(cliOptions.workspace);
   const requiresWorkspace = cliOptions.mode !== 'plugin' || cliOptions.scope === 'workspace';

--- a/src/cli/openclaw.ts
+++ b/src/cli/openclaw.ts
@@ -6,7 +6,13 @@ import { fileURLToPath } from 'url';
 import { AutoMemClient } from '../automem-client.js';
 import { buildDefaultProjectTags } from '../memory-policy/shared.js';
 import { buildStartupProfileFromResults } from '../openclaw-startup-profile.js';
-import { readEndpointFrom, resolveInheritedApiKey, sameEndpoint } from './host-toolkit.js';
+import {
+  AUTOMEM_API_KEY_NAMES,
+  readApiKeyFrom,
+  readEndpointFrom,
+  resolveInheritedApiKey,
+  sameEndpoint,
+} from './host-toolkit.js';
 import { DEFAULT_AUTOMEM_API_URL } from './templates.js';
 
 export type OpenClawSetupMode = 'plugin' | 'mcp' | 'skill';
@@ -565,29 +571,39 @@ export function buildSkillConfigEntry(params: {
   // reading only the canonical one would call a matching pair unpaired and delete the
   // key out of a working authenticated install.
   const existingEndpoint = readEndpointFrom(existingEnv);
+  // The credential can live in either of two places on disk, and both have to obey the
+  // pairing. Pre-#77 installs wrote it *inside* this env block (`configureEnvVars` set
+  // AUTOMEM_ENDPOINT and AUTOMEM_API_KEY into the same literal); the current shape is a
+  // top-level `apiKey`. Guarding only the top-level field let the env copy ride along:
+  // `...existingEnv` carried the old key forward while both endpoint names beside it
+  // were rewritten to the new host.
   const existingApiKey = sameEndpoint(existingEndpoint, params.endpoint)
-    ? reusableKey(existing.apiKey)
+    ? (reusableKey(existing.apiKey) ?? readApiKeyFrom(existingEnv))
     : undefined;
   const apiKey = params.apiKey?.trim() || existingApiKey;
 
-  const entry: Record<string, unknown> = {
-    ...existing,
-    enabled: true,
-    env: {
-      ...existingEnv,
-      AUTOMEM_API_URL: params.endpoint,
-      // The spread carries a pre-rename AUTOMEM_ENDPOINT forward untouched, which would
-      // leave it naming the *old* host after an endpoint change. Kept in sync when the
-      // entry already uses it, never added when it does not — matching how install.ts
-      // treats the same alias in .env.
-      ...(typeof existingEnv.AUTOMEM_ENDPOINT === 'string'
-        ? { AUTOMEM_ENDPOINT: params.endpoint }
-        : {}),
-      ...(params.defaultTags.length > 0
-        ? { AUTOMEM_DEFAULT_TAGS: params.defaultTags.join(',') }
-        : {}),
-    },
+  const env: Record<string, unknown> = {
+    ...existingEnv,
+    AUTOMEM_API_URL: params.endpoint,
+    // The spread carries a pre-rename AUTOMEM_ENDPOINT forward untouched, which would
+    // leave it naming the *old* host after an endpoint change. Kept in sync when the
+    // entry already uses it, never added when it does not — matching how install.ts
+    // treats the same alias in .env.
+    ...(typeof existingEnv.AUTOMEM_ENDPOINT === 'string'
+      ? { AUTOMEM_ENDPOINT: params.endpoint }
+      : {}),
+    ...(params.defaultTags.length > 0
+      ? { AUTOMEM_DEFAULT_TAGS: params.defaultTags.join(',') }
+      : {}),
   };
+  // Explicit deletes, not omitted spreads: `...existingEnv` and `...existing` already
+  // copied both credential locations forward.
+  for (const name of AUTOMEM_API_KEY_NAMES) {
+    if (apiKey && Object.prototype.hasOwnProperty.call(env, name)) env[name] = apiKey;
+    else delete env[name];
+  }
+
+  const entry: Record<string, unknown> = { ...existing, enabled: true, env };
   if (apiKey) entry.apiKey = apiKey;
   else delete entry.apiKey;
   return entry;

--- a/src/cli/setup.test.ts
+++ b/src/cli/setup.test.ts
@@ -79,6 +79,63 @@ describe('runSetup — deprecated AUTOMEM_ENDPOINT alias migration', () => {
     expect(envText).toContain('KEEP_ME=1');
   });
 
+  // setup had no credential/endpoint pairing at all and read only the canonical key
+  // name, so a legacy token was invisible to the code that should have removed it.
+  it('removes a legacy AUTOMEM_API_TOKEN when the endpoint changes', async () => {
+    const envPath = path.join(tmpDir, '.env');
+    fs.writeFileSync(
+      envPath,
+      'AUTOMEM_ENDPOINT=https://old.example.test\nAUTOMEM_API_TOKEN=sk-old\nKEEP_ME=1\n'
+    );
+
+    await runSetup(['--env', envPath, '--endpoint', 'https://new.example.test', '--yes']);
+
+    const envText = fs.readFileSync(envPath, 'utf8');
+    expect(envText).not.toContain('sk-old');
+    expect(envText).not.toMatch(/^AUTOMEM_API_TOKEN=/m);
+    expect(envText).toContain('KEEP_ME=1');
+  });
+
+  it('removes a canonical key written for a different endpoint', async () => {
+    const envPath = path.join(tmpDir, '.env');
+    fs.writeFileSync(envPath, 'AUTOMEM_API_URL=https://old.example.test\nAUTOMEM_API_KEY=sk-old\n');
+
+    await runSetup(['--env', envPath, '--endpoint', 'https://new.example.test', '--yes']);
+
+    const envText = fs.readFileSync(envPath, 'utf8');
+    expect(envText).not.toContain('sk-old');
+    expect(envText).toContain('AUTOMEM_API_URL=https://new.example.test');
+  });
+
+  it('keeps the key on a re-run at the same endpoint', async () => {
+    const envPath = path.join(tmpDir, '.env');
+    fs.writeFileSync(
+      envPath,
+      'AUTOMEM_API_URL=https://same.example.test\nAUTOMEM_API_KEY=sk-keep\n'
+    );
+
+    await runSetup(['--env', envPath, '--endpoint', 'https://same.example.test', '--yes']);
+
+    expect(fs.readFileSync(envPath, 'utf8')).toContain('AUTOMEM_API_KEY=sk-keep');
+  });
+
+  it('does not write a shell key exported for a different endpoint', async () => {
+    const envPath = path.join(tmpDir, '.env');
+    const prevUrl = process.env.AUTOMEM_API_URL;
+    const prevKey = process.env.AUTOMEM_API_KEY;
+    process.env.AUTOMEM_API_URL = 'https://shell.example.test';
+    process.env.AUTOMEM_API_KEY = 'sk-shell';
+    try {
+      await runSetup(['--env', envPath, '--endpoint', 'https://chosen.example.test', '--yes']);
+      expect(fs.readFileSync(envPath, 'utf8')).not.toContain('sk-shell');
+    } finally {
+      if (prevUrl === undefined) delete process.env.AUTOMEM_API_URL;
+      else process.env.AUTOMEM_API_URL = prevUrl;
+      if (prevKey === undefined) delete process.env.AUTOMEM_API_KEY;
+      else process.env.AUTOMEM_API_KEY = prevKey;
+    }
+  });
+
   it('does not introduce the deprecated alias into a fresh .env', async () => {
     const envPath = path.join(tmpDir, '.env');
 

--- a/src/cli/setup.test.ts
+++ b/src/cli/setup.test.ts
@@ -81,6 +81,18 @@ describe('runSetup — deprecated AUTOMEM_ENDPOINT alias migration', () => {
 
   // setup had no credential/endpoint pairing at all and read only the canonical key
   // name, so a legacy token was invisible to the code that should have removed it.
+  it('keeps the key when the stored endpoint is quoted or commented', async () => {
+    const envPath = path.join(tmpDir, '.env');
+    fs.writeFileSync(
+      envPath,
+      "AUTOMEM_API_URL='https://same.example.test' # production\nAUTOMEM_API_KEY=sk-keep\n"
+    );
+
+    await runSetup(['--env', envPath, '--endpoint', 'https://same.example.test', '--yes']);
+
+    expect(fs.readFileSync(envPath, 'utf8')).toContain('sk-keep');
+  });
+
   it('removes a legacy AUTOMEM_API_TOKEN when the endpoint changes', async () => {
     const envPath = path.join(tmpDir, '.env');
     fs.writeFileSync(

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { parse as parseDotenv } from 'dotenv';
 import path from 'path';
 import { stdin as input, stdout as output } from 'node:process';
 import { createInterface } from 'node:readline/promises';
@@ -98,24 +99,15 @@ function parseConfigArgs(args: string[]): ConfigOptions {
   return options;
 }
 
+// Delegates to dotenv — the parser that actually loads this file at server startup.
+// The hand-rolled version unwrapped only double quotes and did not strip comments, so
+// `KEY='value'` or a trailing `# comment` read as a different endpoint and the
+// credential pairing below removed a still-valid key.
 function loadEnvValues(filePath: string): Record<string, string> {
   if (!fs.existsSync(filePath)) {
     return {};
   }
-  const result: Record<string, string> = {};
-  const lines = fs.readFileSync(filePath, 'utf8').split(/\r?\n/);
-  for (const line of lines) {
-    const match = line.match(/^\s*([A-Za-z0-9_]+)\s*=\s*(.*)\s*$/);
-    if (match) {
-      const key = match[1].trim();
-      let value = match[2].trim();
-      if (value.startsWith('"') && value.endsWith('"')) {
-        value = value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
-      }
-      result[key] = value;
-    }
-  }
-  return result;
+  return parseDotenv(fs.readFileSync(filePath, 'utf8'));
 }
 
 function mergeEnvFile(

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -11,7 +11,15 @@ import {
   DEFAULT_AUTOMEM_API_URL,
 } from './templates.js';
 import { applyClaudeCodeSetup } from './claude-code.js';
-import { mergeEnvContent } from './host-toolkit.js';
+import {
+  AUTOMEM_API_KEY_NAMES,
+  mergeEnvContent,
+  readApiKeyFrom,
+  readEndpointFrom,
+  removeEnvContentKeys,
+  resolveInheritedApiKey,
+  sameEndpoint,
+} from './host-toolkit.js';
 
 interface SetupOptions {
   envPath?: string;
@@ -110,9 +118,14 @@ function loadEnvValues(filePath: string): Record<string, string> {
   return result;
 }
 
-function mergeEnvFile(filePath: string, updates: Record<string, string>) {
+function mergeEnvFile(
+  filePath: string,
+  updates: Record<string, string>,
+  removeKeys: readonly string[] = []
+) {
   const existing = fs.existsSync(filePath) ? fs.readFileSync(filePath, 'utf8') : '';
-  fs.writeFileSync(filePath, mergeEnvContent(existing, updates), 'utf8');
+  const merged = mergeEnvContent(existing, updates);
+  fs.writeFileSync(filePath, removeEnvContentKeys(merged, removeKeys), 'utf8');
 }
 
 async function promptValue(prompt: string, fallback: string, prefilled?: string): Promise<string> {
@@ -144,12 +157,24 @@ export async function runSetup(args: string[] = []): Promise<void> {
     process.env[LEGACY_ENV_ENDPOINT_KEY] ||
     DEFAULT_AUTOMEM_API_URL;
 
-  const defaultApiKey =
-    options.apiKey ?? existingValues[ENV_API_KEY] ?? process.env[ENV_API_KEY] ?? '';
-
   const endpoint =
     options.endpoint ??
     (await promptValue('AutoMem API URL', DEFAULT_AUTOMEM_API_URL, defaultEndpoint));
+
+  // A key belongs to the endpoint it was issued for. This resolved the key from the
+  // file and the environment with no endpoint check at all, and read only the
+  // canonical name — so `setup --endpoint <new>` rewrote the URL and left the old
+  // host's credential sitting beside it, and a legacy AUTOMEM_API_TOKEN was invisible
+  // to the code that should have removed it. Computed after `endpoint` because the
+  // pairing needs the endpoint actually being written.
+  const storedEndpoint = readEndpointFrom(existingValues);
+  const defaultApiKey =
+    resolveInheritedApiKey({
+      endpoint,
+      explicitKey: options.apiKey,
+      storedEndpoint,
+      storedKey: readApiKeyFrom(existingValues),
+    }) ?? '';
 
   let apiKey = options.apiKey ?? defaultApiKey;
   if (!options.apiKey && input.isTTY && output.isTTY) {
@@ -189,11 +214,25 @@ export async function runSetup(args: string[] = []): Promise<void> {
   if (hasLegacyLine) {
     updates[LEGACY_ENV_ENDPOINT_KEY] = endpoint;
   }
-  if (apiKey && apiKey !== '<required>' && apiKey !== '<unchanged>') {
+  const writesKey = Boolean(apiKey) && apiKey !== '<required>' && apiKey !== '<unchanged>';
+  if (writesKey) {
     updates[ENV_API_KEY] = apiKey;
   }
 
-  mergeEnvFile(envPath, updates);
+  // Nothing resolved and the file still holds a credential issued for a different
+  // endpoint: remove it under both names rather than leave it to authenticate against
+  // the new host. A file naming a key but no endpoint is not evidence of a mismatch,
+  // so it is left alone — same rule as the guided installer's project .env.
+  const persistedKeyNames = AUTOMEM_API_KEY_NAMES.filter((name) => existingValues[name]);
+  const staleKeyNames =
+    !writesKey &&
+    persistedKeyNames.length > 0 &&
+    storedEndpoint &&
+    !sameEndpoint(storedEndpoint, endpoint)
+      ? persistedKeyNames
+      : [];
+
+  mergeEnvFile(envPath, updates, staleKeyNames);
   console.log(`\n✅ Saved AutoMem settings to ${envPath}`);
   if (hasLegacyLine) {
     console.log(


### PR DESCRIPTION
Sweeps the seven review threads left open on #192, plus every site found by auditing the same defect class across the rest of the installers.

The pattern on #192 was ten review rounds where each round patched the one call site a finding named, and the next round found the same bug at the next site. This fixes each theme once, in a shared helper.

## The guarantee

**An AutoMem API key must never reach an endpoint it was not issued for.** Delivering that turned out to need three layers, not one:

1. **Resolution** — `resolveInheritedApiKey()` in `host-toolkit.ts` pairs every *inherited* key with the endpoint it came from.
2. **Persistence** — every writer that can carry a key forward from prior state must drop it when the endpoint changes. Omission is not enough where a spread or a skip-undefined merge already copied it.
3. **Process boundary** — hosts launch the server with `{...process.env, ...entry.env}`, so a rejected key must be *shadowed with a blank*, not merely left out of the entry. Otherwise a shell-exported key is inherited by a child whose URL the entry just repointed.

Layers 2 and 3 were only found during review. Layer 3 in particular means the original version of this PR did not actually deliver its own title.

## Filed findings (all resolved)

| Thread | Fix |
|---|---|
| `grok.ts:131` — Claude plugin key not endpoint-paired | Installers no longer read `CLAUDE_PLUGIN_OPTION_*` |
| `install.ts:445` — persisted keys survive an endpoint switch | `writeProjectEnv()` removes both names |
| `grok-config.ts:441` — legacy token dropped on re-run | Readers accept `AUTOMEM_API_TOKEN`, canonicalize to `_KEY` |
| `grok-config.ts:105` — backups with a legacy token not chmod'ed | Secrecy predicate reads both names |
| `grok-config.ts:115` — ownership inferred from env text | Identity is command/args or env var *names*, never values |
| `grok.ts:78` — duplicate start markers not rejected | Requires exactly one correctly ordered pair |
| `host-toolkit.ts:143` — pinned package spec rejected | Allows an npm version/dist-tag suffix |
| `hermes-config.ts:181` — endpoint and key merged field-wise | Pairs are returned whole, from one source |
| `openclaw.ts:1112` / `hermes.ts:222` — stored key survives endpoint change | Reuse gated on the previously written endpoint |
| `openclaw.ts:566` — legacy endpoint alias not honoured | Endpoints read under both names |
| `install.ts:953` — first `.env` assignment read, dotenv uses last | Reads the last assignment |
| `host-toolkit.ts:115` / `hermes.ts:193` — rejected key inherited by the child | Blank overrides; provider dotenv cleared on mode switch |
| `openclaw.ts:603` — same, for the skill entry | Blank overrides there too |
| `grok-real-host.test.ts:97` — launch the configured `npx` | **Declined**, see below |

## Sites found by audit, not by review

After the fourth round landed on the persistence layer again, I stopped taking findings one at a time and audited every site that persists a credential. Three of these were never filed:

- **Hermes** (`hermes.ts`, `hermes-config.ts`) — no endpoint check on either inherited source, and readers that saw only `AUTOMEM_API_KEY`, so a Railway-templated config lost its credential on a flagless re-run.
- **OpenClaw** (`openclaw.ts`) — the environment half, plus a credential in `env.AUTOMEM_API_KEY` that pre-#77 installs wrote *inside* the entry's env block, which the spread carried across an endpoint change. Verified against a built artifact: present next to the new endpoint before, absent after.
- **`setup.ts`** — no pairing at all, and canonical-name-only reads. `setup --endpoint <new> --yes` rewrote the URL, left the old host's credential beside it, and could not see a legacy `AUTOMEM_API_TOKEN` at all. Reachable in CI with no prompt.

**Audited and found clean, by reading the write paths rather than grepping:** grok's TOML splice, the cloud providers (endpoint and key always arrive paired from one source), `queue.ts` (read-only, single env object), `cursor`/`codex`/`copilot`/`claude-code` (no credential writes), and install's `--target local` (rejected before any write).

## Verification

- **905 tests pass** (817 on `main`), 88 new.
- **Every behavior mutation-tested** — reverting any one fails at least one assertion. Where the defect is only visible in persisted state, the assertions read the **file**, not an in-memory value; for the process boundary they build `{...process.env, ...entry.env}` and assert on what `readAutoMemApiKeyFromEnv` returns.
- Typecheck, lint (0 errors), `format:check` clean; policy sync reports no `templates/`/`plugins/` churn.

## Disclosed limitations

- **OpenClaw's wiring is not covered end to end.** `resolveApiKey` and both config builders are tested directly, but the `resolveApiKey(cliOptions, endpoint)` call inside `applyOpenClawSetup` is not — the full flow needs a workspace and CLI probing.
- **`grok-real-host.test.ts:97` stays declined.** Executing the configured `npx -y @verygoodplugins/mcp-automem` would run the *published* package rather than this branch, so it would pass even if the PR broke the server, and it adds a network dependency. `tests/e2e/run-matrix.sh` already covers this by packing a tarball from the branch.
- **Marker validation is fixed in Grok only.** The same duplicate-start bug exists in `codex.ts`, `copilot.ts`, `hermes.ts` and `openclaw.ts`. Fixing it in five places is the argument for extracting `upsertMarkedBlock`, which is on the deferred list — tracked separately rather than widened into a credential PR.
- **`buildMcporterConfig` writes no env block.** The `automem` server is registered as bare `npx -y <package>`, so in mcp mode the subprocess takes `AUTOMEM_API_URL` from the ambient environment too, not just the key. Pinning the endpoint there changes how the skill env and mcporter interact, which I could not verify against OpenClaw runtime semantics, so it is flagged rather than guessed at.
- **Two adjacent issues left for a follow-up**, both surfaced by the audit and both outside this theme: `uninstall.ts` does not chmod a backup that still contains the removed key (`grok-config.ts` fixed the identical bug), and `uninstall.ts:709` has a local `isAutoMemMcpServer` reimplementation carrying the exact free-text-substring hazard `isAutoMemServerEntry` was written to remove — used there to decide a *deletion*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
