### PR TITLE
fix: refuse stray rules-file markers across all installer hosts

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1634,6 +1634,25 @@ npx @verygoodplugins/mcp-automem help
 - Verify content doesn't exceed size limits
 - Ensure proper data formatting
 
+### Rules File Issues
+
+#### "does not contain exactly one … block"
+
+Every host writes its memory rules as a marked block (`<!-- BEGIN AUTOMEM … RULES -->` …
+`<!-- END AUTOMEM … RULES -->`) inside a Markdown file you also own. The installer rewrites
+only the bytes between those markers, so it requires exactly one correctly ordered pair.
+
+If a rules file ends up with a stray marker — an interrupted run, a hand edit that removed
+half the block, or a merge that duplicated it — the installer refuses to touch the file and
+names the defect instead. Rewriting anyway would delete whatever sits between the stray
+markers, which is usually content you wrote.
+
+**Fix:** open the file named in the error, remove or restore the stray marker so exactly one
+`BEGIN`/`END` pair remains (or delete the block entirely and let the installer re-add it),
+then re-run. Nothing was written, so nothing needs undoing. Hosts that only *remove* a stale
+block (OpenClaw's legacy `AGENTS.md` cleanup, Copilot's `--format vscode` re-run) print a
+warning and leave the file alone rather than failing the install.
+
 ### Platform-Specific Issues
 
 #### Claude Desktop: MCP server not appearing

--- a/src/cli/codex.test.ts
+++ b/src/cli/codex.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { applyCodexSetup, CODEX_RULES_END, CODEX_RULES_START } from './codex.js';
+
+describe('codex setup', () => {
+  let tmpDir: string;
+  let rulesPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-setup-'));
+    rulesPath = path.join(tmpDir, 'AGENTS.md');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes a marked rules block into a new AGENTS.md', async () => {
+    await applyCodexSetup({ rulesPath, projectName: 'demo', quiet: true });
+
+    const content = fs.readFileSync(rulesPath, 'utf8');
+    expect(content).toContain(CODEX_RULES_START);
+    expect(content).toContain(CODEX_RULES_END);
+    expect(content).toContain('demo');
+  });
+
+  it('appends below existing content instead of replacing the file', async () => {
+    fs.writeFileSync(rulesPath, '# My project notes\n\nKeep this.\n');
+
+    await applyCodexSetup({ rulesPath, projectName: 'demo', quiet: true });
+
+    const content = fs.readFileSync(rulesPath, 'utf8');
+    expect(content).toContain('# My project notes');
+    expect(content).toContain('Keep this.');
+    expect(content.indexOf(CODEX_RULES_START)).toBeGreaterThan(content.indexOf('Keep this.'));
+  });
+
+  // The pre-extraction shape appended a bare `\n` on every merge, so each re-run grew
+  // the file by one newline and no two installs produced the same bytes.
+  it('re-running is byte-stable', async () => {
+    await applyCodexSetup({ rulesPath, projectName: 'demo', quiet: true });
+    const first = fs.readFileSync(rulesPath, 'utf8');
+
+    await applyCodexSetup({ rulesPath, projectName: 'demo', quiet: true });
+    const second = fs.readFileSync(rulesPath, 'utf8');
+
+    expect(second).toBe(first);
+    expect(second.endsWith(`${CODEX_RULES_END}\n`)).toBe(true);
+  });
+
+  it('re-running keeps content below the block in place, byte for byte', async () => {
+    await applyCodexSetup({ rulesPath, projectName: 'demo', quiet: true });
+    fs.writeFileSync(rulesPath, `${fs.readFileSync(rulesPath, 'utf8')}\n# Trailing notes\n`);
+    const before = fs.readFileSync(rulesPath, 'utf8');
+
+    await applyCodexSetup({ rulesPath, projectName: 'demo', quiet: true });
+
+    expect(fs.readFileSync(rulesPath, 'utf8')).toBe(before);
+  });
+
+  // Both markers are present, so an indexOf check treats this as well-formed and
+  // replaces from the first start through the end — deleting the second marker and the
+  // user's notes between them.
+  it('refuses when the rules file has two start markers and one end', async () => {
+    const handWritten = [
+      '# My notes',
+      CODEX_RULES_START,
+      'stale half-block',
+      CODEX_RULES_START,
+      'notes the user wrote between the markers',
+      CODEX_RULES_END,
+      '',
+    ].join('\n');
+    fs.writeFileSync(rulesPath, handWritten);
+
+    await expect(applyCodexSetup({ rulesPath, projectName: 'demo', quiet: true })).rejects.toThrow(
+      /found 2 start markers and 1 end marker/
+    );
+
+    expect(fs.readFileSync(rulesPath, 'utf8')).toBe(handWritten);
+  });
+
+  // Appending past a half-written block leaves one start and two ends, so the *next*
+  // run replaces everything between the original start and the appended end.
+  it('refuses a one-sided start marker instead of appending', async () => {
+    const handWritten = ['# My notes', CODEX_RULES_START, 'half a block, no end', ''].join('\n');
+    fs.writeFileSync(rulesPath, handWritten);
+
+    await expect(applyCodexSetup({ rulesPath, projectName: 'demo', quiet: true })).rejects.toThrow(
+      /without a matching/
+    );
+
+    expect(fs.readFileSync(rulesPath, 'utf8')).toBe(handWritten);
+  });
+
+  it('refuses a stray end marker too', async () => {
+    const handWritten = ['# My notes', CODEX_RULES_END, ''].join('\n');
+    fs.writeFileSync(rulesPath, handWritten);
+
+    await expect(applyCodexSetup({ rulesPath, projectName: 'demo', quiet: true })).rejects.toThrow(
+      /without a matching/
+    );
+
+    expect(fs.readFileSync(rulesPath, 'utf8')).toBe(handWritten);
+  });
+
+  it('refuses when the end marker precedes the start marker', async () => {
+    const handWritten = ['# My notes', CODEX_RULES_END, 'user content', CODEX_RULES_START, ''].join(
+      '\n'
+    );
+    fs.writeFileSync(rulesPath, handWritten);
+
+    await expect(applyCodexSetup({ rulesPath, projectName: 'demo', quiet: true })).rejects.toThrow(
+      /precedes/
+    );
+
+    expect(fs.readFileSync(rulesPath, 'utf8')).toBe(handWritten);
+  });
+
+  it('dry-run writes nothing', async () => {
+    await applyCodexSetup({ rulesPath, projectName: 'demo', dryRun: true, quiet: true });
+    expect(fs.existsSync(rulesPath)).toBe(false);
+  });
+
+  it('dry-run still refuses a malformed rules file', async () => {
+    const handWritten = [CODEX_RULES_START, 'a', CODEX_RULES_START, 'b', CODEX_RULES_END, ''].join(
+      '\n'
+    );
+    fs.writeFileSync(rulesPath, handWritten);
+
+    await expect(
+      applyCodexSetup({ rulesPath, projectName: 'demo', dryRun: true, quiet: true })
+    ).rejects.toThrow(/found 2 start markers and 1 end marker/);
+  });
+});

--- a/src/cli/codex.ts
+++ b/src/cli/codex.ts
@@ -5,8 +5,10 @@ import {
   CommonOptions,
   detectProjectName,
   log,
+  type MarkedBlockMarkers,
   parseCommonFlags,
   replaceTemplateVars,
+  upsertMarkedBlock,
   writeFileWithBackup,
 } from './host-toolkit.js';
 
@@ -18,22 +20,12 @@ const TEMPLATE_ROOT = path.resolve(
   fileURLToPath(new URL('../../templates/codex', import.meta.url))
 );
 
-function upsertRulesWithMarkers(existing: string | null, block: string): string {
-  const start = '<!-- BEGIN AUTOMEM CODEX RULES -->';
-  const end = '<!-- END AUTOMEM CODEX RULES -->';
-  if (!existing) {
-    return `${block}\n`;
-  }
-  const startIdx = existing.indexOf(start);
-  const endIdx = existing.indexOf(end);
-  if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
-    const before = existing.slice(0, startIdx);
-    const after = existing.slice(endIdx + end.length);
-    return `${before}${block}${after}`;
-  }
-  const sep = existing.endsWith('\n') ? '\n' : '\n\n';
-  return `${existing}${sep}${block}\n`;
-}
+export const CODEX_RULES_START = '<!-- BEGIN AUTOMEM CODEX RULES -->';
+export const CODEX_RULES_END = '<!-- END AUTOMEM CODEX RULES -->';
+export const CODEX_RULES_MARKERS: MarkedBlockMarkers = {
+  start: CODEX_RULES_START,
+  end: CODEX_RULES_END,
+};
 
 export async function applyCodexSetup(cliOptions: CodexSetupOptions): Promise<void> {
   const projectName = cliOptions.projectName ?? detectProjectName();
@@ -50,7 +42,12 @@ export async function applyCodexSetup(cliOptions: CodexSetupOptions): Promise<vo
   const processed = replaceTemplateVars(templateContent, vars);
 
   const existingContent = fs.existsSync(rulesPath) ? fs.readFileSync(rulesPath, 'utf8') : null;
-  const finalContent = upsertRulesWithMarkers(existingContent, processed);
+  const finalContent = upsertMarkedBlock(
+    existingContent,
+    processed,
+    CODEX_RULES_MARKERS,
+    rulesPath
+  );
   writeFileWithBackup(rulesPath, finalContent, cliOptions);
 
   log('\n📊 Configuration Status:', cliOptions.quiet);

--- a/src/cli/copilot.ts
+++ b/src/cli/copilot.ts
@@ -8,6 +8,20 @@ import {
   type CopilotInstallFormat,
   type CopilotHookSurface,
 } from './hook-model.js';
+import {
+  describeMarkedBlockDefect,
+  scanMarkedBlock,
+  stripMarkedBlock,
+  upsertMarkedBlock,
+  type MarkedBlockMarkers,
+} from './host-toolkit.js';
+
+export const COPILOT_RULES_START = '<!-- BEGIN AUTOMEM MEMORY RULES -->';
+export const COPILOT_RULES_END = '<!-- END AUTOMEM MEMORY RULES -->';
+const COPILOT_RULES_MARKERS: MarkedBlockMarkers = {
+  start: COPILOT_RULES_START,
+  end: COPILOT_RULES_END,
+};
 
 // --- Type Definitions (T002, T003) ---
 
@@ -188,12 +202,18 @@ function removeCliMemoryRules(targetPath: string, options: CopilotSetupOptions):
     return false;
   }
 
-  const startMarker = '<!-- BEGIN AUTOMEM MEMORY RULES -->';
-  const endMarker = '<!-- END AUTOMEM MEMORY RULES -->';
   const existing = fs.readFileSync(targetPath, 'utf8');
-  const start = existing.indexOf(startMarker);
-  const end = existing.indexOf(endMarker);
-  if (start === -1 || end === -1) {
+  const scan = scanMarkedBlock(existing, COPILOT_RULES_MARKERS);
+  if (scan.absent) {
+    return false;
+  }
+  if (!scan.paired) {
+    // Stripping across a stray marker walks from a start to the *next* end and takes
+    // the user's content in between with it. Leave the file alone and say why.
+    console.warn(
+      `Warning: left ${targetPath} untouched — ${describeMarkedBlockDefect(scan, COPILOT_RULES_MARKERS)}. ` +
+        'Remove the stray marker by hand, then re-run.'
+    );
     return false;
   }
   if (options.dryRun) {
@@ -201,9 +221,7 @@ function removeCliMemoryRules(targetPath: string, options: CopilotSetupOptions):
     return true;
   }
 
-  const updated = (existing.slice(0, start) + existing.slice(end + endMarker.length))
-    .replace(/\n{3,}/g, '\n\n')
-    .trim();
+  const updated = stripMarkedBlock(existing, COPILOT_RULES_MARKERS).trim();
   if (!updated) {
     return removeFileWithBackup(targetPath, options);
   }
@@ -462,33 +480,21 @@ function installMemoryRules(targetDir: string, options: CopilotSetupOptions) {
       }
       const rulesBlock = templateContent.slice(blockStart, blockEnd + '</memory_rules>'.length);
 
-      const startMarker = '<!-- BEGIN AUTOMEM MEMORY RULES -->';
-      const endMarker = '<!-- END AUTOMEM MEMORY RULES -->';
-      const markedBlock = `${startMarker}\n${rulesBlock}\n${endMarker}`;
+      const markedBlock = `${COPILOT_RULES_START}\n${rulesBlock}\n${COPILOT_RULES_END}`;
+
+      const existing = fs.existsSync(cliTargetPath) ? fs.readFileSync(cliTargetPath, 'utf8') : '';
+      // Validated before the dry-run bail so a preview surfaces a rules file this
+      // command would refuse to rewrite, instead of promising an update that throws.
+      const updated = upsertMarkedBlock(
+        existing.length > 0 ? existing : null,
+        markedBlock,
+        COPILOT_RULES_MARKERS,
+        cliTargetPath
+      );
 
       if (options.dryRun) {
         log(`dry-run: would update ${cliTargetPath} (memory rules block)`, options.quiet);
         return;
-      }
-
-      const existing = fs.existsSync(cliTargetPath) ? fs.readFileSync(cliTargetPath, 'utf8') : '';
-
-      let updated: string;
-      const existingStart = existing.indexOf(startMarker);
-      const existingEnd = existing.indexOf(endMarker);
-
-      if (existingStart !== -1 && existingEnd !== -1) {
-        // Replace existing block
-        const before = existing.slice(0, existingStart);
-        const after = existing.slice(existingEnd + endMarker.length);
-        updated = `${before}${markedBlock}${after}`;
-      } else if (existing.length > 0) {
-        // Append to existing file
-        const sep = existing.endsWith('\n') ? '\n' : '\n\n';
-        updated = `${existing}${sep}${markedBlock}\n`;
-      } else {
-        // New file
-        updated = `${markedBlock}\n`;
       }
 
       if (updated !== existing) {

--- a/src/cli/copilot.ts
+++ b/src/cli/copilot.ts
@@ -433,7 +433,70 @@ function installSupportScripts(targetDir: string, options: CopilotSetupOptions) 
   }
 }
 
-function installMemoryRules(targetDir: string, options: CopilotSetupOptions) {
+interface PreparedCliMemoryRules {
+  targetPath: string;
+  existing: string;
+  updated: string;
+}
+
+/**
+ * Render the CLI rules file and validate the markers already in it — pure except for
+ * reads, and the only step of a Copilot install that can refuse.
+ *
+ * Called up front by applyCopilotSetup so a stray marker rejects the run before any
+ * hook is removed or installed. Validating at write time instead would leave a failed
+ * profile switch with stale hooks deleted, new hooks written, and the VS Code rules
+ * replaced, while telling the user nothing was written.
+ *
+ * Returns null when CLI rules are not part of this install or the packaged template is
+ * unusable; both mean "no CLI rules to write", which is not a failure.
+ */
+function prepareCliMemoryRules(
+  targetDir: string,
+  options: CopilotSetupOptions
+): PreparedCliMemoryRules | null {
+  const format = options.format ?? 'both';
+  if (format !== 'cli' && format !== 'both') {
+    return null;
+  }
+
+  const cliTemplatePath = path.resolve(
+    fileURLToPath(new URL('../../templates/COPILOT_INSTRUCTIONS_MEMORY_RULES.md', import.meta.url))
+  );
+  if (!fs.existsSync(cliTemplatePath)) {
+    return null;
+  }
+
+  const templateContent = fs.readFileSync(cliTemplatePath, 'utf8');
+  // Extract just the memory rules block (between the markdown fence markers)
+  const blockStart = templateContent.indexOf('<memory_rules>');
+  const blockEnd = templateContent.indexOf('</memory_rules>');
+  if (blockStart === -1 || blockEnd === -1) {
+    console.error(
+      'Error: Could not find <memory_rules> markers in template - package may be corrupted'
+    );
+    return null;
+  }
+  const rulesBlock = templateContent.slice(blockStart, blockEnd + '</memory_rules>'.length);
+  const markedBlock = `${COPILOT_RULES_START}\n${rulesBlock}\n${COPILOT_RULES_END}`;
+
+  const targetPath = path.join(targetDir, 'copilot-instructions.md');
+  const existing = fs.existsSync(targetPath) ? fs.readFileSync(targetPath, 'utf8') : '';
+  const updated = upsertMarkedBlock(
+    existing.length > 0 ? existing : null,
+    markedBlock,
+    COPILOT_RULES_MARKERS,
+    targetPath
+  );
+
+  return { targetPath, existing, updated };
+}
+
+function installMemoryRules(
+  targetDir: string,
+  options: CopilotSetupOptions,
+  cliRules: PreparedCliMemoryRules | null
+) {
   const format = options.format ?? 'both';
   const installVscode = format === 'vscode' || format === 'both';
   const installCli = format === 'cli' || format === 'both';
@@ -460,48 +523,18 @@ function installMemoryRules(targetDir: string, options: CopilotSetupOptions) {
     }
   }
 
-  // CLI: <targetDir>/copilot-instructions.md (append AutoMem block using markers)
-  if (installCli) {
-    const cliTemplatePath = path.resolve(
-      fileURLToPath(
-        new URL('../../templates/COPILOT_INSTRUCTIONS_MEMORY_RULES.md', import.meta.url)
-      )
-    );
-    if (fs.existsSync(cliTemplatePath)) {
-      const templateContent = fs.readFileSync(cliTemplatePath, 'utf8');
-      // Extract just the memory rules block (between the markdown fence markers)
-      const blockStart = templateContent.indexOf('<memory_rules>');
-      const blockEnd = templateContent.indexOf('</memory_rules>');
-      if (blockStart === -1 || blockEnd === -1) {
-        console.error(
-          'Error: Could not find <memory_rules> markers in template - package may be corrupted'
-        );
-        return;
-      }
-      const rulesBlock = templateContent.slice(blockStart, blockEnd + '</memory_rules>'.length);
-
-      const markedBlock = `${COPILOT_RULES_START}\n${rulesBlock}\n${COPILOT_RULES_END}`;
-
-      const existing = fs.existsSync(cliTargetPath) ? fs.readFileSync(cliTargetPath, 'utf8') : '';
-      // Validated before the dry-run bail so a preview surfaces a rules file this
-      // command would refuse to rewrite, instead of promising an update that throws.
-      const updated = upsertMarkedBlock(
-        existing.length > 0 ? existing : null,
-        markedBlock,
-        COPILOT_RULES_MARKERS,
-        cliTargetPath
-      );
-
-      if (options.dryRun) {
-        log(`dry-run: would update ${cliTargetPath} (memory rules block)`, options.quiet);
-        return;
-      }
-
-      if (updated !== existing) {
-        writeFileWithBackup(cliTargetPath, updated, options);
-      }
-      log(`installed: ${cliTargetPath} (CLI memory rules)`, options.quiet);
+  // CLI: <targetDir>/copilot-instructions.md (append AutoMem block using markers).
+  // Rendered and validated up front by prepareCliMemoryRules; this only writes.
+  if (installCli && cliRules) {
+    if (options.dryRun) {
+      log(`dry-run: would update ${cliRules.targetPath} (memory rules block)`, options.quiet);
+      return;
     }
+
+    if (cliRules.updated !== cliRules.existing) {
+      writeFileWithBackup(cliRules.targetPath, cliRules.updated, options);
+    }
+    log(`installed: ${cliRules.targetPath} (CLI memory rules)`, options.quiet);
   }
 }
 
@@ -536,6 +569,12 @@ export async function applyCopilotSetup(cliOptions: CopilotSetupOptions): Promis
 
   log(`Profile: ${profileName} (${profile.hooks.length} hooks)`, options.quiet);
 
+  // Everything that can reject the run happens before anything is written. A stray
+  // marker in copilot-instructions.md throws here, so a refused install has not yet
+  // removed a stale hook, written a new one, or replaced the VS Code rules — which is
+  // what makes the documented "nothing was written, so nothing needs undoing" true.
+  const cliRules = prepareCliMemoryRules(targetDir, options);
+
   // T032: Create target directories (including when --dir points to non-existent path)
   if (!options.dryRun) {
     fs.mkdirSync(path.join(targetDir, 'hooks'), { recursive: true });
@@ -565,7 +604,7 @@ export async function applyCopilotSetup(cliOptions: CopilotSetupOptions): Promis
   installSupportScripts(targetDir, options);
 
   // Install memory rules based on --format
-  installMemoryRules(targetDir, options);
+  installMemoryRules(targetDir, options, cliRules);
 
   // T021/T030: Post-installation summary (skip for dry-run - files listed inline already)
   const format = options.format ?? 'both';

--- a/src/cli/grok.test.ts
+++ b/src/cli/grok.test.ts
@@ -306,6 +306,43 @@ describe('grok setup', () => {
     expect(configBefore).not.toContain('https://other.example.test');
   });
 
+  // Two starts and one end: both markers are present and correctly ordered, so an
+  // indexOf-based check calls the file well-formed and replaces from the first start
+  // through the end — silently deleting the second marker and the user's notes.
+  it('refuses when the rules file has two start markers and one end', async () => {
+    const rulesPath = path.join(tmpDir, 'AGENTS.md');
+    const handWritten = [
+      '# My notes',
+      GROK_RULES_START,
+      'stale half-block',
+      GROK_RULES_START,
+      'notes the user wrote between the markers',
+      GROK_RULES_END,
+      '',
+    ].join('\n');
+    fs.writeFileSync(rulesPath, handWritten);
+
+    await expect(
+      applyGrokSetup({ endpoint: 'https://automem.example.test', quiet: true })
+    ).rejects.toThrow(/found 2 start markers and 1 end marker/);
+
+    expect(fs.readFileSync(rulesPath, 'utf8')).toBe(handWritten);
+  });
+
+  it('refuses when the end marker precedes the start marker', async () => {
+    const rulesPath = path.join(tmpDir, 'AGENTS.md');
+    const handWritten = ['# My notes', GROK_RULES_END, 'user content', GROK_RULES_START, ''].join(
+      '\n'
+    );
+    fs.writeFileSync(rulesPath, handWritten);
+
+    await expect(
+      applyGrokSetup({ endpoint: 'https://automem.example.test', quiet: true })
+    ).rejects.toThrow(/precedes/);
+
+    expect(fs.readFileSync(rulesPath, 'utf8')).toBe(handWritten);
+  });
+
   it('refuses on a stray end marker too', async () => {
     const rulesPath = path.join(tmpDir, 'AGENTS.md');
     fs.writeFileSync(rulesPath, ['# My notes', GROK_RULES_END, ''].join('\n'));

--- a/src/cli/grok.ts
+++ b/src/cli/grok.ts
@@ -5,9 +5,12 @@ import {
   CommonOptions,
   detectProjectName,
   log,
+  type MarkedBlockMarkers,
   parseCommonFlags,
   replaceTemplateVars,
   resolveInheritedApiKey,
+  stripMarkedBlock,
+  upsertMarkedBlock,
   writeFileWithBackup,
 } from './host-toolkit.js';
 import {
@@ -30,6 +33,7 @@ const TEMPLATE_ROOT = path.resolve(fileURLToPath(new URL('../../templates/grok',
 
 export const GROK_RULES_START = '<!-- BEGIN AUTOMEM GROK RULES -->';
 export const GROK_RULES_END = '<!-- END AUTOMEM GROK RULES -->';
+const GROK_RULES_MARKERS: MarkedBlockMarkers = { start: GROK_RULES_START, end: GROK_RULES_END };
 
 /**
  * Stands in for the project tag when the rules land in the global
@@ -37,10 +41,6 @@ export const GROK_RULES_END = '<!-- END AUTOMEM GROK RULES -->';
  * same reason: the file is not project-scoped, so no single slug can be correct.
  */
 export const GLOBAL_PROJECT_PLACEHOLDER = '<project-slug>';
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
 
 /**
  * Whether two paths name the same file. Resolves symlinks, because the global rules
@@ -67,68 +67,8 @@ function sameFile(a: string, b: string): boolean {
   return real(a) === real(b);
 }
 
-function countOccurrences(haystack: string, needle: string): number {
-  let count = 0;
-  let from = 0;
-  for (;;) {
-    const idx = haystack.indexOf(needle, from);
-    if (idx === -1) return count;
-    count += 1;
-    from = idx + needle.length;
-  }
-}
-
-function upsertRulesWithMarkers(existing: string | null, block: string, rulesPath: string): string {
-  const normalize = (s: string) => `${s.replace(/\n+$/, '')}\n`;
-  if (!existing) {
-    return normalize(block);
-  }
-  const starts = countOccurrences(existing, GROK_RULES_START);
-  const ends = countOccurrences(existing, GROK_RULES_END);
-
-  if (starts === 0 && ends === 0) {
-    const sep = existing.endsWith('\n') ? '\n' : '\n\n';
-    return normalize(`${existing}${sep}${block}`);
-  }
-
-  // Anything other than exactly one correctly ordered pair is refused rather than
-  // repaired. Every malformed shape here destroys user content if we replace anyway:
-  //
-  //  - One-sided (an interrupted run, or a hand edit that deleted half the block):
-  //    appending leaves one start and two ends, so the *next* run replaces everything
-  //    from the original start to the appended end.
-  //  - Two starts before one end: replacing from the first start through the end
-  //    deletes the second marker and whatever the user wrote between them — and the
-  //    file looks well-formed to a one-sided check, which is why counting is the test.
-  //
-  // Repairing these means guessing which side of a stray marker the user's content
-  // belongs to. That is their judgement to make, not ours.
-  const startIdx = existing.indexOf(GROK_RULES_START);
-  const endIdx = existing.indexOf(GROK_RULES_END);
-  const wellFormed = starts === 1 && ends === 1 && startIdx !== -1 && endIdx > startIdx;
-  if (!wellFormed) {
-    const detail =
-      starts === 1 && ends === 1
-        ? `its ${GROK_RULES_END} precedes its ${GROK_RULES_START}`
-        : `found ${starts} start and ${ends} end marker${ends === 1 ? '' : 's'}`;
-    throw new Error(
-      `${rulesPath} does not contain exactly one ${GROK_RULES_START} … ${GROK_RULES_END} block ` +
-        `(${detail}). Rewriting it would delete the content between the stray markers. ` +
-        'Restore or remove them (or point --rules elsewhere), then re-run.'
-    );
-  }
-
-  const before = existing.slice(0, startIdx);
-  const after = existing.slice(endIdx + GROK_RULES_END.length);
-  return normalize(`${before}${block}${after}`);
-}
-
 export function stripGrokRulesMarkers(existing: string): string {
-  const pattern = new RegExp(
-    `\\n?${escapeRegExp(GROK_RULES_START)}[\\s\\S]*?${escapeRegExp(GROK_RULES_END)}\\n?`,
-    'g'
-  );
-  return existing.replace(pattern, '\n').replace(/\n{3,}/g, '\n\n');
+  return stripMarkedBlock(existing, GROK_RULES_MARKERS);
 }
 
 export async function applyGrokSetup(cliOptions: GrokSetupOptions): Promise<void> {
@@ -179,8 +119,8 @@ export async function applyGrokSetup(cliOptions: GrokSetupOptions): Promise<void
   log(`📄 Rules: ${rulesPath}\n`, cliOptions.quiet);
 
   // Everything that can reject the run happens before anything is written. Both the
-  // rules content and the server entry are computed up front: upsertRulesWithMarkers
-  // throws on a one-sided marker, and building the entry is pure. Validating after the
+  // rules content and the server entry are computed up front: upsertMarkedBlock
+  // throws on a stray marker, and building the entry is pure. Validating after the
   // config write would leave a failed run having already replaced the live endpoint and
   // credentials while telling the user to repair their rules file and re-run.
   const templateContent = fs.readFileSync(path.join(TEMPLATE_ROOT, 'memory-rules.md'), 'utf8');
@@ -188,7 +128,7 @@ export async function applyGrokSetup(cliOptions: GrokSetupOptions): Promise<void
     PROJECT_NAME: rulesProjectName,
   });
   const existingContent = fs.existsSync(rulesPath) ? fs.readFileSync(rulesPath, 'utf8') : null;
-  const finalContent = upsertRulesWithMarkers(existingContent, processed, rulesPath);
+  const finalContent = upsertMarkedBlock(existingContent, processed, GROK_RULES_MARKERS, rulesPath);
   const entry = buildGrokAutoMemServerEntry(endpoint, apiKey);
 
   const result = upsertGrokMemoryServer(paths.configPath, entry, {

--- a/src/cli/hermes.test.ts
+++ b/src/cli/hermes.test.ts
@@ -651,6 +651,8 @@ describe('hermes setup handler', () => {
       expect(env.AUTOMEM_API_URL).toBe('https://legacy.example.test');
       expect(env.AUTOMEM_API_KEY).toBe('sk-legacy');
     });
+  });
+
   // Two starts and one end: both markers are present and correctly ordered, so an
   // indexOf-based check calls the file well-formed and replaces from the first start
   // through the end — silently deleting the second marker and the user's notes.
@@ -677,6 +679,58 @@ describe('hermes setup handler', () => {
     ).rejects.toThrow(/found 2 start markers and 1 end marker/);
 
     expect(fs.readFileSync(agentsPath, 'utf8')).toBe(handWritten);
+  });
+
+  // A rejected run must not leave Hermes half-reconfigured. Validation runs before the
+  // MCP entry, the memory provider, the .env, and the provider files are touched, so a
+  // failed mode switch really does leave the install as it was.
+  it('writes nothing at all when the rules file is rejected', async () => {
+    await applyHermesSetup({
+      mode: 'both',
+      targetDir: tmpDir,
+      projectName: 'test-project',
+      endpoint: 'https://live.example.test',
+      apiKey: 'sk-live',
+      quiet: true,
+    });
+
+    const configPath = path.join(tmpDir, 'config.yaml');
+    const envPath = path.join(tmpDir, '.env');
+    const providerPath = path.join(tmpDir, 'plugins', 'automem', '__init__.py');
+    const agentsPath = path.join(tmpDir, 'AGENTS.md');
+    const configBefore = fs.readFileSync(configPath, 'utf8');
+    const envBefore = fs.readFileSync(envPath, 'utf8');
+    const providerBefore = fs.readFileSync(providerPath, 'utf8');
+
+    // Now break the rules file and re-run as a different mode against another host.
+    const handWritten = [
+      '# Notes',
+      '<!-- BEGIN AUTOMEM HERMES RULES -->',
+      'stale half-block',
+      '<!-- BEGIN AUTOMEM HERMES RULES -->',
+      'notes the user wrote between the markers',
+      '<!-- END AUTOMEM HERMES RULES -->',
+      '',
+    ].join('\n');
+    fs.writeFileSync(agentsPath, handWritten);
+
+    await expect(
+      applyHermesSetup({
+        mode: 'mcp',
+        targetDir: tmpDir,
+        projectName: 'test-project',
+        endpoint: 'https://other.example.test',
+        apiKey: 'sk-other',
+        quiet: true,
+      })
+    ).rejects.toThrow(/found 2 start markers and 1 end marker/);
+
+    expect(fs.readFileSync(configPath, 'utf8')).toBe(configBefore);
+    expect(fs.readFileSync(envPath, 'utf8')).toBe(envBefore);
+    expect(fs.readFileSync(providerPath, 'utf8')).toBe(providerBefore);
+    expect(fs.readFileSync(agentsPath, 'utf8')).toBe(handWritten);
+    expect(configBefore).toContain('https://live.example.test');
+    expect(configBefore).not.toContain('https://other.example.test');
   });
 
   it('refuses a one-sided Hermes marker instead of appending', async () => {

--- a/src/cli/hermes.test.ts
+++ b/src/cli/hermes.test.ts
@@ -651,5 +651,87 @@ describe('hermes setup handler', () => {
       expect(env.AUTOMEM_API_URL).toBe('https://legacy.example.test');
       expect(env.AUTOMEM_API_KEY).toBe('sk-legacy');
     });
+  // Two starts and one end: both markers are present and correctly ordered, so an
+  // indexOf-based check calls the file well-formed and replaces from the first start
+  // through the end — silently deleting the second marker and the user's notes.
+  it('refuses when the rules file has two start markers and one end', async () => {
+    const agentsPath = path.join(tmpDir, 'AGENTS.md');
+    const handWritten = [
+      '# Existing Hermes Rules',
+      '<!-- BEGIN AUTOMEM HERMES RULES -->',
+      'stale half-block',
+      '<!-- BEGIN AUTOMEM HERMES RULES -->',
+      'notes the user wrote between the markers',
+      '<!-- END AUTOMEM HERMES RULES -->',
+      '',
+    ].join('\n');
+    fs.writeFileSync(agentsPath, handWritten);
+
+    await expect(
+      applyHermesSetup({
+        targetDir: tmpDir,
+        projectName: 'test-project',
+        endpoint: 'https://example.automem.test',
+        quiet: true,
+      })
+    ).rejects.toThrow(/found 2 start markers and 1 end marker/);
+
+    expect(fs.readFileSync(agentsPath, 'utf8')).toBe(handWritten);
+  });
+
+  it('refuses a one-sided Hermes marker instead of appending', async () => {
+    const agentsPath = path.join(tmpDir, 'AGENTS.md');
+    const handWritten = ['# Notes', '<!-- BEGIN AUTOMEM HERMES RULES -->', 'half a block', ''].join(
+      '\n'
+    );
+    fs.writeFileSync(agentsPath, handWritten);
+
+    await expect(
+      applyHermesSetup({
+        targetDir: tmpDir,
+        projectName: 'test-project',
+        endpoint: 'https://example.automem.test',
+        quiet: true,
+      })
+    ).rejects.toThrow(/without a matching/);
+
+    expect(fs.readFileSync(agentsPath, 'utf8')).toBe(handWritten);
+  });
+
+  // Dropping the legacy Codex block is a migration, not this run's responsibility. A
+  // stray Codex marker must not block the Hermes install — the Codex block is simply
+  // left alone, markers and all, for the user to sort out.
+  it('installs anyway when a stale Codex block has a stray marker', async () => {
+    const agentsPath = path.join(tmpDir, 'AGENTS.md');
+    fs.writeFileSync(
+      agentsPath,
+      [
+        '# Existing Hermes Rules',
+        '',
+        '<!-- BEGIN AUTOMEM CODEX RULES -->',
+        'stale codex guidance',
+        '<!-- BEGIN AUTOMEM CODEX RULES -->',
+        'notes the user wrote between the markers',
+        '<!-- END AUTOMEM CODEX RULES -->',
+        '',
+        'Keep this unrelated Hermes rule.',
+        '',
+      ].join('\n')
+    );
+
+    await applyHermesSetup({
+      mode: 'provider',
+      targetDir: tmpDir,
+      projectName: 'test-project',
+      endpoint: 'https://example.automem.test',
+      quiet: true,
+    });
+
+    const agents = fs.readFileSync(agentsPath, 'utf8');
+    expect(agents).toContain('<!-- BEGIN AUTOMEM HERMES RULES -->');
+    expect(agents).toContain('Keep this unrelated Hermes rule.');
+    // Nothing between the stray Codex markers was taken along with the migration.
+    expect(agents).toContain('notes the user wrote between the markers');
+    expect(agents).toContain('<!-- END AUTOMEM CODEX RULES -->');
   });
 });

--- a/src/cli/hermes.ts
+++ b/src/cli/hermes.ts
@@ -236,6 +236,23 @@ export async function applyHermesSetup(cliOptions: HermesSetupOptions): Promise<
   log(`📄 Config: ${paths.configPath}`, cliOptions.quiet);
   log(`📄 Rules: ${rulesPath}\n`, cliOptions.quiet);
 
+  // Everything that can reject the run happens before anything is written, matching
+  // applyGrokSetup. upsertRulesWithMarkers throws on a stray marker, and rendering the
+  // template is pure — so validating here is what makes "nothing was written" true.
+  // Validating after the config write would leave a failed mode switch having already
+  // moved the MCP entry, the memory provider, the .env, and the provider files while
+  // telling the user to repair their rules file and re-run.
+  const templateContent = fs.readFileSync(
+    path.join(HERMES_TEMPLATE_ROOT, 'memory-rules.md'),
+    'utf8'
+  );
+  const processed = replaceTemplateVars(templateContent, {
+    PROJECT_NAME: projectName,
+    HERMES_MODE_RULES: renderHermesModeRules(mode),
+  });
+  const existingContent = fs.existsSync(rulesPath) ? fs.readFileSync(rulesPath, 'utf8') : null;
+  const finalContent = upsertRulesWithMarkers(existingContent, processed, rulesPath);
+
   if (mode === 'provider') {
     removeMcpServerEntry(paths.configPath, HERMES_MCP_SERVER_NAME, {
       dryRun: cliOptions.dryRun,
@@ -289,17 +306,6 @@ export async function applyHermesSetup(cliOptions: HermesSetupOptions): Promise<
     installHermesProvider(paths, endpoint, apiKey, mode === 'provider', cliOptions);
   }
 
-  const templateContent = fs.readFileSync(
-    path.join(HERMES_TEMPLATE_ROOT, 'memory-rules.md'),
-    'utf8'
-  );
-  const processed = replaceTemplateVars(templateContent, {
-    PROJECT_NAME: projectName,
-    HERMES_MODE_RULES: renderHermesModeRules(mode),
-  });
-
-  const existingContent = fs.existsSync(rulesPath) ? fs.readFileSync(rulesPath, 'utf8') : null;
-  const finalContent = upsertRulesWithMarkers(existingContent, processed, rulesPath);
   writeFileWithBackup(rulesPath, finalContent, cliOptions);
 
   log('\n📊 Configuration Status:', cliOptions.quiet);

--- a/src/cli/hermes.ts
+++ b/src/cli/hermes.ts
@@ -45,8 +45,8 @@ const HERMES_TEMPLATE_ROOT = path.resolve(
 const HERMES_PROVIDER_TEMPLATE_ROOT = path.join(HERMES_TEMPLATE_ROOT, 'provider');
 const HERMES_MCP_SERVER_NAME = 'automem';
 const HERMES_PROVIDER_NAME = 'automem';
-const HERMES_RULES_START = '<!-- BEGIN AUTOMEM HERMES RULES -->';
-const HERMES_RULES_END = '<!-- END AUTOMEM HERMES RULES -->';
+export const HERMES_RULES_START = '<!-- BEGIN AUTOMEM HERMES RULES -->';
+export const HERMES_RULES_END = '<!-- END AUTOMEM HERMES RULES -->';
 const HERMES_RULES_MARKERS: MarkedBlockMarkers = {
   start: HERMES_RULES_START,
   end: HERMES_RULES_END,

--- a/src/cli/hermes.ts
+++ b/src/cli/hermes.ts
@@ -5,14 +5,19 @@ import {
   CommonOptions,
   detectProjectName,
   log,
+  type MarkedBlockMarkers,
   parseCommonFlags,
   replaceTemplateVars,
   AUTOMEM_API_KEY_NAMES,
   AUTOMEM_ENDPOINT_NAMES,
   parseEnvAssignment,
   resolveInheritedApiKey,
+  scanMarkedBlock,
+  stripMarkedBlock,
+  upsertMarkedBlock,
   writeFileWithBackup,
 } from './host-toolkit.js';
+import { CODEX_RULES_MARKERS } from './codex.js';
 import {
   buildAutoMemServerEntry,
   readExistingHermesCredentials,
@@ -42,35 +47,22 @@ const HERMES_MCP_SERVER_NAME = 'automem';
 const HERMES_PROVIDER_NAME = 'automem';
 const HERMES_RULES_START = '<!-- BEGIN AUTOMEM HERMES RULES -->';
 const HERMES_RULES_END = '<!-- END AUTOMEM HERMES RULES -->';
-const CODEX_RULES_START = '<!-- BEGIN AUTOMEM CODEX RULES -->';
-const CODEX_RULES_END = '<!-- END AUTOMEM CODEX RULES -->';
+const HERMES_RULES_MARKERS: MarkedBlockMarkers = {
+  start: HERMES_RULES_START,
+  end: HERMES_RULES_END,
+};
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function removeMarkedBlocks(existing: string, start: string, end: string): string {
-  const pattern = new RegExp(`\\n?${escapeRegExp(start)}[\\s\\S]*?${escapeRegExp(end)}\\n?`, 'g');
-  return existing.replace(pattern, '\n').replace(/\n{3,}/g, '\n\n');
-}
-
-function upsertRulesWithMarkers(existing: string | null, block: string): string {
-  // Normalize to exactly one trailing newline so re-runs are byte-stable
-  // (the previous codex.ts shape accreted a newline each merge).
-  const normalize = (s: string) => `${s.replace(/\n+$/, '')}\n`;
+function upsertRulesWithMarkers(existing: string | null, block: string, rulesPath: string): string {
   if (!existing) {
-    return normalize(block);
+    return upsertMarkedBlock(null, block, HERMES_RULES_MARKERS, rulesPath);
   }
-  const cleaned = removeMarkedBlocks(existing, CODEX_RULES_START, CODEX_RULES_END);
-  const startIdx = cleaned.indexOf(HERMES_RULES_START);
-  const endIdx = cleaned.indexOf(HERMES_RULES_END);
-  if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
-    const before = cleaned.slice(0, startIdx);
-    const after = cleaned.slice(endIdx + HERMES_RULES_END.length);
-    return normalize(`${before}${block}${after}`);
-  }
-  const sep = cleaned.endsWith('\n') ? '\n' : '\n\n';
-  return normalize(`${cleaned}${sep}${block}`);
+  // Hermes used to install the Codex rules into this same file. Dropping that block is
+  // a best-effort migration, so a malformed Codex pair is left alone rather than made
+  // fatal — the Hermes block is what this run is responsible for, and refusing the
+  // install over someone else's stray marker helps nobody.
+  const codexScan = scanMarkedBlock(existing, CODEX_RULES_MARKERS);
+  const cleaned = codexScan.paired ? stripMarkedBlock(existing, CODEX_RULES_MARKERS) : existing;
+  return upsertMarkedBlock(cleaned, block, HERMES_RULES_MARKERS, rulesPath);
 }
 
 function formatEnvValue(value: string): string {
@@ -307,7 +299,7 @@ export async function applyHermesSetup(cliOptions: HermesSetupOptions): Promise<
   });
 
   const existingContent = fs.existsSync(rulesPath) ? fs.readFileSync(rulesPath, 'utf8') : null;
-  const finalContent = upsertRulesWithMarkers(existingContent, processed);
+  const finalContent = upsertRulesWithMarkers(existingContent, processed, rulesPath);
   writeFileWithBackup(rulesPath, finalContent, cliOptions);
 
   log('\n📊 Configuration Status:', cliOptions.quiet);

--- a/src/cli/host-toolkit.test.ts
+++ b/src/cli/host-toolkit.test.ts
@@ -356,6 +356,16 @@ describe('host-toolkit', () => {
       expect(third).toBe(first);
     });
 
+    // The installer always writes `END\n`, but a hand-edited file can put text right
+    // after the end marker. Trimming the block's own newline must not run the marker
+    // into that line.
+    it('keeps the end marker on its own line when text follows it immediately', () => {
+      const existing = `${MARKERS.start}\nold\n${MARKERS.end}trailing text\n`;
+      const result = upsertMarkedBlock(existing, BLOCK, MARKERS, 'rules.md');
+      expect(result).toBe(`${MARKERS.start}\nrules body\n${MARKERS.end}\ntrailing text\n`);
+      expect(upsertMarkedBlock(result, BLOCK, MARKERS, 'rules.md')).toBe(result);
+    });
+
     it('refuses two start markers and one end', () => {
       const existing = [MARKERS.start, 'stale', MARKERS.start, 'user notes', MARKERS.end, ''].join(
         '\n'

--- a/src/cli/host-toolkit.test.ts
+++ b/src/cli/host-toolkit.test.ts
@@ -4,6 +4,7 @@ import os from 'os';
 import path from 'path';
 import {
   backupPath,
+  describeMarkedBlockDefect,
   detectProjectName,
   formatEnvValue,
   isAutoMemServerEntry,
@@ -16,8 +17,14 @@ import {
   replaceTemplateVars,
   parseEnvAssignment,
   resolveInheritedApiKey,
+  scanMarkedBlock,
+  stripMarkedBlock,
+  upsertMarkedBlock,
   writeFileWithBackup,
 } from './host-toolkit.js';
+
+const MARKERS = { start: '<!-- BEGIN TEST RULES -->', end: '<!-- END TEST RULES -->' };
+const BLOCK = `${MARKERS.start}\nrules body\n${MARKERS.end}\n`;
 
 describe('host-toolkit', () => {
   let tmpDir: string;
@@ -266,6 +273,153 @@ describe('host-toolkit', () => {
         expect(fs.statSync(backup).mode & 0o777).toBe(0o600);
       }
     );
+  });
+
+  describe('scanMarkedBlock', () => {
+    it('reports an untouched file as absent', () => {
+      const scan = scanMarkedBlock('# Notes\n', MARKERS);
+      expect(scan).toMatchObject({ starts: 0, ends: 0, absent: true, paired: false });
+    });
+
+    it('reports one ordered pair as a single block', () => {
+      const scan = scanMarkedBlock(`# Notes\n\n${BLOCK}`, MARKERS);
+      expect(scan).toMatchObject({ starts: 1, ends: 1, paired: true, singlePair: true });
+    });
+
+    it('counts repeated markers instead of stopping at the first', () => {
+      const content = [MARKERS.start, 'first', MARKERS.start, 'second', MARKERS.end, ''].join('\n');
+      const scan = scanMarkedBlock(content, MARKERS);
+      // Both markers are present, so an indexOf check calls this well-formed. The
+      // counts are what make it refusable.
+      expect(scan.startIndex).not.toBe(-1);
+      expect(scan.endIndex).toBeGreaterThan(scan.startIndex);
+      expect(scan).toMatchObject({ starts: 2, ends: 1, paired: false, singlePair: false });
+    });
+
+    it('rejects a reversed pair', () => {
+      const scan = scanMarkedBlock(`${MARKERS.end}\nbody\n${MARKERS.start}\n`, MARKERS);
+      expect(scan).toMatchObject({ starts: 1, ends: 1, paired: false, singlePair: false });
+    });
+
+    it('accepts two properly nested pairs as paired but not a single block', () => {
+      const scan = scanMarkedBlock(`${BLOCK}\n${BLOCK}`, MARKERS);
+      expect(scan).toMatchObject({ starts: 2, ends: 2, paired: true, singlePair: false });
+    });
+
+    it('rejects two pairs whose markers interleave out of order', () => {
+      const content = [MARKERS.start, 'a', MARKERS.start, 'b', MARKERS.end, MARKERS.end, ''].join(
+        '\n'
+      );
+      expect(scanMarkedBlock(content, MARKERS)).toMatchObject({
+        starts: 2,
+        ends: 2,
+        paired: false,
+      });
+    });
+  });
+
+  describe('upsertMarkedBlock', () => {
+    it('writes the block with one trailing newline into a new file', () => {
+      expect(upsertMarkedBlock(null, BLOCK, MARKERS, 'rules.md')).toBe(
+        `${MARKERS.start}\nrules body\n${MARKERS.end}\n`
+      );
+    });
+
+    it('appends below unrelated content', () => {
+      const result = upsertMarkedBlock('# Notes\n', BLOCK, MARKERS, 'rules.md');
+      expect(result).toBe(`# Notes\n\n${MARKERS.start}\nrules body\n${MARKERS.end}\n`);
+    });
+
+    it('replaces an existing block and is byte-stable across re-runs', () => {
+      const first = upsertMarkedBlock('# Notes\n', BLOCK, MARKERS, 'rules.md');
+      const second = upsertMarkedBlock(first, BLOCK, MARKERS, 'rules.md');
+      expect(second).toBe(first);
+      const third = upsertMarkedBlock(second, BLOCK, MARKERS, 'rules.md');
+      expect(third).toBe(second);
+    });
+
+    it('keeps content that follows the block', () => {
+      const existing = `# Top\n\n${MARKERS.start}\nold\n${MARKERS.end}\n\n# Bottom\n`;
+      const result = upsertMarkedBlock(existing, BLOCK, MARKERS, 'rules.md');
+      expect(result).toBe(`# Top\n\n${MARKERS.start}\nrules body\n${MARKERS.end}\n\n# Bottom\n`);
+    });
+
+    // Normalizing only the end of the file hides a growing seam: the block template
+    // ends with a newline and `after` opens with one, so a naive join adds a blank
+    // line per run to every file that has content below the block.
+    it('is byte-stable across re-runs when content follows the block', () => {
+      const existing = `# Top\n\n${MARKERS.start}\nold\n${MARKERS.end}\n\n# Bottom\n`;
+      const first = upsertMarkedBlock(existing, BLOCK, MARKERS, 'rules.md');
+      const second = upsertMarkedBlock(first, BLOCK, MARKERS, 'rules.md');
+      const third = upsertMarkedBlock(second, BLOCK, MARKERS, 'rules.md');
+      expect(second).toBe(first);
+      expect(third).toBe(first);
+    });
+
+    it('refuses two start markers and one end', () => {
+      const existing = [MARKERS.start, 'stale', MARKERS.start, 'user notes', MARKERS.end, ''].join(
+        '\n'
+      );
+      expect(() => upsertMarkedBlock(existing, BLOCK, MARKERS, 'rules.md')).toThrow(
+        /found 2 start markers and 1 end marker/
+      );
+    });
+
+    it('refuses a one-sided start marker', () => {
+      expect(() =>
+        upsertMarkedBlock(`# Notes\n${MARKERS.start}\nhalf\n`, BLOCK, MARKERS, 'rules.md')
+      ).toThrow(/without a matching/);
+    });
+
+    it('refuses a one-sided end marker', () => {
+      expect(() =>
+        upsertMarkedBlock(`# Notes\n${MARKERS.end}\n`, BLOCK, MARKERS, 'rules.md')
+      ).toThrow(/without a matching/);
+    });
+
+    it('refuses a reversed pair', () => {
+      expect(() =>
+        upsertMarkedBlock(`${MARKERS.end}\nbody\n${MARKERS.start}\n`, BLOCK, MARKERS, 'rules.md')
+      ).toThrow(/precedes/);
+    });
+
+    it('refuses two complete blocks rather than picking one', () => {
+      expect(() => upsertMarkedBlock(`${BLOCK}\n${BLOCK}`, BLOCK, MARKERS, 'rules.md')).toThrow(
+        /found 2 start markers and 2 end markers/
+      );
+    });
+
+    it('names the file in the error so the user knows what to repair', () => {
+      expect(() =>
+        upsertMarkedBlock(`${MARKERS.start}\n`, BLOCK, MARKERS, '/tmp/AGENTS.md')
+      ).toThrow(/\/tmp\/AGENTS\.md/);
+    });
+  });
+
+  describe('stripMarkedBlock', () => {
+    it('removes the block and collapses the blank lines left behind', () => {
+      const existing = `# Top\n\n${BLOCK}\n# Bottom\n`;
+      expect(stripMarkedBlock(existing, MARKERS)).toBe('# Top\n\n# Bottom\n');
+    });
+
+    it('leaves content without markers alone', () => {
+      expect(stripMarkedBlock('# Top\n', MARKERS)).toBe('# Top\n');
+    });
+
+    it('removes every properly paired block', () => {
+      expect(stripMarkedBlock(`# Top\n\n${BLOCK}\n${BLOCK}\n# Bottom\n`, MARKERS)).toBe(
+        '# Top\n\n# Bottom\n'
+      );
+    });
+  });
+
+  describe('describeMarkedBlockDefect', () => {
+    it('singularizes a lone marker count', () => {
+      const scan = scanMarkedBlock(`${MARKERS.start}\n${MARKERS.start}\n${MARKERS.end}\n`, MARKERS);
+      expect(describeMarkedBlockDefect(scan, MARKERS)).toBe(
+        'found 2 start markers and 1 end marker'
+      );
+    });
   });
 });
 

--- a/src/cli/host-toolkit.ts
+++ b/src/cli/host-toolkit.ts
@@ -347,6 +347,178 @@ export function replaceTemplateVars(content: string, vars: Record<string, string
   return result;
 }
 
+// --- Marked rules blocks -----------------------------------------------------
+//
+// Every host installs its memory rules as a marked block inside a Markdown file the
+// user also owns (AGENTS.md, copilot-instructions.md). The markers are the only thing
+// telling an installer which bytes are its own, so the shape of the markers in the
+// file is a correctness question, not a formatting one — see upsertMarkedBlock.
+
+export interface MarkedBlockMarkers {
+  start: string;
+  end: string;
+}
+
+export interface MarkedBlockScan {
+  /** Occurrences of the start marker. */
+  starts: number;
+  /** Occurrences of the end marker. */
+  ends: number;
+  /** Index of the first start marker, or -1 when there is none. */
+  startIndex: number;
+  /** Index of the first end marker, or -1 when there is none. */
+  endIndex: number;
+  /** Neither marker appears anywhere in the content. */
+  absent: boolean;
+  /**
+   * Markers alternate start, end, start, end … in equal numbers, with at least one
+   * pair. Every start then owns its own end, so removing the marked regions cannot
+   * swallow a stray marker or the user's content around it.
+   */
+  paired: boolean;
+  /** `paired` with exactly one pair — the only shape an upsert is allowed to rewrite. */
+  singlePair: boolean;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function indicesOf(haystack: string, needle: string): number[] {
+  const found: number[] = [];
+  let from = 0;
+  for (;;) {
+    const idx = haystack.indexOf(needle, from);
+    if (idx === -1) return found;
+    found.push(idx);
+    from = idx + needle.length;
+  }
+}
+
+function countOf(n: number, noun: string): string {
+  return `${n} ${noun}${n === 1 ? '' : 's'}`;
+}
+
+/**
+ * Count and order the markers in `content`. Counting is the point: a file holding two
+ * start markers and one end contains both markers, so an `indexOf`-based check calls it
+ * well-formed and replaces from the first start through the end — silently deleting the
+ * second marker and everything the user wrote between them.
+ */
+export function scanMarkedBlock(content: string, markers: MarkedBlockMarkers): MarkedBlockScan {
+  const startPositions = indicesOf(content, markers.start);
+  const endPositions = indicesOf(content, markers.end);
+  const starts = startPositions.length;
+  const ends = endPositions.length;
+
+  let paired = starts === ends && starts >= 1;
+  for (let i = 0; paired && i < starts; i += 1) {
+    const nextStart = i + 1 < starts ? startPositions[i + 1] : Number.POSITIVE_INFINITY;
+    paired = startPositions[i] < endPositions[i] && endPositions[i] < nextStart;
+  }
+
+  return {
+    starts,
+    ends,
+    startIndex: starts ? startPositions[0] : -1,
+    endIndex: ends ? endPositions[0] : -1,
+    absent: starts === 0 && ends === 0,
+    paired,
+    singlePair: paired && starts === 1,
+  };
+}
+
+/** Human-readable reason a scan is neither `absent` nor usable, for errors and warnings. */
+export function describeMarkedBlockDefect(
+  scan: MarkedBlockScan,
+  markers: MarkedBlockMarkers
+): string {
+  if (scan.starts > 0 && scan.ends === 0) {
+    return `it has ${markers.start} without a matching ${markers.end}`;
+  }
+  if (scan.ends > 0 && scan.starts === 0) {
+    return `it has ${markers.end} without a matching ${markers.start}`;
+  }
+  if (scan.starts === 1 && scan.ends === 1) {
+    return `its ${markers.end} precedes its ${markers.start}`;
+  }
+  if (scan.starts === scan.ends && !scan.paired) {
+    return `its ${markers.start} and ${markers.end} markers do not pair up in order`;
+  }
+  return `found ${countOf(scan.starts, 'start marker')} and ${countOf(scan.ends, 'end marker')}`;
+}
+
+/**
+ * Insert `block` into `existing`, replacing the marked block already there.
+ *
+ * Anything other than a clean file (no markers → append) or exactly one correctly
+ * ordered pair (→ replace) is refused rather than repaired, because every other shape
+ * destroys user content if rewritten anyway:
+ *
+ *  - One-sided (an interrupted run, or a hand edit that deleted half the block):
+ *    appending leaves one start and two ends, so the *next* run replaces everything
+ *    from the original start to the appended end.
+ *  - Two starts before one end: replacing from the first start through the end deletes
+ *    the second marker and whatever the user wrote between them — and the file looks
+ *    well-formed to an `indexOf` check, which is why counting is the test.
+ *
+ * Repairing these means guessing which side of a stray marker the user's content belongs
+ * on. That is their judgement to make, not ours.
+ *
+ * Output is normalized to exactly one trailing newline so re-runs are byte-stable.
+ */
+export function upsertMarkedBlock(
+  existing: string | null,
+  block: string,
+  markers: MarkedBlockMarkers,
+  filePath: string
+): string {
+  const normalize = (value: string): string => `${value.replace(/\n+$/, '')}\n`;
+  if (!existing) {
+    return normalize(block);
+  }
+
+  const scan = scanMarkedBlock(existing, markers);
+  if (scan.absent) {
+    const sep = existing.endsWith('\n') ? '\n' : '\n\n';
+    return normalize(`${existing}${sep}${block}`);
+  }
+
+  if (!scan.singlePair) {
+    throw new Error(
+      `${filePath} does not contain exactly one ${markers.start} … ${markers.end} block ` +
+        `(${describeMarkedBlockDefect(scan, markers)}). Rewriting it would delete the content ` +
+        'between the stray markers. Restore or remove them (or point the rules path ' +
+        'elsewhere), then re-run.'
+    );
+  }
+
+  const before = existing.slice(0, scan.startIndex);
+  const after = existing.slice(scan.endIndex + markers.end.length);
+  // `after` opens with whatever separated the old block from the content below it, and
+  // the block template carries its own trailing newline. Joining both blindly inserts
+  // one more blank line every single run — normalizing only the end of the file hides
+  // that when the block is last and lets it grow forever when it is not.
+  return normalize(`${before}${block.replace(/\n+$/, '')}${after}`);
+}
+
+/**
+ * Remove every marked region from `content`, collapsing the blank lines left behind.
+ *
+ * Only safe on content whose scan reports `paired` — on a stray marker this walks from
+ * a start to the *next* end and takes the user's content in between with it. Callers
+ * check `scanMarkedBlock(...).paired` first and decide what an unpaired file means for
+ * them. Trailing-newline shape is left to the caller, which is the only part that
+ * differs between the hosts.
+ */
+export function stripMarkedBlock(content: string, markers: MarkedBlockMarkers): string {
+  const pattern = new RegExp(
+    `\\n?${escapeRegExp(markers.start)}[\\s\\S]*?${escapeRegExp(markers.end)}\\n?`,
+    'g'
+  );
+  return content.replace(pattern, '\n').replace(/\n{3,}/g, '\n\n');
+}
+
 export function detectProjectName(cwd: string = process.cwd()): string {
   // 1) package.json name
   const pkgPath = path.join(cwd, 'package.json');

--- a/src/cli/host-toolkit.ts
+++ b/src/cli/host-toolkit.ts
@@ -498,8 +498,11 @@ export function upsertMarkedBlock(
   // `after` opens with whatever separated the old block from the content below it, and
   // the block template carries its own trailing newline. Joining both blindly inserts
   // one more blank line every single run — normalizing only the end of the file hides
-  // that when the block is last and lets it grow forever when it is not.
-  return normalize(`${before}${block.replace(/\n+$/, '')}${after}`);
+  // that when the block is last and lets it grow forever when it is not. Dropping the
+  // block's newline needs `after` to supply one, which a hand-edited file may not, so
+  // the seam puts one back rather than running the end marker into the next line.
+  const seam = after && !after.startsWith('\n') ? '\n' : '';
+  return normalize(`${before}${block.replace(/\n+$/, '')}${seam}${after}`);
 }
 
 /**

--- a/src/cli/openclaw.test.ts
+++ b/src/cli/openclaw.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   allowAutoMemTools,
   allowPluginWhenAllowlistExists,
@@ -20,6 +20,9 @@ import {
   redactConfigForOutput,
   replaceOpenClawMemorySystem,
   resolveApiKey,
+  cleanOldAgentsBlock,
+  OPENCLAW_RULES_END,
+  OPENCLAW_RULES_START,
 } from './openclaw.js';
 import fs from 'fs';
 import os from 'os';
@@ -770,5 +773,107 @@ describe('openclaw stored-key pairing in config builders', () => {
       defaultTags: [],
     });
     expect(entry.apiKey).toBe('sk-same');
+describe('cleanOldAgentsBlock', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openclaw-agents-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const setupOptions = { mode: 'plugin', scope: 'workspace', quiet: true } as const;
+
+  it('removes a well-formed legacy block and keeps the surrounding content', () => {
+    const agentsPath = path.join(tmpDir, 'AGENTS.md');
+    fs.writeFileSync(
+      agentsPath,
+      [
+        '# Workspace notes',
+        '',
+        OPENCLAW_RULES_START,
+        'stale automem guidance',
+        OPENCLAW_RULES_END,
+        '',
+        '# Keep this',
+        '',
+      ].join('\n')
+    );
+
+    expect(cleanOldAgentsBlock(tmpDir, setupOptions)).toBe(true);
+
+    const content = fs.readFileSync(agentsPath, 'utf8');
+    expect(content).toBe('# Workspace notes\n\n# Keep this\n');
+  });
+
+  it('reports nothing to do when the file has no AutoMem markers', () => {
+    const agentsPath = path.join(tmpDir, 'AGENTS.md');
+    fs.writeFileSync(agentsPath, '# Workspace notes\n');
+
+    expect(cleanOldAgentsBlock(tmpDir, setupOptions)).toBe(false);
+    expect(fs.readFileSync(agentsPath, 'utf8')).toBe('# Workspace notes\n');
+  });
+
+  // Stripping walks from a start to the *next* end, so on two starts and one end it
+  // takes the second marker and everything the user wrote between them.
+  it('leaves the file alone when it has two start markers and one end', () => {
+    const agentsPath = path.join(tmpDir, 'AGENTS.md');
+    const handWritten = [
+      '# Workspace notes',
+      OPENCLAW_RULES_START,
+      'stale half-block',
+      OPENCLAW_RULES_START,
+      'notes the user wrote between the markers',
+      OPENCLAW_RULES_END,
+      '',
+    ].join('\n');
+    fs.writeFileSync(agentsPath, handWritten);
+
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => void warnings.push(args.join(' '));
+    try {
+      expect(cleanOldAgentsBlock(tmpDir, setupOptions)).toBe(false);
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(fs.readFileSync(agentsPath, 'utf8')).toBe(handWritten);
+    expect(warnings.join('\n')).toMatch(/found 2 start markers and 1 end marker/);
+  });
+
+  it('leaves the file alone when the end marker precedes the start marker', () => {
+    const agentsPath = path.join(tmpDir, 'AGENTS.md');
+    const handWritten = [
+      '# Workspace notes',
+      OPENCLAW_RULES_END,
+      'user content',
+      OPENCLAW_RULES_START,
+      '',
+    ].join('\n');
+    fs.writeFileSync(agentsPath, handWritten);
+
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => void warnings.push(args.join(' '));
+    try {
+      expect(cleanOldAgentsBlock(tmpDir, setupOptions)).toBe(false);
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(fs.readFileSync(agentsPath, 'utf8')).toBe(handWritten);
+    expect(warnings.join('\n')).toMatch(/precedes/);
+  });
+
+  it('writes nothing in dry-run mode', () => {
+    const agentsPath = path.join(tmpDir, 'AGENTS.md');
+    const original = [OPENCLAW_RULES_START, 'stale', OPENCLAW_RULES_END, ''].join('\n');
+    fs.writeFileSync(agentsPath, original);
+
+    expect(cleanOldAgentsBlock(tmpDir, { ...setupOptions, dryRun: true })).toBe(true);
+    expect(fs.readFileSync(agentsPath, 'utf8')).toBe(original);
   });
 });

--- a/src/cli/openclaw.test.ts
+++ b/src/cli/openclaw.test.ts
@@ -773,6 +773,9 @@ describe('openclaw stored-key pairing in config builders', () => {
       defaultTags: [],
     });
     expect(entry.apiKey).toBe('sk-same');
+  });
+});
+
 describe('cleanOldAgentsBlock', () => {
   let tmpDir: string;
 

--- a/src/cli/openclaw.ts
+++ b/src/cli/openclaw.ts
@@ -8,12 +8,23 @@ import { buildDefaultProjectTags } from '../memory-policy/shared.js';
 import { buildStartupProfileFromResults } from '../openclaw-startup-profile.js';
 import {
   AUTOMEM_API_KEY_NAMES,
+  describeMarkedBlockDefect,
   readApiKeyFrom,
   readEndpointFrom,
   resolveInheritedApiKey,
   sameEndpoint,
+  scanMarkedBlock,
+  stripMarkedBlock,
+  type MarkedBlockMarkers,
 } from './host-toolkit.js';
 import { DEFAULT_AUTOMEM_API_URL } from './templates.js';
+
+export const OPENCLAW_RULES_START = '<!-- BEGIN AUTOMEM OPENCLAW RULES -->';
+export const OPENCLAW_RULES_END = '<!-- END AUTOMEM OPENCLAW RULES -->';
+const OPENCLAW_RULES_MARKERS: MarkedBlockMarkers = {
+  start: OPENCLAW_RULES_START,
+  end: OPENCLAW_RULES_END,
+};
 
 export type OpenClawSetupMode = 'plugin' | 'mcp' | 'skill';
 export type OpenClawSetupScope = 'workspace' | 'shared';
@@ -430,19 +441,27 @@ function readMcporterConfig(configPath: string): JsonObject {
 /**
  * Remove old AGENTS.md AutoMem block if present from previous installs.
  */
-function cleanOldAgentsBlock(workspaceDir: string, options: OpenClawSetupOptions): boolean {
+export function cleanOldAgentsBlock(workspaceDir: string, options: OpenClawSetupOptions): boolean {
   const agentsPath = path.join(workspaceDir, 'AGENTS.md');
   if (!fs.existsSync(agentsPath)) {
     return false;
   }
 
   const content = fs.readFileSync(agentsPath, 'utf8');
-  const startMarker = '<!-- BEGIN AUTOMEM OPENCLAW RULES -->';
-  const endMarker = '<!-- END AUTOMEM OPENCLAW RULES -->';
-  const startIndex = content.indexOf(startMarker);
-  const endIndex = content.indexOf(endMarker);
+  const scan = scanMarkedBlock(content, OPENCLAW_RULES_MARKERS);
 
-  if (startIndex === -1 || endIndex === -1 || endIndex <= startIndex) {
+  if (scan.absent) {
+    return false;
+  }
+
+  if (!scan.paired) {
+    // Stripping across a stray marker walks from a start to the *next* end and takes
+    // the user's content in between with it. This is a best-effort cleanup of a legacy
+    // block, so leave the file alone and say why rather than guessing at a repair.
+    console.warn(
+      `Warning: left ${agentsPath} untouched — ${describeMarkedBlockDefect(scan, OPENCLAW_RULES_MARKERS)}. ` +
+        'Remove the stray marker by hand, then re-run.'
+    );
     return false;
   }
 
@@ -455,9 +474,7 @@ function cleanOldAgentsBlock(workspaceDir: string, options: OpenClawSetupOptions
   fs.copyFileSync(agentsPath, backup);
   log(`Backup created: ${backup}`, options.quiet);
 
-  const before = content.slice(0, startIndex).trimEnd();
-  const after = content.slice(endIndex + endMarker.length).trimStart();
-  const cleaned = `${before}${after ? `\n\n${after}` : ''}\n`;
+  const cleaned = `${stripMarkedBlock(content, OPENCLAW_RULES_MARKERS).replace(/\n+$/, '')}\n`;
 
   fs.writeFileSync(agentsPath, cleaned, 'utf8');
   log('Removed old AutoMem block from AGENTS.md', options.quiet);

--- a/src/cli/uninstall.ts
+++ b/src/cli/uninstall.ts
@@ -13,6 +13,13 @@ import {
 } from './hermes-config.js';
 import { removeGrokMemoryServer, resolveGrokPaths } from './grok-config.js';
 import { GROK_RULES_END, GROK_RULES_START, stripGrokRulesMarkers } from './grok.js';
+// Marker literals come from the host modules that write them. Re-typing the strings
+// here is the hand-written duplication that caused #186; the strip logic below is
+// deliberately left as-is (its output shape differs from the install-time helper and
+// is pinned by uninstall.test.ts).
+import { CODEX_RULES_END, CODEX_RULES_START } from './codex.js';
+import { COPILOT_RULES_END, COPILOT_RULES_START } from './copilot.js';
+import { HERMES_RULES_END, HERMES_RULES_START } from './hermes.js';
 import { UNINSTALL_PLATFORMS, type UninstallPlatform } from './clients.js';
 
 interface UninstallOptions {
@@ -308,8 +315,8 @@ async function uninstallHermes(options: UninstallOptions): Promise<void> {
   }
 
   if (fs.existsSync(rulesFile)) {
-    const start = '<!-- BEGIN AUTOMEM HERMES RULES -->';
-    const end = '<!-- END AUTOMEM HERMES RULES -->';
+    const start = HERMES_RULES_START;
+    const end = HERMES_RULES_END;
     const raw = fs.readFileSync(rulesFile, 'utf8');
     const startIdx = raw.indexOf(start);
     const endIdx = raw.indexOf(end);
@@ -418,8 +425,8 @@ async function uninstallCodex(options: UninstallOptions): Promise<void> {
     return;
   }
 
-  const start = '<!-- BEGIN AUTOMEM CODEX RULES -->';
-  const end = '<!-- END AUTOMEM CODEX RULES -->';
+  const start = CODEX_RULES_START;
+  const end = CODEX_RULES_END;
   const raw = fs.readFileSync(rulesFile, 'utf8');
   const startIdx = raw.indexOf(start);
   const endIdx = raw.indexOf(end);
@@ -624,8 +631,8 @@ async function uninstallCopilot(options: UninstallOptions): Promise<void> {
   // Strip AutoMem marker block from copilot-instructions.md
   const cliRulesPath = path.join(copilotDir, 'copilot-instructions.md');
   if (fs.existsSync(cliRulesPath)) {
-    const startMarker = '<!-- BEGIN AUTOMEM MEMORY RULES -->';
-    const endMarker = '<!-- END AUTOMEM MEMORY RULES -->';
+    const startMarker = COPILOT_RULES_START;
+    const endMarker = COPILOT_RULES_END;
     const content = fs.readFileSync(cliRulesPath, 'utf8');
     const startIdx = content.indexOf(startMarker);
     const endIdx = content.indexOf(endMarker);

--- a/tests/copilot-setup.test.ts
+++ b/tests/copilot-setup.test.ts
@@ -157,6 +157,97 @@ describe('installMemoryRules (format gating)', () => {
     expect(fs.existsSync(vscodePath)).toBe(false);
   });
 
+  // Two starts and one end: both markers are present and correctly ordered, so an
+  // indexOf-based check calls the file well-formed and replaces from the first start
+  // through the end — silently deleting the second marker and the user's notes.
+  it('refuses to rewrite CLI rules with two start markers and one end', async () => {
+    const cliPath = path.join(tempDir, 'copilot-instructions.md');
+    const handWritten = [
+      '# My custom instructions',
+      '<!-- BEGIN AUTOMEM MEMORY RULES -->',
+      'stale half-block',
+      '<!-- BEGIN AUTOMEM MEMORY RULES -->',
+      'notes the user wrote between the markers',
+      '<!-- END AUTOMEM MEMORY RULES -->',
+      '',
+    ].join('\n');
+    fs.writeFileSync(cliPath, handWritten, 'utf8');
+
+    await expect(
+      applyCopilotSetup({ targetDir: tempDir, format: 'cli', yes: true, quiet: true })
+    ).rejects.toThrow(/found 2 start markers and 1 end marker/);
+
+    expect(fs.readFileSync(cliPath, 'utf8')).toBe(handWritten);
+  });
+
+  it('refuses a one-sided CLI marker instead of appending', async () => {
+    const cliPath = path.join(tempDir, 'copilot-instructions.md');
+    const handWritten = ['# Notes', '<!-- BEGIN AUTOMEM MEMORY RULES -->', 'half a block', ''].join(
+      '\n'
+    );
+    fs.writeFileSync(cliPath, handWritten, 'utf8');
+
+    await expect(
+      applyCopilotSetup({ targetDir: tempDir, format: 'cli', yes: true, quiet: true })
+    ).rejects.toThrow(/without a matching/);
+
+    expect(fs.readFileSync(cliPath, 'utf8')).toBe(handWritten);
+  });
+
+  it('dry-run surfaces a malformed CLI rules file instead of promising an update', async () => {
+    const cliPath = path.join(tempDir, 'copilot-instructions.md');
+    fs.writeFileSync(
+      cliPath,
+      [
+        '<!-- BEGIN AUTOMEM MEMORY RULES -->',
+        'a',
+        '<!-- BEGIN AUTOMEM MEMORY RULES -->',
+        'b',
+        '<!-- END AUTOMEM MEMORY RULES -->',
+        '',
+      ].join('\n'),
+      'utf8'
+    );
+
+    await expect(
+      applyCopilotSetup({
+        targetDir: tempDir,
+        format: 'cli',
+        yes: true,
+        quiet: true,
+        dryRun: true,
+      })
+    ).rejects.toThrow(/found 2 start markers and 1 end marker/);
+  });
+
+  // Removing the block on a --format vscode re-run walks from a start to the *next*
+  // end, so a stray marker means the user's content in between goes with it.
+  it('leaves a malformed CLI rules file alone when re-run for VS Code only', async () => {
+    const cliPath = path.join(tempDir, 'copilot-instructions.md');
+    const handWritten = [
+      '# My custom instructions',
+      '<!-- BEGIN AUTOMEM MEMORY RULES -->',
+      'stale half-block',
+      '<!-- BEGIN AUTOMEM MEMORY RULES -->',
+      'notes the user wrote between the markers',
+      '<!-- END AUTOMEM MEMORY RULES -->',
+      '',
+    ].join('\n');
+    fs.writeFileSync(cliPath, handWritten, 'utf8');
+
+    const warnings: string[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => void warnings.push(args.join(' '));
+    try {
+      await applyCopilotSetup({ targetDir: tempDir, format: 'vscode', yes: true, quiet: true });
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(fs.readFileSync(cliPath, 'utf8')).toBe(handWritten);
+    expect(warnings.join('\n')).toMatch(/found 2 start markers and 1 end marker/);
+  });
+
   it('removes only the managed CLI block when re-run for VS Code only', async () => {
     await applyCopilotSetup({ targetDir: tempDir, format: 'both', yes: true, quiet: true });
     const cliPath = path.join(tempDir, 'copilot-instructions.md');

--- a/tests/copilot-setup.test.ts
+++ b/tests/copilot-setup.test.ts
@@ -180,6 +180,58 @@ describe('installMemoryRules (format gating)', () => {
     expect(fs.readFileSync(cliPath, 'utf8')).toBe(handWritten);
   });
 
+  // A rejected run must not leave Copilot half-updated. Validation runs before stale
+  // hooks are removed, new hooks and scripts are installed, or the VS Code rules are
+  // replaced — so a failed profile switch really does leave the install as it was.
+  it('writes nothing at all when the CLI rules file is rejected', async () => {
+    await applyCopilotSetup({
+      targetDir: tempDir,
+      format: 'both',
+      profile: 'full',
+      yes: true,
+      quiet: true,
+    });
+
+    const snapshot = (): Record<string, string> => {
+      const seen: Record<string, string> = {};
+      const walk = (dir: string) => {
+        for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+          const full = path.join(dir, entry.name);
+          if (entry.isDirectory()) walk(full);
+          else seen[path.relative(tempDir, full)] = fs.readFileSync(full, 'utf8');
+        }
+      };
+      walk(tempDir);
+      return seen;
+    };
+
+    const cliPath = path.join(tempDir, 'copilot-instructions.md');
+    const handWritten = [
+      '# My custom instructions',
+      '<!-- BEGIN AUTOMEM MEMORY RULES -->',
+      'stale half-block',
+      '<!-- BEGIN AUTOMEM MEMORY RULES -->',
+      'notes the user wrote between the markers',
+      '<!-- END AUTOMEM MEMORY RULES -->',
+      '',
+    ].join('\n');
+    fs.writeFileSync(cliPath, handWritten, 'utf8');
+    const before = snapshot();
+
+    // A profile switch is the case that would otherwise delete hooks before failing.
+    await expect(
+      applyCopilotSetup({
+        targetDir: tempDir,
+        format: 'both',
+        profile: 'lean',
+        yes: true,
+        quiet: true,
+      })
+    ).rejects.toThrow(/found 2 start markers and 1 end marker/);
+
+    expect(snapshot()).toEqual(before);
+  });
+
   it('refuses a one-sided CLI marker instead of appending', async () => {
     const cliPath = path.join(tempDir, 'copilot-instructions.md');
     const handWritten = ['# Notes', '<!-- BEGIN AUTOMEM MEMORY RULES -->', 'half a block', ''].join(


### PR DESCRIPTION
## What

The "insert or replace a marked rules block" logic was copy-pasted into five hosts. [#197](https://github.com/verygoodplugins/mcp-automem/pull/197) hardened only the Grok copy against a real data-loss bug; this PR extracts the shared helper and adopts it everywhere, which is the deferred item #197 deliberately left out to keep a credential-focused PR from widening.

**The bug.** A rules file holding two start markers and one end contains *both* markers, so an `indexOf`-based check calls it well-formed and replaces from the first start through the end — silently deleting the second marker and whatever the user wrote between them. Codex additionally still had the older shape where a one-sided marker fell through to "append", which set the *next* run up to delete the content between the original start and the appended end.

## The shared helper

`src/cli/host-toolkit.ts` gains four functions:

| Function | Purpose |
|---|---|
| `scanMarkedBlock` | Counts markers and checks ordering. Returns `absent` / `paired` / `singlePair`. |
| `upsertMarkedBlock` | Append when absent, replace on exactly one ordered pair, **throw otherwise**. |
| `stripMarkedBlock` | Remove marked regions (documented as safe only on `paired` content). |
| `describeMarkedBlockDefect` | Names the defect for errors and warnings. |

Counting is the whole point — `paired` walks the marker positions and requires start, end, start, end… in equal numbers, so no start can swallow a stray marker or the content around it.

Repairing a malformed file means guessing which side of a stray marker the user's content belongs on. That's their judgement, not ours, so the installer refuses and names the defect.

## Adoption

| Host | Adopts |
|---|---|
| `codex.ts` | `upsertMarkedBlock` — also loses the one-sided → append fall-through |
| `copilot.ts` | `upsertMarkedBlock` (rules install) + `scanMarkedBlock`/`stripMarkedBlock` (`--format vscode` removal) |
| `grok.ts` | `upsertMarkedBlock`; `stripGrokRulesMarkers` is now a wrapper (still exported — `uninstall.ts` imports it) |
| `hermes.ts` | Both; the legacy Codex-block migration stays best-effort |
| `openclaw.ts` | `scanMarkedBlock`/`stripMarkedBlock` in the legacy `AGENTS.md` cleanup |

`escapeRegExp`, duplicated verbatim in grok and hermes, is now shared.

**Refuse vs. warn.** Rewriting a rules file throws — nothing is written, and Grok's existing "validate before any write" ordering means no partial install. Install-time *strips* (openclaw's legacy cleanup, copilot's `--format vscode` re-run) warn and leave the file alone instead, since failing an install over a stale block nobody asked about helps nobody. Hermes's Codex-block migration is likewise non-fatal: someone else's stray marker must not block a Hermes install.

**`src/cli/uninstall.ts` — marker literals only.** It re-typed the same six marker strings its host modules already export, which is the hand-written duplication AGENTS.md names as the cause of #186; it now imports them (`hermes.ts` exports `HERMES_RULES_START/END` for this). Its **strip logic and output shape are deliberately untouched**: those four copies are uninstall-time, their output shape differs from the install-time helper, and they are pinned by `uninstall.test.ts`. Unifying them would widen this PR the way #197 refused to.

Known follow-up, filed here rather than done silently: the uninstall strips are unevenly weak, not uniformly weak. Three of them guard with `endIdx <= startIdx`; the copilot one at `uninstall.ts:627` checks only that both markers exist, with no ordering check at all. None of them count. Worth a dedicated pass that can also settle their output shape.

## Deliberate output changes

Marker strings and block placement are unchanged for every host. Two trailing-newline behaviors do change, both fixing accretion the old shapes carried:

1. **Codex normalizes to a single trailing newline.** It appended a bare `\n` on every merge, so no two installs produced the same bytes. `hermes.ts` already carried a comment calling this out ("the previous codex.ts shape accreted a newline each merge") — hermes was written to fix it, and the shared helper now settles it. No test pinned the old shape.
2. **The replace seam no longer gains a blank line per run when content follows the block.** The block template ends with a newline and `after` opens with one; normalizing only the end of the file hid this when the block was last and let it grow forever when it wasn't. This one affected grok and hermes too — my own new unit test caught it.

Copilot's block carries no trailing newline, so it is byte-identical before and after.

## Tests

Mutation-tested as requested: reverting `scanMarkedBlock` to the pre-#197 `indexOf` semantics fails at least one assertion in **every** adopting host, not just the shared unit tests.

| Suite | Failures under mutation |
|---|---|
| `host-toolkit.test.ts` | 5 |
| `codex.test.ts` (new file — codex had no tests) | 2 |
| `grok.test.ts` | 1 |
| `hermes.test.ts` | 2 |
| `copilot-setup.test.ts` | 3 |
| `openclaw.test.ts` | 1 |

Each host test drives the host's own entry point with a two-start/one-end fixture and asserts the user's file is left byte-identical.

## Verification

```
npx vitest run --exclude '**/.claude/**'   863 passed, 14 skipped, 2 failed*
npm run typecheck                          clean
npx eslint src tests scripts               0 errors (181 pre-existing warnings)
npm run format:check                       clean
```

\* The two failures are pre-existing and environmental, present on `main` before this branch: `tests/host-smoke/hermes-real-host.test.ts` derives its project tag from `basename(cwd)`, which is the worktree directory name rather than `mcp-automem` (`expected [ 'elastic-mccarthy-b08185' ] to include 'mcp-automem'`). They pass in a normally-named checkout.

## Note for reviewers

This overlaps #197, which is still open and also rewrites `upsertRulesWithMarkers` in `grok.ts` and adds to `host-toolkit.ts`. A conflict is expected whichever lands first; the resolution is to take the shared helper. Because #197 is unmerged, the count-based validation ships here rather than being inherited.

`INSTALLATION.md` gains a troubleshooting entry for the new refusal, since it is user-visible behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
