### PR TITLE
fix(test): make the suite pass from any checkout directory

### DIFF
--- a/tests/host-smoke/hermes-real-host.test.ts
+++ b/tests/host-smoke/hermes-real-host.test.ts
@@ -322,10 +322,24 @@ print(json.dumps({
   return JSON.parse(lastJsonLine);
 }
 
+/**
+ * Working directory the prefetch runs in. The provider derives its project tag from
+ * `basename(os.getcwd())`, so this — not the repo — decides what the tag assertions see.
+ *
+ * It used to default to REPO_ROOT, which made the assertions pass only where the
+ * checkout directory happened to be named `mcp-automem`: a git worktree, a second clone,
+ * or a CI cache path under any other name failed on a tag the provider never promised.
+ * A fixture directory named for the slug is deterministic everywhere, and it pins the
+ * contract (tag == basename of cwd) instead of the machine's directory layout. Set per
+ * test in beforeEach; the Python imports resolve from the Hermes venv, not from cwd.
+ */
+const PROJECT_SLUG = 'mcp-automem';
+let projectCwd: string;
+
 async function runHermesProviderPrefetchSequence(
   home: string,
   prompts: string[],
-  cwd: string = REPO_ROOT
+  cwd: string = projectCwd
 ): Promise<string[]> {
   if (!HERMES_PYTHON) {
     throw new Error('Hermes Python is not available');
@@ -481,13 +495,21 @@ describe.skipIf(!HERMES_PYTHON)('Hermes real host integration', () => {
   let tmpDir: string;
   let fakeApi: FakeAutoMemApi;
 
+  let projectRoot: string;
+
   beforeEach(async () => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'automem-hermes-host-'));
+    // See PROJECT_SLUG: the prefetch runs here so the provider's project tag is the
+    // slug under test rather than whatever this checkout's directory is called.
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'automem-hermes-project-'));
+    projectCwd = path.join(projectRoot, PROJECT_SLUG);
+    fs.mkdirSync(projectCwd, { recursive: true });
     fakeApi = await startFakeAutoMemApi();
   });
 
   afterEach(async () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(projectRoot, { recursive: true, force: true });
     await fakeApi.close();
   });
 
@@ -637,7 +659,7 @@ describe.skipIf(!HERMES_PYTHON)('Hermes real host integration', () => {
     expect(firstContext?.searchParams.get('limit')).toBe('10');
     expect(firstContext?.searchParams.get('time_query')).toBe('last 90 days');
     expect(firstContext?.searchParams.get('format')).toBe('detailed');
-    expect(firstContext?.searchParams.getAll('tags')).toContain('mcp-automem');
+    expect(firstContext?.searchParams.getAll('tags')).toContain(PROJECT_SLUG);
 
     const topicShift = recalls.find(
       (url) => url.searchParams.get('query') === 'Railway deployment status'
@@ -699,7 +721,8 @@ describe.skipIf(!HERMES_PYTHON)('Hermes real host integration', () => {
     });
 
     await runHermesProviderPrefetchSequence(tmpDir, ['do we like Example Contact?']);
-    await runHermesProviderPrefetchSequence(tmpDir, ['what do we know about mcp-automem Hermes?']);
+    const projectPrompt = `what do we know about ${PROJECT_SLUG} Hermes?`;
+    await runHermesProviderPrefetchSequence(tmpDir, [projectPrompt]);
 
     const generalContext = recallRequests(fakeApi).find(
       (url) => url.searchParams.get('query') === 'do we like Example Contact?'
@@ -708,10 +731,10 @@ describe.skipIf(!HERMES_PYTHON)('Hermes real host integration', () => {
     expect(generalContext?.searchParams.getAll('tags')).toEqual([]);
 
     const projectContext = recallRequests(fakeApi).find(
-      (url) => url.searchParams.get('query') === 'what do we know about mcp-automem Hermes?'
+      (url) => url.searchParams.get('query') === projectPrompt
     );
     expect(projectContext?.searchParams.get('limit')).toBe('10');
-    expect(projectContext?.searchParams.getAll('tags')).toContain('mcp-automem');
+    expect(projectContext?.searchParams.getAll('tags')).toContain(PROJECT_SLUG);
   }, 45_000);
 
   it('provider explicit recall clamps large limits before calling AutoMem', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,9 +4,20 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    // Default: exclude integration tests (they need real service)
-    // Run integration tests with: npm run test:integration
-    exclude: ['node_modules/**', 'dist/**', 'tests/integration/automem-service.test.ts'],
+    // Setting `exclude` REPLACES vitest's defaults, so everything that must stay out of
+    // the run has to be listed here — including the recursive `**/` forms, or a nested
+    // copy of the repo brings its own node_modules and dist back into scope.
+    exclude: [
+      '**/node_modules/**',
+      '**/dist/**',
+      // Agent worktrees under .claude/worktrees/ are full checkouts of this repo. Without
+      // this, `npm test` from the main checkout globs every suite twice — once from the
+      // real tree and once from each worktree's (stale) copy — and reports failures for
+      // code that is not the code under test.
+      '**/.claude/**',
+      // Integration tests need a real service; run them with `npm run test:integration`.
+      'tests/integration/automem-service.test.ts',
+    ],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## What

A bare `npm test` is only reliable when the checkout directory is literally named `mcp-automem`. Two independent defects cause that; both are fixed here.

This is why work on #198 had to be run as `npx vitest run --exclude '**/.claude/**'` and *still* reported two failures that CI didn't see.

## 1. `vitest.config.ts` — the exclude list is incomplete

Setting `exclude` **replaces** vitest's defaults rather than extending them, so the list has to carry everything. It didn't:

- `'node_modules/**'` and `'dist/**'` lack the recursive `**/` form, so a nested copy of the repo brings its own back into scope.
- Nothing excluded `.claude/`. Agent worktrees under `.claude/worktrees/` are **full checkouts of this repo**, so from the main checkout the glob walks them: **106 test files across 2 worktrees** on this machine right now.

The result is every suite running twice — the second time against a stale copy — and failures reported for code that isn't the code under test.

```bash
npx vitest list --filesOnly | grep -c "worktrees/"
```

## 2. `hermes-real-host.test.ts` — the checkout directory name leaks into assertions

The Hermes provider derives its project tag from `basename(os.getcwd())`:

```python
def _default_project_tags() -> List[str]:
    slug = _normalize_project_tag(os.path.basename(os.getcwd()))
```

`runHermesProviderPrefetchSequence` defaulted `cwd` to `REPO_ROOT`, and the tests then asserted the literal tag `mcp-automem`. So the assertions held only where the checkout happened to carry that name, and failed anywhere else:

```
AssertionError: expected [ 'elastic-mccarthy-b08185' ] to include 'mcp-automem'
```

A git worktree, a second clone, a fork, or a CI cache path under another name all trip it.

The prefetch now runs in a fixture directory named for the slug (`PROJECT_SLUG`, created per test in `beforeEach`). That pins the contract the provider actually promises — *tag == basename of cwd* — instead of the machine's directory layout. The Python imports resolve from the Hermes venv rather than cwd, so nothing else here depended on `REPO_ROOT`; the existing test that passes an explicit ambiguous-slug directory is untouched.

## Verification

Run from a worktree named `elastic-mccarthy-b08185` — the exact environment that failed before:

```
npm test          54 files, 820 passed, 14 skipped, 0 failed
npm run typecheck clean
npx eslint .      0 errors
format:check      clean
```

No `--exclude` workaround.

Both fixes were mutation-checked:

| Mutation | Result |
|---|---|
| Drop `'**/.claude/**'` from the exclude list | A planted `.claude/worktrees/fake-wt/` test fixture is globbed again (0 → 1) |
| Restore `cwd: string = REPO_ROOT` | Exactly the two prefetch tests fail, nothing else |

## Note

#198 is stacked behind this. Once this merges I'll rebase it on main so its suite runs clean locally too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
