### PR TITLE
feat(install): onboarding polish for non-technical users

### DIFF
--- a/src/cli/cloud/installer-bridge.test.ts
+++ b/src/cli/cloud/installer-bridge.test.ts
@@ -266,4 +266,68 @@ describe('provisionViaInstaPodsLink routing', () => {
     expect(promptMocks.promptText).not.toHaveBeenCalled();
     expect(promptMocks.promptPassword).not.toHaveBeenCalled();
   });
+
+  // The billing gate: cost + card disclosure must come BEFORE the browser opens
+  // (parity with Railway's billingConfirmMessage), and declining it must fall
+  // back to the paste path without ever opening the signup page.
+  it('confirms billing before opening the InstaPods signup page', async () => {
+    promptMocks.promptSelect.mockResolvedValueOnce('open' as never);
+    promptMocks.promptConfirm.mockResolvedValueOnce(true as never);
+    promptMocks.promptText.mockResolvedValueOnce('https://pod.example' as never);
+    promptMocks.promptPassword.mockResolvedValueOnce('tok' as never);
+    let opened = 0;
+
+    const result = await provisionViaInstaPodsLink({
+      interactive: true,
+      log: () => {},
+      openUrl: async () => {
+        opened += 1;
+      },
+    });
+
+    expect(promptMocks.promptConfirm).toHaveBeenCalledTimes(1);
+    const confirmArg = (promptMocks.promptConfirm.mock.calls[0] as unknown[])[0] as {
+      message: string;
+    };
+    expect(confirmArg.message).toContain('$15/mo');
+    expect(opened).toBe(1);
+    expect(result.endpoint).toBe('https://pod.example');
+  });
+
+  it('declining the billing confirm skips the browser and falls back to paste', async () => {
+    promptMocks.promptSelect.mockResolvedValueOnce('open' as never);
+    promptMocks.promptConfirm.mockResolvedValueOnce(false as never);
+    promptMocks.promptText.mockResolvedValueOnce('https://pod.example' as never);
+    promptMocks.promptPassword.mockResolvedValueOnce('' as never);
+    let opened = 0;
+
+    const result = await provisionViaInstaPodsLink({
+      interactive: true,
+      log: () => {},
+      openUrl: async () => {
+        opened += 1;
+      },
+    });
+
+    expect(opened).toBe(0);
+    expect(result.endpoint).toBe('https://pod.example');
+  });
+
+  it('the paste branch never shows the billing confirm', async () => {
+    promptMocks.promptSelect.mockResolvedValueOnce('paste' as never);
+    promptMocks.promptText.mockResolvedValueOnce('https://pod.example' as never);
+    promptMocks.promptPassword.mockResolvedValueOnce('tok' as never);
+    let opened = 0;
+
+    await provisionViaInstaPodsLink({
+      interactive: true,
+      log: () => {},
+      openUrl: async () => {
+        opened += 1;
+      },
+    });
+
+    expect(promptMocks.promptConfirm).not.toHaveBeenCalled();
+    expect(opened).toBe(0);
+  });
 });

--- a/src/cli/cloud/installer-bridge.test.ts
+++ b/src/cli/cloud/installer-bridge.test.ts
@@ -24,6 +24,8 @@ const promptMocks = vi.hoisted(() => ({
 
 vi.mock('../ui/prompts.js', () => ({
   cancelable: (promise: Promise<unknown>) => promise,
+  // Captions write to stdout only — a no-op keeps test output clean.
+  promptCaption: () => {},
   ...promptMocks,
 }));
 

--- a/src/cli/cloud/installer-bridge.ts
+++ b/src/cli/cloud/installer-bridge.ts
@@ -112,6 +112,16 @@ export async function provisionViaInstaPodsLink(
   );
 
   if (choice === 'open') {
+    // Billing parity with the Railway path: say what it costs and that a card
+    // is involved BEFORE any browser page asks for one.
+    const proceed = await cancelable(
+      promptConfirm({
+        message:
+          "InstaPods hosts AutoMem for ~$15/mo (their Grow plan). You'll create an account and add a card on their site. Open the signup page?",
+        initialValue: true,
+      })
+    );
+    if (!proceed) return promptManualCredentials();
     await openUrl(INSTAPODS_CREATE_URL);
     log(
       noteBox('InstaPods setup', [
@@ -122,6 +132,7 @@ export async function provisionViaInstaPodsLink(
         INSTAPODS_CREATE_URL,
       ])
     );
+    log('  Waiting — the email can take a minute or two. Paste here when it arrives.');
   }
 
   return promptManualCredentials();

--- a/src/cli/cloud/installer-bridge.ts
+++ b/src/cli/cloud/installer-bridge.ts
@@ -63,7 +63,7 @@ export async function promptManualCredentials(): Promise<ProvisionResult> {
   const apiKey = (
     await cancelable(
       promptPassword({
-        message: 'AutoMem API key (leave blank if this endpoint does not require one)',
+        message: "AutoMem API key (leave blank if you don't have one)",
       })
     )
   ).trim();

--- a/src/cli/cloud/installer-bridge.ts
+++ b/src/cli/cloud/installer-bridge.ts
@@ -12,6 +12,7 @@
 import { noteBox } from '../ui/messages.js';
 import {
   cancelable,
+  promptCaption,
   promptConfirm,
   promptPassword,
   promptSelect,
@@ -51,15 +52,18 @@ export interface ProvisionResult {
 // Shared paste step: collect an AutoMem endpoint + optional token. Used by the
 // InstaPods link flow and as the universal fallback.
 export async function promptManualCredentials(): Promise<ProvisionResult> {
+  promptCaption("Your AutoMem server's web address — from the email, or wherever you set it up.");
   const endpoint = (
     await cancelable(
       promptText({
         message: 'AutoMem API URL',
         validate: (value) =>
-          /^https?:\/\/\S+$/.test(value.trim()) || 'Enter a URL like https://your-automem.example',
+          /^https?:\/\/\S+$/.test(value.trim()) ||
+          "That doesn't look like a URL — try something like https://your-automem.example",
       })
     )
   ).trim();
+  promptCaption("Its password, if it has one. Many setups don't.");
   const apiKey = (
     await cancelable(
       promptPassword({
@@ -121,7 +125,12 @@ export async function provisionViaInstaPodsLink(
         initialValue: true,
       })
     );
-    if (!proceed) return promptManualCredentials();
+    if (!proceed) {
+      log(
+        'No problem — paste an AutoMem URL + key if you have one from elsewhere, or press Ctrl-C to start over and pick a different setup.'
+      );
+      return promptManualCredentials();
+    }
     await openUrl(INSTAPODS_CREATE_URL);
     log(
       noteBox('InstaPods setup', [

--- a/src/cli/install-ui.test.ts
+++ b/src/cli/install-ui.test.ts
@@ -104,9 +104,22 @@ describe('installer mascot UI', () => {
   });
 
   it('can colorize the wordmark without changing visible text', () => {
-    const colored = gradientLine('AutoMem', true);
-
-    expect(colored).toContain('\u001b[38;2;');
-    expect(stripAnsi(colored)).toBe('AutoMem');
+    // Truecolor gradient only when the terminal signals support; otherwise the
+    // line collapses to one bright-yellow SGR the terminal theme can map.
+    const prev = process.env.COLORTERM;
+    process.env.COLORTERM = 'truecolor';
+    try {
+      const colored = gradientLine('AutoMem', true);
+      expect(colored).toContain('\u001b[38;2;');
+      expect(stripAnsi(colored)).toBe('AutoMem');
+    } finally {
+      if (prev === undefined) delete process.env.COLORTERM;
+      else process.env.COLORTERM = prev;
+    }
+    delete process.env.COLORTERM;
+    const fallback = gradientLine('AutoMem', true);
+    expect(fallback).toContain('\u001b[93m');
+    expect(fallback).not.toContain('38;2');
+    expect(stripAnsi(fallback)).toBe('AutoMem');
   });
 });

--- a/src/cli/install-ui.test.ts
+++ b/src/cli/install-ui.test.ts
@@ -117,9 +117,14 @@ describe('installer mascot UI', () => {
       else process.env.COLORTERM = prev;
     }
     delete process.env.COLORTERM;
-    const fallback = gradientLine('AutoMem', true);
-    expect(fallback).toContain('\u001b[93m');
-    expect(fallback).not.toContain('38;2');
-    expect(stripAnsi(fallback)).toBe('AutoMem');
+    try {
+      const fallback = gradientLine('AutoMem', true);
+      expect(fallback).toContain('\u001b[93m');
+      expect(fallback).not.toContain('38;2');
+      expect(stripAnsi(fallback)).toBe('AutoMem');
+    } finally {
+      if (prev === undefined) delete process.env.COLORTERM;
+      else process.env.COLORTERM = prev;
+    }
   });
 });

--- a/src/cli/install-ui.ts
+++ b/src/cli/install-ui.ts
@@ -199,16 +199,18 @@ export function renderInstallerSplash(
     color,
     sparkleFrame: options.sparkleFrame,
   });
+  // Kept tight on purpose: ~12 lines total so the first prompt still fits on a
+  // stock 80x24 terminal next to the branding. The old third subtitle line
+  // ("guided local, hosted, and existing-endpoint setup") moved into the
+  // wizard's framing line, and the wordmark/mascot share one separator.
   return [
     renderWordmark(color, options.wordmarkOffset ?? 0),
     '',
     centerBlock(mascot),
-    '',
     centerLine(rgb(COLORS.gold, 'AutoMem', color)),
     centerLine(
       `${rgb(COLORS.text, "Your agents' memory. Everywhere.", color)} ${rgb(COLORS.goldBright, '✦', color)}`
     ),
-    centerLine(rgb(COLORS.muted, 'guided local, hosted, and existing-endpoint setup', color)),
   ].join('\n');
 }
 

--- a/src/cli/install-ui.ts
+++ b/src/cli/install-ui.ts
@@ -1,4 +1,4 @@
-import { visibleLength } from './ui/theme.js';
+import { supportsTruecolor, visibleLength } from './ui/theme.js';
 
 export type MascotState = 'idle' | 'blink' | 'working' | 'done' | 'sleeping' | 'error';
 
@@ -71,8 +71,27 @@ export function centerLine(line: string, width: number = WORDMARK_WIDTH): string
   return pad === 0 ? line : `${' '.repeat(pad)}${line}`;
 }
 
-function rgb(color: readonly [number, number, number], value: string, enabled: boolean): string {
+// Nearest ANSI-16 stand-in for each palette entry, used when the terminal never
+// signaled truecolor (COLORTERM) — absolute RGB would render wrong or unreadably
+// there, and 93/90/39 track the terminal's own theme on light backgrounds too.
+function fallbackSgr(color: readonly [number, number, number]): string {
+  const [r, g, b] = color;
+  if (r > 200 && g > 200 && b > 200) return ''; // near-white text — default fg
+  if (r > 200 && g > 150) return '\x1b[93m'; // golds / amber (goldBright included)
+  return '\x1b[90m'; // frame / muted grays
+}
+
+function rgb(
+  color: readonly [number, number, number],
+  value: string,
+  enabled: boolean,
+  truecolor: boolean = supportsTruecolor()
+): string {
   if (!enabled || value.length === 0) return value;
+  if (!truecolor) {
+    const open = fallbackSgr(color);
+    return open ? `${open}${value}${RESET}` : value;
+  }
   return `\x1b[38;2;${color[0]};${color[1]};${color[2]}m${value}${RESET}`;
 }
 
@@ -95,6 +114,9 @@ export function gradientLine(
   offset = 0
 ): string {
   if (!color || text.length === 0) return text;
+  // Without truecolor a per-character gradient is impossible — collapse to one
+  // bright-yellow line rather than emitting 24-bit codes the terminal may mangle.
+  if (!supportsTruecolor()) return `\x1b[93m${text}${RESET}`;
   const colors = stops.map(hexToRgb);
   const chars = [...text];
 

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -554,6 +554,38 @@ describe('guided install helpers', () => {
       expect(cmd).toContain('--local-dir /Users/tester/.automem/server');
     });
 
+    it('shell-quotes dynamic values so the printed command survives a paste', () => {
+      const cmd = equivalentInstallCommand({
+        target: 'local',
+        clients: [],
+        hermesMode: 'mcp',
+        localDir: '/Users/me/AutoMem Server',
+        apiKeyProvided: false,
+      });
+      expect(cmd).toContain("--local-dir '/Users/me/AutoMem Server'");
+
+      const urlCmd = equivalentInstallCommand({
+        target: 'existing',
+        endpoint: 'https://memory.example/api?region=eu&tier=2',
+        clients: [],
+        hermesMode: 'mcp',
+        apiKeyProvided: false,
+      });
+      // & would background the command and ? globs — the URL must be quoted.
+      expect(urlCmd).toContain("--endpoint 'https://memory.example/api?region=eu&tier=2'");
+
+      // Plain values stay unquoted for readability.
+      const plain = equivalentInstallCommand({
+        target: 'existing',
+        endpoint: 'https://memory.example',
+        clients: [],
+        hermesMode: 'mcp',
+        apiKeyProvided: false,
+      });
+      expect(plain).toContain('--endpoint https://memory.example');
+      expect(plain).not.toContain("'");
+    });
+
     it('carries hermes mode only when hermes is selected, and cloud provider for cloud', () => {
       const cmd = equivalentInstallCommand({
         target: 'cloud',

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -535,8 +535,10 @@ describe('guided install helpers', () => {
         hermesMode: 'mcp',
         apiKeyProvided: true,
       });
-      expect(cmd).toContain('--api-key <your key>');
-      expect(cmd).not.toMatch(/--api-key\s+(?!<your key>)\S/);
+      // Shell-safe on purpose: '<your key>' would be parsed as redirections
+      // when the printed command is pasted verbatim.
+      expect(cmd).toContain('--api-key YOUR_KEY_HERE');
+      expect(cmd).not.toMatch(/--api-key\s+(?!YOUR_KEY_HERE)\S/);
     });
 
     it('omits the endpoint for local targets (which reject --endpoint)', () => {

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -554,6 +554,42 @@ describe('guided install helpers', () => {
       expect(cmd).toContain('--local-dir /Users/tester/.automem/server');
     });
 
+    it('preserves an explicitly empty client selection as --no-agent-install', () => {
+      // clients [] with noAgentInstall unset means the user CONFIRMED zero
+      // tools; omitting both flags would reopen the wizard (or restore the
+      // headless default set) on re-run.
+      const cmd = equivalentInstallCommand({
+        target: 'existing',
+        endpoint: 'https://memory.example',
+        clients: [],
+        hermesMode: 'mcp',
+        apiKeyProvided: false,
+      });
+      expect(cmd).toContain('--no-agent-install');
+      expect(cmd).not.toContain('--clients');
+    });
+
+    it('carries --yes so a headless retry actually applies instead of previewing', () => {
+      const cmd = equivalentInstallCommand({
+        target: 'existing',
+        endpoint: 'https://memory.example',
+        clients: ['grok'],
+        hermesMode: 'mcp',
+        yes: true,
+        apiKeyProvided: false,
+      });
+      expect(cmd).toContain('--yes');
+      const interactive = equivalentInstallCommand({
+        target: 'existing',
+        endpoint: 'https://memory.example',
+        clients: ['grok'],
+        hermesMode: 'mcp',
+        yes: false,
+        apiKeyProvided: false,
+      });
+      expect(interactive).not.toContain('--yes');
+    });
+
     it('shell-quotes dynamic values so the printed command survives a paste', () => {
       const cmd = equivalentInstallCommand({
         target: 'local',

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -20,6 +20,7 @@ import {
   renderInstallPlan,
   dryRunApplyHint,
   equivalentInstallCommand,
+  localRetryHasExplicitApiKey,
   shouldUseNonInteractivePreview,
   validateInstallPrerequisites,
   verifyAutoMemEndpoint,
@@ -506,6 +507,42 @@ describe('guided install helpers', () => {
       expect(hint).toContain('AUTOMEM_DRY_RUN');
       expect(hint).toContain('--yes');
     });
+  });
+
+  // prepareLocalServer persists a reused-or-generated token to localDir/.env
+  // BEFORE verify runs. A local retry command must never echo a placeholder
+  // for that generated token — pasting it would overwrite the real persisted
+  // value. Only an explicit user-supplied key is safe to echo.
+  describe('localRetryHasExplicitApiKey', () => {
+    it('is true when the user explicitly supplied a key', () => {
+      expect(localRetryHasExplicitApiKey('sk-explicit')).toBe(true);
+    });
+
+    it('is false when no key was explicitly supplied (prepareLocalServer generates one)', () => {
+      expect(localRetryHasExplicitApiKey(undefined)).toBe(false);
+    });
+  });
+
+  it('a local retry command omits --api-key for a generated (non-explicit) key', () => {
+    const cmd = equivalentInstallCommand({
+      target: 'local',
+      clients: ['codex'],
+      hermesMode: 'mcp',
+      localDir: '/Users/tester/.automem/server',
+      apiKeyProvided: localRetryHasExplicitApiKey(undefined),
+    });
+    expect(cmd).not.toContain('--api-key');
+  });
+
+  it('a local retry command still echoes an explicit user-supplied key', () => {
+    const cmd = equivalentInstallCommand({
+      target: 'local',
+      clients: ['codex'],
+      hermesMode: 'mcp',
+      localDir: '/Users/tester/.automem/server',
+      apiKeyProvided: localRetryHasExplicitApiKey('sk-typed-by-user'),
+    });
+    expect(cmd).toContain('--api-key YOUR_KEY_HERE');
   });
 
   // Both cancel-style endings (declined confirm, failed verify) hand the user

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -19,6 +19,7 @@ import {
   prepareLocalServer,
   renderInstallPlan,
   dryRunApplyHint,
+  equivalentInstallCommand,
   shouldUseNonInteractivePreview,
   validateInstallPrerequisites,
   verifyAutoMemEndpoint,
@@ -504,6 +505,64 @@ describe('guided install helpers', () => {
       expect(hint).toContain('--dry-run');
       expect(hint).toContain('AUTOMEM_DRY_RUN');
       expect(hint).toContain('--yes');
+    });
+  });
+
+  // Both cancel-style endings (declined confirm, failed verify) hand the user
+  // their answers back as a runnable command so six prompts of work never
+  // evaporates. The command must reconstruct flags from resolved options and
+  // must never echo a real API key.
+  describe('equivalentInstallCommand', () => {
+    it('reconstructs an existing-endpoint install with clients and modes', () => {
+      const cmd = equivalentInstallCommand({
+        target: 'existing',
+        endpoint: 'https://memory.example',
+        clients: ['claude-code', 'grok'],
+        claudeCodeMode: 'plugin',
+        hermesMode: 'mcp',
+        apiKeyProvided: false,
+      });
+      expect(cmd).toBe(
+        'npx @verygoodplugins/mcp-automem install --target existing --endpoint https://memory.example --clients claude-code,grok --claude-code-mode plugin'
+      );
+    });
+
+    it('names the api key as a placeholder, never a value', () => {
+      const cmd = equivalentInstallCommand({
+        target: 'existing',
+        endpoint: 'https://memory.example',
+        clients: [],
+        hermesMode: 'mcp',
+        apiKeyProvided: true,
+      });
+      expect(cmd).toContain('--api-key <your key>');
+      expect(cmd).not.toMatch(/--api-key\s+(?!<your key>)\S/);
+    });
+
+    it('omits the endpoint for local targets (which reject --endpoint)', () => {
+      const cmd = equivalentInstallCommand({
+        target: 'local',
+        endpoint: 'http://127.0.0.1:8001',
+        clients: ['codex'],
+        hermesMode: 'mcp',
+        localDir: '/Users/tester/.automem/server',
+        apiKeyProvided: false,
+      });
+      expect(cmd).not.toContain('--endpoint');
+      expect(cmd).toContain('--local-dir /Users/tester/.automem/server');
+    });
+
+    it('carries hermes mode only when hermes is selected, and cloud provider for cloud', () => {
+      const cmd = equivalentInstallCommand({
+        target: 'cloud',
+        cloudProvider: 'railway',
+        clients: ['hermes'],
+        hermesMode: 'provider',
+        apiKeyProvided: false,
+      });
+      expect(cmd).toContain('--cloud-provider railway');
+      expect(cmd).toContain('--hermes-mode provider');
+      expect(cmd).not.toContain('--claude-code-mode');
     });
   });
 

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -37,6 +37,7 @@ import {
   promptSelect,
   promptPassword,
   promptText,
+  promptCaption,
 } from './ui/prompts.js';
 
 // Claude Code is plugin-first: the marketplace plugin bundles the MCP server +
@@ -209,6 +210,9 @@ export type InstallPlan = {
   // A preview renders the same stages and the same file paths as a real run, so
   // the renderer needs to know which one this is to label them honestly.
   dryRun: boolean;
+  // Deliberate --no-agent-install runs must not get the accidental-zero-agent
+  // warning in the review.
+  noAgentInstall: boolean;
   actions: InstallAction[];
 };
 
@@ -307,13 +311,6 @@ async function drainBufferedStdin(windowMs = 50): Promise<void> {
   }
 }
 
-// One dim line of plain-language context above a prompt, for the questions whose
-// jargon (API URL, API key) the prompt message itself can't afford to caption.
-function promptCaption(text: string): void {
-  const theme = makeTheme(process.stdout);
-  process.stdout.write(`${theme.style.dim(text)}\n`);
-}
-
 // A single themed status line (the rich plan is written directly, not boxed, so
 // these closers match its left-aligned look instead of a clack rail).
 function writeStatus(message: string, tone: 'info' | 'ok' | 'warn' = 'info'): void {
@@ -384,7 +381,9 @@ export function equivalentInstallCommand(options: {
   if (options.endpoint && options.target !== 'local') parts.push(`--endpoint ${options.endpoint}`);
   if (options.target === 'cloud' && options.cloudProvider)
     parts.push(`--cloud-provider ${options.cloudProvider}`);
-  if (options.apiKeyProvided) parts.push('--api-key <your key>');
+  // YOUR_KEY_HERE (no shell metacharacters): '<your key>' would be parsed as
+  // redirections when pasted, silently creating a file named 'key'.
+  if (options.apiKeyProvided) parts.push('--api-key YOUR_KEY_HERE');
   if (options.target === 'local' && options.localDir) parts.push(`--local-dir ${options.localDir}`);
   if (options.noAgentInstall) parts.push('--no-agent-install');
   else if (options.clients.length > 0) parts.push(`--clients ${options.clients.join(',')}`);
@@ -813,6 +812,7 @@ export function buildInstallPlan(params: {
       (action) => action.paths.length > 0 || action.kind === 'prepare-local'
     ),
     dryRun: options.dryRun,
+    noAgentInstall: Boolean(options.noAgentInstall),
     actions,
   };
 }
@@ -1086,6 +1086,15 @@ function readEnvFileValue(filePath: string, key: string): string | undefined {
   return value ? value : undefined;
 }
 
+// `docker --version` succeeds with the daemon stopped (Docker Desktop quit but
+// CLI on PATH), so the presence check alone can't catch the most common local
+// failure. `docker info` needs the daemon. Only called when Local Docker was
+// actually chosen, so the extra ~seconds never tax other targets.
+function dockerDaemonRunning(): boolean {
+  const result = spawnSync('docker', ['info'], { stdio: 'ignore', timeout: 15000 });
+  return result.status === 0;
+}
+
 function defaultRunCommand(
   command: string,
   args: string[],
@@ -1343,7 +1352,7 @@ export function renderInstallPlan(
   // At-a-glance summary chip.
   const agentCount = plan.actions.filter((action) => action.client).length;
   const chip = `${plan.actions.length} stages · ${targetLabel(plan.target)} · ${
-    agentCount ? `${agentCount} agent${agentCount === 1 ? '' : 's'}` : 'no agents'
+    agentCount ? `${agentCount} AI tool${agentCount === 1 ? '' : 's'}` : 'no AI tools'
   }${plan.dryRun ? ' · dry run' : ''}`;
   out.push(`  ${theme.style.dim(chip)}`, '');
 
@@ -1366,11 +1375,12 @@ export function renderInstallPlan(
   if (plan.target === 'local') {
     rows.push({ label: 'server', value: theme.style.dim(tildify(plan.localDir)), status: 'muted' });
   }
-  if (agentCount === 0) {
+  if (agentCount === 0 && !plan.noAgentInstall) {
     // A zero-agent plan is legal but almost never what a first-time user meant —
-    // say it in the review instead of quietly omitting the agent clause.
+    // say it in the review instead of quietly omitting the clause. A deliberate
+    // --no-agent-install run skips the warning (it asked for exactly this).
     rows.push({
-      label: 'agents',
+      label: 'ai tools',
       value: 'none selected — nothing will be connected',
       status: 'warn',
     });
@@ -1434,7 +1444,7 @@ async function resolveInteractiveOptions(
           {
             value: 'cloud',
             label: 'Hosted Cloud (recommended)',
-            hint: 'easiest — we set it up for you, from ~$1/mo',
+            hint: 'easiest — we set it up for you, ~$1–15/mo depending on provider',
           },
           {
             value: 'local',
@@ -1487,15 +1497,26 @@ async function resolveInteractiveOptions(
     );
   }
 
-  if (target === 'local' && !parsed.dryRun && !environment.prerequisites.docker) {
+  if (target === 'local' && !parsed.dryRun) {
     // Fail at the decision, not three prompts later. Dry runs stay open so the
     // path can still be previewed on a machine without Docker.
-    throw new InstallError(
-      "AutoMem's local option needs Docker running on this machine.",
-      `Get Docker Desktop (free): https://www.docker.com/products/docker-desktop\n` +
-        `Install it, open it once so it's running, then re-run this installer.\n` +
-        `Or pick Hosted Cloud — no Docker needed.`
-    );
+    if (!environment.prerequisites.docker) {
+      throw new InstallError(
+        "AutoMem's local option needs Docker on this machine.",
+        `Get Docker Desktop (free): https://www.docker.com/products/docker-desktop\n` +
+          `Install it, open it once so it's running, then re-run this installer.\n` +
+          `Or pick Hosted Cloud — no Docker needed.`
+      );
+    }
+    // The CLI existing doesn't mean the daemon is up — Docker Desktop quit but
+    // still on PATH is the most common local-install failure. Catch it here.
+    if (!dockerDaemonRunning()) {
+      throw new InstallError(
+        'Docker is installed but not running.',
+        `Open Docker Desktop, wait until it says it's running, then re-run this installer.\n` +
+          `Or pick Hosted Cloud — no Docker needed.`
+      );
+    }
   }
   if (target === 'local') {
     promptCaption("Where the server's files live — the default is fine.");
@@ -1898,7 +1919,7 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
           spin.error('AutoMem is not responding yet');
           throw new InstallError(
             `AutoMem deployed, but ${endpoint} isn't responding yet.`,
-            `A multi-service deploy can take a few minutes. Check the provider's logs (e.g. \`railway logs\`), then finish with:\n  npx @verygoodplugins/mcp-automem install --target existing --endpoint ${endpoint}${apiKey ? ' --api-key <token>' : ''}`
+            `A multi-service deploy can take a few minutes. Check the provider's logs (e.g. \`railway logs\`), then finish with:\n  npx @verygoodplugins/mcp-automem install --target existing --endpoint ${endpoint}${apiKey ? ' --api-key YOUR_KEY_HERE' : ''}`
           );
         }
       }
@@ -1949,11 +1970,33 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
       });
       if (!verify.ok) {
         list.fail('verify');
+        // Retry against the endpoint we actually verified — for a cloud run
+        // that's the freshly provisioned deployment. Reconstructing the
+        // resolve-time cloud options would re-provision (and re-bill) a second
+        // deployment instead of reconnecting to the one that already exists.
+        const retryCommand =
+          resolved.target === 'local'
+            ? equivalentInstallCommand({ ...resolved, apiKeyProvided: Boolean(apiKey) })
+            : equivalentInstallCommand({
+                ...resolved,
+                target: 'existing',
+                cloudProvider: undefined,
+                endpoint,
+                apiKeyProvided: Boolean(apiKey),
+              });
+        // Be precise about machine state per target: a cloud deploy already
+        // exists (and may bill), a local run has cloned/started containers.
+        const machineState =
+          resolved.target === 'cloud'
+            ? 'Your cloud deployment exists — nothing on this machine was changed.'
+            : resolved.target === 'local'
+              ? 'The local server may still be starting — no agent files were changed.'
+              : "Nothing was installed — your machine wasn't changed.";
         throw new InstallError(
           "Couldn't reach your AutoMem server.",
-          `Nothing was installed — your machine wasn't changed.\n` +
+          `${machineState}\n` +
             `Check the URL is right, or wait a minute (the server may still be starting) and re-run:\n` +
-            `  ${equivalentInstallCommand({ ...resolved, apiKeyProvided: Boolean(apiKey) })}\n` +
+            `  ${retryCommand}\n` +
             `Technical detail: ${verify.message}`
         );
       }
@@ -2051,7 +2094,7 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
       nextSteps.push(
         `Restart ${installedClients.map((client) => clientLabel(client)).join(' / ')} to pick up the connection.`
       );
-      nextSteps.push('Try it: ask your agent "what do you remember about me?"');
+      nextSteps.push('Try it: ask "what do you remember about me?"');
     }
     nextSteps.push('Docs: https://automem.ai');
     // Only surface the manual /plugin commands when the auto-install didn't run or
@@ -2074,8 +2117,8 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
     if (agentFailures.length > 0) {
       const subject =
         agentFailures.length === 1
-          ? '1 agent needs a manual step:'
-          : `${agentFailures.length} agents need a manual step:`;
+          ? '1 AI tool needs a manual step:'
+          : `${agentFailures.length} AI tools need a manual step:`;
       nextSteps.push(subject);
       for (const failure of agentFailures) {
         nextSteps.push(`  ${failure.hint ?? manualFixHint(failure.client)}`);

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -364,7 +364,7 @@ export function dryRunApplyHint(params: {
 // a shell would interpret (spaces, &, ?, …) — an unquoted "/AutoMem Server"
 // splits into two arguments on paste. Plain values stay bare for readability.
 function shellQuote(value: string): string {
-  if (/^[A-Za-z0-9_@%+=:,.\/-]+$/.test(value)) return value;
+  if (/^[A-Za-z0-9_@%+=:,./-]+$/.test(value)) return value;
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -381,6 +381,7 @@ export function equivalentInstallCommand(options: {
   hermesMode?: HermesInstallMode;
   localDir?: string;
   noAgentInstall?: boolean;
+  yes?: boolean;
   apiKeyProvided: boolean;
 }): string {
   const parts = ['npx @verygoodplugins/mcp-automem install', `--target ${options.target}`];
@@ -395,12 +396,19 @@ export function equivalentInstallCommand(options: {
   if (options.apiKeyProvided) parts.push('--api-key YOUR_KEY_HERE');
   if (options.target === 'local' && options.localDir)
     parts.push(`--local-dir ${shellQuote(options.localDir)}`);
-  if (options.noAgentInstall) parts.push('--no-agent-install');
-  else if (options.clients.length > 0) parts.push(`--clients ${options.clients.join(',')}`);
+  // clients [] with noAgentInstall unset is a CONFIRMED zero-tool selection
+  // (the wizard's guard asked). Emitting neither flag would reopen the wizard —
+  // or restore the headless default set — on re-run, so both map to the same
+  // explicit flag.
+  if (options.noAgentInstall || options.clients.length === 0) parts.push('--no-agent-install');
+  else parts.push(`--clients ${options.clients.join(',')}`);
   if (!options.noAgentInstall && options.clients.includes('claude-code') && options.claudeCodeMode)
     parts.push(`--claude-code-mode ${options.claudeCodeMode}`);
   if (!options.noAgentInstall && options.clients.includes('hermes') && options.hermesMode)
     parts.push(`--hermes-mode ${options.hermesMode}`);
+  // A headless run needed --yes to get past shouldUseNonInteractivePreview;
+  // a retry command without it would only print a preview in the same shell.
+  if (options.yes) parts.push('--yes');
   return parts.join(' ');
 }
 
@@ -1998,7 +2006,7 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
         // exists (and may bill), a local run has cloned/started containers.
         const machineState =
           resolved.target === 'cloud'
-            ? 'Your cloud deployment exists — nothing on this machine was changed.'
+            ? 'Your cloud deployment exists — no AutoMem files were written on this machine yet.'
             : resolved.target === 'local'
               ? 'The local server may still be starting — no agent files were changed.'
               : "Nothing was installed — your machine wasn't changed.";

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -368,6 +368,21 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
+// Whether a LOCAL retry command should offer --api-key. prepareLocalServer
+// reuses-or-generates a token and persists it to localDir/.env BEFORE verify
+// runs, so pasting a placeholder key on retry would overwrite that persisted
+// real token with the literal string, rotating auth to a known value. Only
+// an EXPLICIT user-supplied key (--api-key / typed at the prompt) is safe to
+// echo — a generated one must stay out of the command entirely so the next
+// run's prepareLocalServer call reuses what's already on disk. Scoped to
+// local on purpose: cloud/existing retry commands reflect a different
+// question (does a live key exist right now, computed at the call site) and
+// must not be answered by this function. Named + exported so the decision is
+// unit-testable, not buried inside runGuidedInstall.
+export function localRetryHasExplicitApiKey(explicitApiKey: string | undefined): boolean {
+  return Boolean(explicitApiKey);
+}
+
 // Reconstruct the non-interactive command equivalent to a set of resolved wizard
 // answers. Shown when a run stops without applying (declined confirm, failed
 // verify) so the user's prompt answers survive as something they can paste. The
@@ -1994,7 +2009,10 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
         // deployment instead of reconnecting to the one that already exists.
         const retryCommand =
           resolved.target === 'local'
-            ? equivalentInstallCommand({ ...resolved, apiKeyProvided: Boolean(apiKey) })
+            ? equivalentInstallCommand({
+                ...resolved,
+                apiKeyProvided: localRetryHasExplicitApiKey(resolved.apiKey),
+              })
             : equivalentInstallCommand({
                 ...resolved,
                 target: 'existing',

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -284,6 +284,27 @@ function tildify(filePath: string, homeDir: string = os.homedir()): string {
   return filePath;
 }
 
+// Discard any keystrokes sitting in the terminal buffer. Used right before the
+// apply confirm: keys pressed during the typed plan reveal (impatient Enters
+// included) would otherwise be delivered to the prompt the moment it opens.
+// Best-effort and brief — resumes stdin in raw mode for a beat, swallowing
+// whatever arrives, then restores the paused state inquirer expects.
+async function drainBufferedStdin(windowMs = 50): Promise<void> {
+  const stdin = process.stdin;
+  if (!stdin.isTTY) return;
+  const swallow = () => {};
+  try {
+    stdin.setRawMode?.(true);
+    stdin.on('data', swallow);
+    stdin.resume();
+    await new Promise((resolve) => setTimeout(resolve, windowMs));
+  } finally {
+    stdin.pause();
+    stdin.off('data', swallow);
+    stdin.setRawMode?.(false);
+  }
+}
+
 // One dim line of plain-language context above a prompt, for the questions whose
 // jargon (API URL, API key) the prompt message itself can't afford to caption.
 function promptCaption(text: string): void {
@@ -1734,6 +1755,10 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
 
     if (!resolved.yes) {
       process.stdout.write('\n');
+      // Discard keystrokes buffered while the plan was typing out — a buffered
+      // Enter would otherwise answer this confirm the instant it opens and
+      // silently discard the whole wizard (default is No).
+      await drainBufferedStdin();
       const approved = await cancelable(
         promptConfirm({ message: 'Apply this AutoMem install plan?', initialValue: false })
       );

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -253,7 +253,7 @@ type WaitEndpointOptions = VerifyEndpointOptions & {
 type CommandRunner = (
   command: string,
   args: string[],
-  options?: { cwd?: string; env?: NodeJS.ProcessEnv }
+  options?: { cwd?: string; env?: NodeJS.ProcessEnv; logFile?: string }
 ) => void;
 
 const AUTOMEM_REPO = 'https://github.com/verygoodplugins/automem';
@@ -1086,8 +1086,28 @@ function readEnvFileValue(filePath: string, key: string): string | undefined {
 function defaultRunCommand(
   command: string,
   args: string[],
-  options: { cwd?: string; env?: NodeJS.ProcessEnv } = {}
+  options: { cwd?: string; env?: NodeJS.ProcessEnv; logFile?: string } = {}
 ): void {
+  // With logFile set, the child's output is contained there instead of flooding
+  // the wizard (docker compose builds print hundreds of lines). Failures still
+  // throw; the caller decides how much of the log to surface.
+  if (options.logFile) {
+    const fd = fs.openSync(options.logFile, 'a');
+    try {
+      const result = spawnSync(command, args, {
+        cwd: options.cwd,
+        env: options.env ?? process.env,
+        stdio: ['ignore', fd, fd],
+      });
+      if (result.error) throw result.error;
+      if (result.status !== 0) {
+        throw new Error(`${command} exited with code ${result.status ?? 'unknown'}`);
+      }
+    } finally {
+      fs.closeSync(fd);
+    }
+    return;
+  }
   execFileSync(command, args, {
     cwd: options.cwd,
     env: options.env ?? process.env,
@@ -1148,16 +1168,28 @@ export async function prepareLocalServer(params: {
     },
     false
   );
+  const composeLog = path.join(params.localDir, 'install.log');
   try {
     runCommand('docker', ['compose', '--env-file', '.env', 'up', '-d', '--build'], {
       cwd: params.localDir,
       env: { ...process.env, AUTOMEM_API_TOKEN: apiKey, ADMIN_API_TOKEN: adminToken },
+      logFile: composeLog,
     });
   } catch {
+    // Surface only the tail — the full compose transcript lives in the log.
+    let tail = '';
+    try {
+      const logLines = fs.readFileSync(composeLog, 'utf8').trimEnd().split('\n');
+      tail = logLines.slice(-15).join('\n');
+    } catch {
+      /* no log — docker may have failed to launch at all */
+    }
     throw new InstallError(
       "Local AutoMem server didn't start (docker compose).",
-      'Most often a port is already in use — FalkorDB :3000, Qdrant :6333, or the API :8001. ' +
-        'Stop the conflicting container (`docker ps`) or free the port, then re-run. Docker output is above.'
+      `Is Docker Desktop running? Open it, then re-run this installer.\n` +
+        `Also common: a port already in use — FalkorDB :3000, Qdrant :6333, or the API :8001 ` +
+        `(run \`docker ps\` to find the conflict).\n` +
+        `Full build log: ${tildify(composeLog)}${tail ? `\nLast lines:\n${tail}` : ''}`
     );
   }
 
@@ -1449,7 +1481,18 @@ async function resolveInteractiveOptions(
     );
   }
 
+  if (target === 'local' && !parsed.dryRun && !environment.prerequisites.docker) {
+    // Fail at the decision, not three prompts later. Dry runs stay open so the
+    // path can still be previewed on a machine without Docker.
+    throw new InstallError(
+      "AutoMem's local option needs Docker running on this machine.",
+      `Get Docker Desktop (free): https://www.docker.com/products/docker-desktop\n` +
+        `Install it, open it once so it's running, then re-run this installer.\n` +
+        `Or pick Hosted Cloud — no Docker needed.`
+    );
+  }
   if (target === 'local') {
+    promptCaption("Where the server's files live — the default is fine.");
     localDir = (
       await cancelable(
         promptText({
@@ -1788,7 +1831,8 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
     // BEFORE the live checklist — a redraw region can't share the screen with it.
     if (resolved.target === 'local') {
       process.stdout.write(
-        `  ${theme.style.dim(theme.symbol.arrow)} Building & starting local AutoMem server (first run can take a minute)…\n`
+        `  ${theme.style.dim(theme.symbol.arrow)} Building the local server — the first time can take a few minutes ` +
+          `${theme.style.dim(`(log: ${tildify(path.join(plan.localDir, 'install.log'))})`)}…\n`
       );
       const local = await prepareLocalServer({ localDir: plan.localDir, apiKey, dryRun: false });
       endpoint = local.endpoint;

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -2095,10 +2095,25 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
     const nextSteps: string[] = [`endpoint  ${endpoint}`];
     // The finish line earns its box only if it says what to do NOW: restart the
     // tools that were just wired, and a concrete way to see memory working.
+    // Only surface the manual /plugin commands when the auto-install didn't run or
+    // didn't succeed — i.e. the `claude` binary was absent, or the install failed.
+    const pluginAutoInstallFailed = agentFailures.some(
+      (failure) => failure.client === 'claude-code' && failure.showPluginCommands !== false
+    );
+    // Plugin mode without the `claude` binary installs nothing yet — the /plugin
+    // commands below ARE the install. Restarting Claude Code before running them
+    // would do nothing, so keep it out of the restart line.
+    const claudePluginIsManual =
+      !resolved.noAgentInstall &&
+      resolved.clients.includes('claude-code') &&
+      resolved.claudeCodeMode === 'plugin' &&
+      (!environment.prerequisites.claude || pluginAutoInstallFailed);
     const installedClients = resolved.noAgentInstall
       ? []
       : resolved.clients.filter(
-          (client) => !agentFailures.some((failure) => failure.client === client)
+          (client) =>
+            !agentFailures.some((failure) => failure.client === client) &&
+            !(client === 'claude-code' && claudePluginIsManual)
         );
     if (installedClients.length > 0) {
       nextSteps.push(
@@ -2107,17 +2122,7 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
       nextSteps.push('Try it: ask "what do you remember about me?"');
     }
     nextSteps.push('Docs: https://automem.ai');
-    // Only surface the manual /plugin commands when the auto-install didn't run or
-    // didn't succeed — i.e. the `claude` binary was absent, or the install failed.
-    const pluginAutoInstallFailed = agentFailures.some(
-      (failure) => failure.client === 'claude-code' && failure.showPluginCommands !== false
-    );
-    if (
-      !resolved.noAgentInstall &&
-      resolved.clients.includes('claude-code') &&
-      resolved.claudeCodeMode === 'plugin' &&
-      (!environment.prerequisites.claude || pluginAutoInstallFailed)
-    ) {
+    if (claudePluginIsManual) {
       nextSteps.push('Claude Code plugin — run these inside Claude Code:');
       for (const cmd of CLAUDE_CODE_PLUGIN_COMMANDS) {
         nextSteps.push(`  ${cmd}`);

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -360,6 +360,14 @@ export function dryRunApplyHint(params: {
   return 'To install for real, run the same command without --dry-run.';
 }
 
+// Single-quote a value for the reconstructed command when it contains anything
+// a shell would interpret (spaces, &, ?, …) — an unquoted "/AutoMem Server"
+// splits into two arguments on paste. Plain values stay bare for readability.
+function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9_@%+=:,.\/-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
 // Reconstruct the non-interactive command equivalent to a set of resolved wizard
 // answers. Shown when a run stops without applying (declined confirm, failed
 // verify) so the user's prompt answers survive as something they can paste. The
@@ -378,13 +386,15 @@ export function equivalentInstallCommand(options: {
   const parts = ['npx @verygoodplugins/mcp-automem install', `--target ${options.target}`];
   // --endpoint is rejected with --target local (the local server always binds the
   // compose default), so never reconstruct one there.
-  if (options.endpoint && options.target !== 'local') parts.push(`--endpoint ${options.endpoint}`);
+  if (options.endpoint && options.target !== 'local')
+    parts.push(`--endpoint ${shellQuote(options.endpoint)}`);
   if (options.target === 'cloud' && options.cloudProvider)
     parts.push(`--cloud-provider ${options.cloudProvider}`);
   // YOUR_KEY_HERE (no shell metacharacters): '<your key>' would be parsed as
   // redirections when pasted, silently creating a file named 'key'.
   if (options.apiKeyProvided) parts.push('--api-key YOUR_KEY_HERE');
-  if (options.target === 'local' && options.localDir) parts.push(`--local-dir ${options.localDir}`);
+  if (options.target === 'local' && options.localDir)
+    parts.push(`--local-dir ${shellQuote(options.localDir)}`);
   if (options.noAgentInstall) parts.push('--no-agent-install');
   else if (options.clients.length > 0) parts.push(`--clients ${options.clients.join(',')}`);
   if (!options.noAgentInstall && options.clients.includes('claude-code') && options.claudeCodeMode)

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -284,6 +284,13 @@ function tildify(filePath: string, homeDir: string = os.homedir()): string {
   return filePath;
 }
 
+// One dim line of plain-language context above a prompt, for the questions whose
+// jargon (API URL, API key) the prompt message itself can't afford to caption.
+function promptCaption(text: string): void {
+  const theme = makeTheme(process.stdout);
+  process.stdout.write(`${theme.style.dim(text)}\n`);
+}
+
 // A single themed status line (the rich plan is written directly, not boxed, so
 // these closers match its left-aligned look instead of a clack rail).
 function writeStatus(message: string, tone: 'info' | 'ok' | 'warn' = 'info'): void {
@@ -323,9 +330,14 @@ export function dryRunApplyHint(params: {
         : fromFlag
           ? 'drop --dry-run'
           : 'turn off dry-run mode';
-  return params.interactive
-    ? `To apply, ${disable} and re-run.`
-    : `To apply, ${disable}, then re-run with --yes.`;
+  if (!params.interactive) return `To apply, ${disable}, then re-run with --yes.`;
+  // TTY wording is for a human at a keyboard, not a script: say "preview" and
+  // "install for real" instead of flag-native verbs like "drop".
+  if (fromFlag && fromEnv)
+    return 'This was a preview. To install for real, remove --dry-run, set AUTOMEM_DRY_RUN=0, and run it again.';
+  if (fromEnv)
+    return 'This was a preview. To install for real, set AUTOMEM_DRY_RUN=0 (it is on in your shell or .env) and run it again.';
+  return 'This was a preview. To install for real, run the same command without --dry-run.';
 }
 
 // Reconstruct the non-interactive command equivalent to a set of resolved wizard
@@ -1131,6 +1143,19 @@ export async function prepareLocalServer(params: {
   return { endpoint: DEFAULT_AUTOMEM_API_URL, apiKey };
 }
 
+// The user picked a labeled option; the review should echo that label back, not
+// the internal enum value ("existing" / "cloud" / "local").
+function targetLabel(target: InstallTarget): string {
+  switch (target) {
+    case 'cloud':
+      return 'hosted cloud';
+    case 'local':
+      return 'local docker';
+    case 'existing':
+      return 'existing endpoint';
+  }
+}
+
 function clientLabel(client: AgentClient): string {
   switch (client) {
     case 'codex':
@@ -1236,6 +1261,7 @@ function renderActionDetail(
         detail(
           `AUTOMEM_API_URL=${plan.endpoint ?? '<prompted>'}${plan.apiKeyProvided ? '  + API key' : ''}`
         ),
+        detail('saved in the folder you ran this from:'),
       ];
     case 'prepare-local':
       return [detail(`docker compose in ${tildify(plan.localDir)}`)];
@@ -1257,17 +1283,20 @@ export function renderInstallPlan(
 
   // At-a-glance summary chip.
   const agentCount = plan.actions.filter((action) => action.client).length;
-  const chip = `${plan.actions.length} stages · ${plan.target} · ${
+  const chip = `${plan.actions.length} stages · ${targetLabel(plan.target)} · ${
     agentCount ? `${agentCount} agent${agentCount === 1 ? '' : 's'}` : 'no agents'
   }${plan.dryRun ? ' · dry run' : ''}`;
   out.push(`  ${theme.style.dim(chip)}`, '');
 
   const rows: TableRow[] = [
-    { label: 'mode', value: plan.target, status: 'ok' },
+    { label: 'setup', value: targetLabel(plan.target), status: 'ok' },
     {
       label: 'endpoint',
-      value: plan.endpoint ?? theme.style.dim('not set yet'),
-      status: plan.endpoint ? 'ok' : 'warn',
+      // A cloud plan's endpoint arrives during setup — expected, not a warning.
+      value:
+        plan.endpoint ??
+        theme.style.dim(plan.target === 'cloud' ? 'provisioned during setup' : 'not set yet'),
+      status: plan.endpoint || plan.target === 'cloud' ? (plan.endpoint ? 'ok' : 'muted') : 'warn',
     },
     {
       label: 'api key',
@@ -1343,16 +1372,24 @@ async function resolveInteractiveOptions(
       promptSelect<InstallTarget>({
         message: 'Where should AutoMem run?',
         options: [
-          { value: 'cloud', label: 'Hosted Cloud', hint: 'InstaPods or Railway — guided deploy' },
+          {
+            value: 'cloud',
+            label: 'Hosted Cloud (recommended)',
+            hint: 'easiest — we set it up for you, from ~$1/mo',
+          },
           {
             value: 'local',
             label: 'Local Docker',
-            hint: 'Clone AutoMem and start Docker Compose on this machine',
+            // Docker-aware: tell the user NOW whether this path can even start,
+            // instead of letting them discover a missing prerequisite mid-wizard.
+            hint: environment.prerequisites.docker
+              ? 'free, runs on this computer — Docker detected'
+              : 'free, runs on this computer — needs Docker (not found here)',
           },
           {
             value: 'existing',
             label: 'Existing Endpoint',
-            hint: 'Use an AutoMem URL you already have',
+            hint: 'paste an AutoMem URL + key you already have',
           },
         ],
         initialValue: 'cloud',
@@ -1368,17 +1405,17 @@ async function resolveInteractiveOptions(
   if (target === 'cloud' && !cloudProvider) {
     cloudProvider = await cancelable(
       promptSelect<CloudProviderId>({
-        message: 'How should we stand up your hosted AutoMem?',
+        message: 'How do you want to set up your hosted AutoMem?',
         options: [
           {
             value: 'instapods',
             label: 'InstaPods',
-            hint: 'open the setup page — it deploys AutoMem and emails your URL + key',
+            hint: 'they run it for you and email your URL + key — ~$15/mo',
           },
           {
             value: 'railway',
             label: 'Railway (guided)',
-            hint: 'sign in with the railway CLI, deploy from the terminal, then auto-capture keys',
+            hint: 'we open Railway, walk you through sign-in, and grab your keys — ~$1–5/mo',
           },
           {
             value: 'other',
@@ -1410,24 +1447,26 @@ async function resolveInteractiveOptions(
     target === 'existing' || (target === 'cloud' && cloudProvider === 'other');
 
   if (collectEndpointHere && !endpoint) {
+    promptCaption("Your AutoMem server's web address — you got this when you set it up.");
     endpoint = (
       await cancelable(
         promptText({
           message: 'AutoMem API URL',
           validate: (value) =>
             /^https?:\/\/\S+$/.test(value.trim()) ||
-            'Enter a URL like https://your-automem.example',
+            "That doesn't look like a URL — try something like https://your-automem.example",
         })
       )
     ).trim();
   }
 
   if (collectEndpointHere && !apiKey) {
+    promptCaption("Its password, if it has one. Many setups don't.");
     // Masked: the key must never echo in cleartext as the user types.
     const entered = (
       await cancelable(
         promptPassword({
-          message: 'AutoMem API key (leave blank if this endpoint does not require one)',
+          message: "AutoMem API key (leave blank if you don't have one)",
         })
       )
     ).trim();
@@ -1443,13 +1482,13 @@ async function resolveInteractiveOptions(
     for (;;) {
       const selected = await cancelable(
         promptMultiselect<AgentClient>({
-          message: 'Install AutoMem into which agents?',
+          message: 'Connect AutoMem to which AI tools?',
           options: AGENT_CLIENTS.map((client) => ({
             value: client,
             label: clientLabel(client),
             hint: detected.has(client)
               ? 'detected on this machine'
-              : 'not detected, still installable',
+              : 'not found here — pick it anyway if you use it',
           })),
           // Pre-check everything detected on this machine (Hermes included) so a
           // user who already runs an agent reaches its follow-up prompts by default.
@@ -1484,12 +1523,12 @@ async function resolveInteractiveOptions(
           {
             value: 'provider',
             label: 'Native memory provider',
-            hint: 'recommended; replaces Hermes built-in memory provider selection',
+            hint: "recommended — replaces Hermes's built-in memory",
           },
           {
             value: 'mcp',
             label: 'MCP tools only',
-            hint: 'portable tools, no provider replacement',
+            hint: 'standard protocol connection — works everywhere',
           },
           {
             value: 'both',
@@ -1652,6 +1691,15 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
   }
 
   try {
+    if (interactive && !parsed.yes) {
+      // One line of framing before the first question: how long this takes and —
+      // the cheapest trust win in the flow — that nothing happens until the
+      // reviewed plan is approved.
+      const theme = makeTheme(process.stdout);
+      process.stdout.write(
+        `  ${theme.style.dim('About 2 minutes. Nothing is written until you approve the plan at the end.')}\n`
+      );
+    }
     const resolved = interactive
       ? await resolveInteractiveOptions(
           parsed,
@@ -1685,6 +1733,7 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
     }
 
     if (!resolved.yes) {
+      process.stdout.write('\n');
       const approved = await cancelable(
         promptConfirm({ message: 'Apply this AutoMem install plan?', initialValue: false })
       );

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -1257,8 +1257,8 @@ export function renderInstallPlan(
 
   // At-a-glance summary chip.
   const agentCount = plan.actions.filter((action) => action.client).length;
-  const chip = `${plan.actions.length} stages · ${plan.target}${
-    agentCount ? ` · ${agentCount} agent${agentCount === 1 ? '' : 's'}` : ''
+  const chip = `${plan.actions.length} stages · ${plan.target} · ${
+    agentCount ? `${agentCount} agent${agentCount === 1 ? '' : 's'}` : 'no agents'
   }${plan.dryRun ? ' · dry run' : ''}`;
   out.push(`  ${theme.style.dim(chip)}`, '');
 
@@ -1277,6 +1277,15 @@ export function renderInstallPlan(
   ];
   if (plan.target === 'local') {
     rows.push({ label: 'server', value: theme.style.dim(tildify(plan.localDir)), status: 'muted' });
+  }
+  if (agentCount === 0) {
+    // A zero-agent plan is legal but almost never what a first-time user meant —
+    // say it in the review instead of quietly omitting the agent clause.
+    rows.push({
+      label: 'agents',
+      value: 'none selected — nothing will be connected',
+      status: 'warn',
+    });
   }
   out.push(keyValueRows(rows, theme), '', sectionTitle('Stages', theme));
 
@@ -1428,23 +1437,42 @@ async function resolveInteractiveOptions(
   let clients = parsed.clients;
   if (!parsed.noAgentInstall && !clientsExplicit) {
     const detected = new Set(environment.detectedClients.map((client) => client.client));
-    const selected = await cancelable(
-      promptMultiselect<AgentClient>({
-        message: 'Install AutoMem into which agents?',
-        options: AGENT_CLIENTS.map((client) => ({
-          value: client,
-          label: clientLabel(client),
-          hint: detected.has(client)
-            ? 'detected on this machine'
-            : 'not detected, still installable',
-        })),
-        // Pre-check everything detected on this machine (Hermes included) so a
-        // user who already runs an agent reaches its follow-up prompts by default.
-        initialValues: AGENT_CLIENTS.filter((client) => detected.has(client)),
-        required: false,
-      })
-    );
-    clients = selected.length > 0 ? selected : [];
+    // On a fresh machine nothing is detected, nothing is pre-checked, and Enter
+    // submits an empty selection — silently skipping the tool's entire purpose.
+    // Loop: an empty submit gets one explicit confirm; No re-opens the list.
+    for (;;) {
+      const selected = await cancelable(
+        promptMultiselect<AgentClient>({
+          message: 'Install AutoMem into which agents?',
+          options: AGENT_CLIENTS.map((client) => ({
+            value: client,
+            label: clientLabel(client),
+            hint: detected.has(client)
+              ? 'detected on this machine'
+              : 'not detected, still installable',
+          })),
+          // Pre-check everything detected on this machine (Hermes included) so a
+          // user who already runs an agent reaches its follow-up prompts by default.
+          initialValues: AGENT_CLIENTS.filter((client) => detected.has(client)),
+          required: false,
+        })
+      );
+      if (selected.length > 0) {
+        clients = selected;
+        break;
+      }
+      const skipAgents = await cancelable(
+        promptConfirm({
+          message:
+            'No AI tools selected — AutoMem will be set up but nothing will use it. Continue anyway?',
+          initialValue: false,
+        })
+      );
+      if (skipAgents) {
+        clients = [];
+        break;
+      }
+    }
   }
 
   let hermesMode = parsed.hermesMode;
@@ -1926,8 +1954,22 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
     nextSteps.push('Backups: every changed file keeps a <file>.bak copy.');
     // The card is a box, so rows snap in whole (never half-drawn) but slowly —
     // a deliberate beat per row so the finish lands instead of flashing past.
+    // Deliberate --no-agent-install runs keep the plain title; the callout is
+    // for a wizard user who ended up with nothing connected.
+    const zeroAgents = !resolved.noAgentInstall && resolved.clients.length === 0;
+    if (zeroAgents) {
+      nextSteps.splice(
+        1,
+        0,
+        'Connect one: npx @verygoodplugins/mcp-automem install --clients claude-code (or your tool).'
+      );
+    }
     const cardTitle =
-      agentFailures.length > 0 ? 'AutoMem is installed — with follow-ups' : 'AutoMem is installed';
+      agentFailures.length > 0
+        ? 'AutoMem is installed — with follow-ups'
+        : zeroAgents
+          ? 'AutoMem is installed — but not connected to any AI tool'
+          : 'AutoMem is installed';
     await revealLines(renderSuccessCard(cardTitle, nextSteps), {
       typed: true,
       wordDelayMs: 42,

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -357,10 +357,10 @@ export function dryRunApplyHint(params: {
   // TTY wording is for a human at a keyboard, not a script: say "preview" and
   // "install for real" instead of flag-native verbs like "drop".
   if (fromFlag && fromEnv)
-    return 'This was a preview. To install for real, remove --dry-run, set AUTOMEM_DRY_RUN=0, and run it again.';
+    return 'To install for real, remove --dry-run, set AUTOMEM_DRY_RUN=0, and run it again.';
   if (fromEnv)
-    return 'This was a preview. To install for real, set AUTOMEM_DRY_RUN=0 (it is on in your shell or .env) and run it again.';
-  return 'This was a preview. To install for real, run the same command without --dry-run.';
+    return 'To install for real, set AUTOMEM_DRY_RUN=0 (it is on in your shell or .env) and run it again.';
+  return 'To install for real, run the same command without --dry-run.';
 }
 
 // Reconstruct the non-interactive command equivalent to a set of resolved wizard

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -240,6 +240,8 @@ type VerifyEndpointOptions = {
 type WaitEndpointOptions = VerifyEndpointOptions & {
   attempts?: number;
   intervalMs?: number;
+  // Called before each attempt — lets the caller surface retry progress.
+  onAttempt?: (attempt: number, attempts: number) => void;
   /**
    * Require this many CONSECUTIVE successful verifies before declaring ready
    * (default 1). A freshly deployed service can flicker during early boot — health
@@ -960,6 +962,7 @@ export async function waitForAutoMemEndpoint(
   let streak = 0;
 
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    options.onAttempt?.(attempt, attempts);
     last = await verifyAutoMemEndpoint({
       endpoint: options.endpoint,
       apiKey: options.apiKey,
@@ -1323,7 +1326,10 @@ function renderActionDetail(
     case 'manual-step':
       return [detail(action.detail)];
     case 'install-agent':
-      return []; // the title ("Install <Agent> integration") says it all
+      // Path-writing agent installs are self-explanatory (title + path lines),
+      // but a manual/plugin-style action with no paths carries its authored
+      // explanation in `detail` — the plugin path's ONLY description. Show it.
+      return action.paths.length === 0 && action.detail ? [detail(action.detail)] : [];
   }
 }
 
@@ -1934,6 +1940,12 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
         apiKey,
         attempts: 8,
         intervalMs: 2000,
+        // From the second try onward, show the ladder — 16 quiet seconds of
+        // spinner otherwise reads as a hang.
+        onAttempt: (attempt, attempts) => {
+          if (attempt > 1)
+            list.update('verify', `Verify endpoint — attempt ${attempt}/${attempts}`);
+        },
       });
       if (!verify.ok) {
         list.fail('verify');

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -328,6 +328,38 @@ export function dryRunApplyHint(params: {
     : `To apply, ${disable}, then re-run with --yes.`;
 }
 
+// Reconstruct the non-interactive command equivalent to a set of resolved wizard
+// answers. Shown when a run stops without applying (declined confirm, failed
+// verify) so the user's prompt answers survive as something they can paste. The
+// API key is always the literal placeholder <your key> — never the value.
+export function equivalentInstallCommand(options: {
+  target: InstallTarget;
+  endpoint?: string;
+  cloudProvider?: CloudProviderId;
+  clients: AgentClient[];
+  claudeCodeMode?: ClaudeCodeMode;
+  hermesMode?: HermesInstallMode;
+  localDir?: string;
+  noAgentInstall?: boolean;
+  apiKeyProvided: boolean;
+}): string {
+  const parts = ['npx @verygoodplugins/mcp-automem install', `--target ${options.target}`];
+  // --endpoint is rejected with --target local (the local server always binds the
+  // compose default), so never reconstruct one there.
+  if (options.endpoint && options.target !== 'local') parts.push(`--endpoint ${options.endpoint}`);
+  if (options.target === 'cloud' && options.cloudProvider)
+    parts.push(`--cloud-provider ${options.cloudProvider}`);
+  if (options.apiKeyProvided) parts.push('--api-key <your key>');
+  if (options.target === 'local' && options.localDir) parts.push(`--local-dir ${options.localDir}`);
+  if (options.noAgentInstall) parts.push('--no-agent-install');
+  else if (options.clients.length > 0) parts.push(`--clients ${options.clients.join(',')}`);
+  if (!options.noAgentInstall && options.clients.includes('claude-code') && options.claudeCodeMode)
+    parts.push(`--claude-code-mode ${options.claudeCodeMode}`);
+  if (!options.noAgentInstall && options.clients.includes('hermes') && options.hermesMode)
+    parts.push(`--hermes-mode ${options.hermesMode}`);
+  return parts.join(' ');
+}
+
 // Render a failure as a clean themed block — never a raw Error/stack. The message
 // is shown as-is; InstallError hints add an actionable follow-up line. "Command
 // failed: …" noise from execFileSync is stripped so users see intent, not internals.
@@ -340,7 +372,11 @@ export function formatInstallError(
   message = message.replace(/^Command failed:.*$/m, '').trim() || 'AutoMem install failed.';
   const lines = [`\n${theme.style.red(theme.symbol.cross)} ${theme.style.bold(message)}`];
   if (err instanceof InstallError && err.hint) {
-    lines.push(`  ${theme.style.dim(err.hint)}`);
+    // The hint is the recovery path — indent every line and keep it normal
+    // weight (dim recovery text is illegible on light terminals).
+    for (const hintLine of err.hint.split('\n')) {
+      lines.push(`  ${hintLine}`);
+    }
   }
   return `${lines.join('\n')}\n`;
 }
@@ -1625,7 +1661,14 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
         promptConfirm({ message: 'Apply this AutoMem install plan?', initialValue: false })
       );
       if (!approved) {
-        writeStatus('No files were changed.');
+        // Six prompts of answers shouldn't evaporate on a No — hand them back
+        // as the equivalent one-liner so re-running skips the wizard entirely.
+        writeStatus('Nothing was installed — no files were changed.');
+        const theme = makeTheme(process.stdout);
+        process.stdout.write(
+          `  ${theme.style.dim('Your answers, ready to re-run:')}\n` +
+            `  ${theme.style.gold('$')} ${equivalentInstallCommand({ ...resolved, apiKeyProvided: Boolean(resolved.apiKey) })}\n`
+        );
         return;
       }
     }
@@ -1748,7 +1791,13 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
       });
       if (!verify.ok) {
         list.fail('verify');
-        throw new InstallError("Couldn't verify the AutoMem endpoint.", verify.message);
+        throw new InstallError(
+          "Couldn't reach your AutoMem server.",
+          `Nothing was installed — your machine wasn't changed.\n` +
+            `Check the URL is right, or wait a minute (the server may still be starting) and re-run:\n` +
+            `  ${equivalentInstallCommand({ ...resolved, apiKeyProvided: Boolean(apiKey) })}\n` +
+            `Technical detail: ${verify.message}`
+        );
       }
       list.done('verify', `Endpoint verified (${endpoint.replace(/\/$/, '')})`);
 
@@ -1833,6 +1882,20 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
     }
 
     const nextSteps: string[] = [`endpoint  ${endpoint}`];
+    // The finish line earns its box only if it says what to do NOW: restart the
+    // tools that were just wired, and a concrete way to see memory working.
+    const installedClients = resolved.noAgentInstall
+      ? []
+      : resolved.clients.filter(
+          (client) => !agentFailures.some((failure) => failure.client === client)
+        );
+    if (installedClients.length > 0) {
+      nextSteps.push(
+        `Restart ${installedClients.map((client) => clientLabel(client)).join(' / ')} to pick up the connection.`
+      );
+      nextSteps.push('Try it: ask your agent "what do you remember about me?"');
+    }
+    nextSteps.push('Docs: https://automem.ai');
     // Only surface the manual /plugin commands when the auto-install didn't run or
     // didn't succeed — i.e. the `claude` binary was absent, or the install failed.
     const pluginAutoInstallFailed = agentFailures.some(

--- a/src/cli/ui/brand.ts
+++ b/src/cli/ui/brand.ts
@@ -71,7 +71,9 @@ export function renderSuccessCard(
 
   const content = [
     `${theme.style.gold(theme.symbol.check)} ${theme.style.bold(title)}`,
-    ...lines.map((line) => theme.style.dim(line)),
+    // Normal weight on purpose: these lines are the endpoint + next steps — the
+    // card's entire payload — and bare ANSI dim is illegible on light terminals.
+    ...lines,
   ];
   const innerWidth = Math.min(
     theme.width - 4,

--- a/src/cli/ui/brand.ts
+++ b/src/cli/ui/brand.ts
@@ -1,4 +1,3 @@
-import { badge } from './messages.js';
 import { makeTheme, padEndVisible, repeatVisible, visibleLength, type Theme } from './theme.js';
 import { centerBlock, centerLine, renderMascot, renderWordmark } from '../install-ui.js';
 
@@ -26,7 +25,8 @@ export function renderBrandHeader(
   // The wide header's mascot is Unicode box art — collapse to the one-line badge
   // when unicode is off (ASCII/dumb terminals) as well as the existing cases.
   if (options.compact || theme.width < 60 || !theme.color || !theme.unicode) {
-    return `${badge('automem', theme)} ${theme.style.bold('AutoMem')} ${theme.style.dim(TAGLINE)}\n`;
+    // No badge: it printed the brand name twice back-to-back ("automem AutoMem").
+    return `${theme.style.bold('AutoMem')} ${theme.style.dim(`— ${TAGLINE}.`)}\n`;
   }
   return [
     '',

--- a/src/cli/ui/checklist.ts
+++ b/src/cli/ui/checklist.ts
@@ -10,6 +10,9 @@ type Status = 'pending' | 'running' | 'done' | 'fail';
 
 export type Checklist = {
   start(key: string): void;
+  // Refresh a running step's label in place (e.g. a retry counter) without
+  // changing its status.
+  update(key: string, label: string): void;
   done(key: string, label?: string): void;
   fail(key: string, label?: string): void;
   // Clean up the animation + restore the cursor (call before printing an error,
@@ -106,6 +109,7 @@ export function startChecklist(
 
   return {
     start: (key) => set(key, 'running'),
+    update: (key, label) => set(key, 'running', label),
     done: (key, label) => set(key, 'done', label),
     fail: (key, label) => set(key, 'fail', label),
     stop,

--- a/src/cli/ui/prompts.ts
+++ b/src/cli/ui/prompts.ts
@@ -50,7 +50,11 @@ export async function cancelable<T>(promise: Promise<T>): Promise<T> {
   } catch (err) {
     if (err instanceof Error && err.name === 'ExitPromptError') {
       const t = makeTheme(process.stdout);
-      process.stdout.write(`\n${t.style.dim('AutoMem install canceled.')}\n`);
+      // Reassure + resume: a Ctrl-C mid-wizard must say the machine is untouched
+      // (nothing is written before the apply confirm) and how to pick back up.
+      process.stdout.write(
+        `\n${t.style.dim('AutoMem install canceled — nothing was changed. Run the same command again anytime.')}\n`
+      );
       process.exit(0);
     }
     throw err;

--- a/src/cli/ui/prompts.ts
+++ b/src/cli/ui/prompts.ts
@@ -5,6 +5,15 @@
 import { checkbox, confirm, input, password, select } from '@inquirer/prompts';
 import { makeTheme } from './theme.js';
 
+// One dim line of plain-language context above a prompt, for questions whose
+// jargon (API URL, API key) the prompt message itself can't afford to caption.
+// Dim is deliberate here: captions are auxiliary hierarchy, not load-bearing —
+// the prompt reads fine without them on a worst-case light theme.
+export function promptCaption(text: string): void {
+  const t = makeTheme(process.stdout);
+  process.stdout.write(`${t.style.dim(text)}\n`);
+}
+
 export type PromptOption<T> = {
   value: T;
   label: string;
@@ -56,7 +65,7 @@ export async function cancelable<T>(promise: Promise<T>): Promise<T> {
       // Reassure + resume: a Ctrl-C mid-wizard must say the machine is untouched
       // (nothing is written before the apply confirm) and how to pick back up.
       process.stdout.write(
-        `\n${t.style.dim('AutoMem install canceled — nothing was changed. Run the same command again anytime.')}\n`
+        `\n${t.style.dim('AutoMem install canceled — no AutoMem files were changed. Run the same command again anytime.')}\n`
       );
       process.exit(0);
     }

--- a/src/cli/ui/prompts.ts
+++ b/src/cli/ui/prompts.ts
@@ -28,7 +28,10 @@ function goldTheme(stream: NodeJS.WriteStream = process.stdout) {
       highlight: (s: string) => t.style.gold(s),
       help: (s: string) => t.style.dim(s),
       error: (s: string) => t.style.red(s),
-      defaultAnswer: (s: string) => t.style.dim(s),
+      // Normal weight on purpose: the default answer ("y/N") is the one string
+      // that says what Enter will do — dim makes it illegible on light themes,
+      // and the apply confirm is the only prompt here with real side effects.
+      defaultAnswer: (s: string) => s,
       key: (s: string) => t.style.gold(s),
       description: (s: string) => t.style.dim(s),
     },

--- a/src/cli/ui/theme.ts
+++ b/src/cli/ui/theme.ts
@@ -22,6 +22,7 @@ export type ThemeOptions = {
 
 export type Theme = {
   color: boolean;
+  truecolor: boolean;
   unicode: boolean;
   width: number;
   style: {
@@ -47,7 +48,11 @@ export type Theme = {
   };
 };
 
-const ANSI = {
+// Two palettes, one shape. Truecolor carries the exact brand values; the ANSI-16
+// tier maps every slot to a terminal-theme-relative code so colors stay legible
+// on terminals without 24-bit support AND on light backgrounds (the terminal's
+// own theme picks a readable yellow, which absolute #ffd23f cannot promise).
+const ANSI_TRUECOLOR = {
   reset: '\x1b[0m',
   bold: '\x1b[1m',
   dim: '\x1b[2m',
@@ -61,6 +66,30 @@ const ANSI = {
   goldBg: '\x1b[48;2;255;210;63m',
   black: '\x1b[30m',
 };
+
+const ANSI_16 = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  magenta: '\x1b[35m',
+  gold: '\x1b[93m',
+  goldBright: '\x1b[93m',
+  goldBg: '\x1b[103m',
+  black: '\x1b[30m',
+};
+
+// COLORTERM is the de-facto truecolor signal (set by iTerm2, WezTerm, Windows
+// Terminal, kitty, VS Code…). Absent it, emit ANSI-16 — Apple Terminal and
+// tmux-without-RGB are the common cases that would otherwise get raw 24-bit
+// sequences they don't fully support.
+export function supportsTruecolor(env: NodeJS.ProcessEnv = process.env): boolean {
+  const colorterm = (env.COLORTERM ?? '').toLowerCase();
+  return colorterm.includes('truecolor') || colorterm.includes('24bit');
+}
 
 export function streamWidth(stream: NodeJS.WriteStream = process.stdout): number {
   return Math.max(40, Math.min(stream.columns ?? 80, 120));
@@ -84,8 +113,10 @@ function shouldUseUnicode(stream: NodeJS.WriteStream, mode: SymbolMode): boolean
   return process.platform !== 'win32' || Boolean(process.env.WT_SESSION);
 }
 
+const RESET = '\x1b[0m';
+
 function wrap(enabled: boolean, open: string): (text: string) => string {
-  return (text) => (enabled && text.length > 0 ? `${open}${text}${ANSI.reset}` : text);
+  return (text) => (enabled && text.length > 0 ? `${open}${text}${RESET}` : text);
 }
 
 export function makeTheme(
@@ -94,8 +125,11 @@ export function makeTheme(
 ): Theme {
   const color = shouldColor(stream, options.color ?? 'auto');
   const unicode = shouldUseUnicode(stream, options.symbols ?? 'auto');
+  const truecolor = supportsTruecolor();
+  const ANSI = truecolor ? ANSI_TRUECOLOR : ANSI_16;
   return {
     color,
+    truecolor,
     unicode,
     width: options.width ?? streamWidth(stream),
     style: {

--- a/src/cli/ui/ui.test.ts
+++ b/src/cli/ui/ui.test.ts
@@ -310,3 +310,34 @@ describe('install-ui/centering', () => {
     expect(pads[0]).toBeGreaterThan(0);
   });
 });
+
+describe('color tier fallback', () => {
+  const stream = { isTTY: true, columns: 100 } as unknown as NodeJS.WriteStream;
+
+  it('emits truecolor SGR only when COLORTERM signals support', () => {
+    const prev = process.env.COLORTERM;
+    process.env.COLORTERM = 'truecolor';
+    try {
+      expect(makeTheme(stream, { color: 'always' }).style.gold('x')).toContain('\x1b[38;2;');
+    } finally {
+      if (prev === undefined) delete process.env.COLORTERM;
+      else process.env.COLORTERM = prev;
+    }
+  });
+
+  it('falls back to ANSI-16 codes when COLORTERM is unset', () => {
+    const prev = process.env.COLORTERM;
+    delete process.env.COLORTERM;
+    try {
+      const gold = makeTheme(stream, { color: 'always' }).style.gold('x');
+      // Bright yellow, terminal-theme mapped — never a raw 24-bit sequence the
+      // terminal may not understand (and that is illegible on light themes).
+      expect(gold).toContain('\x1b[93m');
+      expect(gold).not.toContain('38;2');
+      expect(makeTheme(stream, { color: 'always' }).style.red('x')).toContain('\x1b[31m');
+    } finally {
+      if (prev === undefined) delete process.env.COLORTERM;
+      else process.env.COLORTERM = prev;
+    }
+  });
+});

--- a/tests/e2e/interactive.mjs
+++ b/tests/e2e/interactive.mjs
@@ -125,6 +125,8 @@ const SCENARIOS = [
       { waitFor: /Where should AutoMem run/, send: KEY.enter }, // cloud (default)
       { waitFor: /stand up your hosted AutoMem/, send: KEY.enter }, // InstaPods (default)
       { waitFor: /which agents/, send: KEY.enter }, // none selected
+      { waitFor: /Continue anyway/, send: 'y' }, // zero-agent guard confirm
+      { send: KEY.enter },
     ],
     // InstaPods opens the setup page + pastes during apply, so dry-run shows the
     // provision step and never prompts for a URL/token in resolve.
@@ -143,6 +145,8 @@ const SCENARIOS = [
       { send: KEY.enter },
       { waitFor: /AutoMem API key/, send: KEY.enter }, // blank
       { waitFor: /which agents/, send: KEY.enter }, // none selected
+      { waitFor: /Continue anyway/, send: 'y' }, // zero-agent guard confirm
+      { send: KEY.enter },
     ],
     // 'other' pastes up front like an existing endpoint — verify, no provision step.
     expect: [/Verify AutoMem endpoint/, /Install review/, /mode\s+cloud/, /Dry run only/],
@@ -160,6 +164,8 @@ const SCENARIOS = [
       { waitFor: /stand up your hosted AutoMem/, send: KEY.down }, // InstaPods → Railway
       { send: KEY.enter },
       { waitFor: /which agents/, send: KEY.enter }, // none selected
+      { waitFor: /Continue anyway/, send: 'y' }, // zero-agent guard confirm
+      { send: KEY.enter },
     ],
     // Railway provisions endpoint+token during apply (via the railway CLI), so
     // dry-run shows the provision step and never prompts for a URL/token.
@@ -174,6 +180,8 @@ const SCENARIOS = [
       { send: KEY.enter },
       { waitFor: /Local AutoMem server directory/, send: KEY.enter }, // accept default
       { waitFor: /which agents/, send: KEY.enter }, // none
+      { waitFor: /Continue anyway/, send: 'y' }, // zero-agent guard confirm
+      { send: KEY.enter },
     ],
     expect: [/Prepare local AutoMem server/, /mode\s+local/, /Dry run only/],
     notExpect: [/AutoMem install canceled/],
@@ -217,6 +225,29 @@ const SCENARIOS = [
       /--yes/,
       /AUTOMEM_DRY_RUN/,
     ],
+  },
+  {
+    name: 'existing-none',
+    description: 'zero-agent guard: empty multiselect -> explicit confirm -> review says no agents',
+    steps: [
+      { waitFor: /Where should AutoMem run/, send: KEY.down }, // cloud → local
+      { send: KEY.down }, // local → existing
+      { send: KEY.enter },
+      { waitFor: /AutoMem API URL/, send: ENDPOINT },
+      { send: KEY.enter },
+      { waitFor: /AutoMem API key/, send: KEY.enter }, // blank
+      { waitFor: /which agents/, send: KEY.enter }, // submit empty
+      { waitFor: /Continue anyway/, send: 'y' },
+      { send: KEY.enter },
+    ],
+    expect: [
+      /No AI tools selected/,
+      /Install review/,
+      /no agents/,
+      /none selected — nothing will be connected/,
+      /Dry run only/,
+    ],
+    notExpect: [/AutoMem install canceled/],
   },
 ];
 

--- a/tests/e2e/interactive.mjs
+++ b/tests/e2e/interactive.mjs
@@ -248,7 +248,7 @@ const SCENARIOS = [
     expect: [
       /No AI tools selected/,
       /Install review/,
-      /no agents/,
+      /no AI tools/,
       /none selected — nothing will be connected/,
       /Dry run only/,
     ],

--- a/tests/e2e/interactive.mjs
+++ b/tests/e2e/interactive.mjs
@@ -73,7 +73,7 @@ const SCENARIOS = [
       { waitFor: /AutoMem API URL/, send: ENDPOINT },
       { send: KEY.enter },
       { waitFor: /AutoMem API key/, send: KEY.enter }, // blank
-      { waitFor: /which agents/, send: KEY.down }, // codex → claude-code
+      { waitFor: /which AI tools/, send: KEY.down }, // codex → claude-code
       { send: KEY.down }, // claude-code → cursor
       { send: KEY.space }, // check cursor
       { send: KEY.enter },
@@ -91,7 +91,7 @@ const SCENARIOS = [
       { waitFor: /AutoMem API URL/, send: ENDPOINT },
       { send: KEY.enter },
       { waitFor: /AutoMem API key/, send: KEY.enter },
-      { waitFor: /which agents/, send: KEY.down }, // codex → claude-code
+      { waitFor: /which AI tools/, send: KEY.down }, // codex → claude-code
       { send: KEY.space }, // check claude-code
       { send: KEY.enter },
       { waitFor: /integrate with Claude Code/, send: KEY.enter }, // plugin (default)
@@ -109,7 +109,7 @@ const SCENARIOS = [
       { waitFor: /AutoMem API URL/, send: ENDPOINT },
       { send: KEY.enter },
       { waitFor: /AutoMem API key/, send: KEY.enter },
-      { waitFor: /which agents/, send: KEY.down },
+      { waitFor: /which AI tools/, send: KEY.down },
       { send: KEY.space },
       { send: KEY.enter },
       { waitFor: /integrate with Claude Code/, send: KEY.down }, // plugin → settings
@@ -123,14 +123,19 @@ const SCENARIOS = [
     description: 'hosted cloud → InstaPods: provider select → no resolve paste → setup-page plan',
     steps: [
       { waitFor: /Where should AutoMem run/, send: KEY.enter }, // cloud (default)
-      { waitFor: /stand up your hosted AutoMem/, send: KEY.enter }, // InstaPods (default)
-      { waitFor: /which agents/, send: KEY.enter }, // none selected
+      { waitFor: /set up your hosted AutoMem/, send: KEY.enter }, // InstaPods (default)
+      { waitFor: /which AI tools/, send: KEY.enter }, // none selected
       { waitFor: /Continue anyway/, send: 'y' }, // zero-agent guard confirm
       { send: KEY.enter },
     ],
     // InstaPods opens the setup page + pastes during apply, so dry-run shows the
     // provision step and never prompts for a URL/token in resolve.
-    expect: [/Set up AutoMem on InstaPods/, /Install review/, /mode\s+cloud/, /Dry run only/],
+    expect: [
+      /Set up AutoMem on InstaPods/,
+      /Install review/,
+      /setup\s+hosted cloud/,
+      /Dry run only/,
+    ],
     notExpect: [/AutoMem API URL/, /AutoMem install canceled/],
   },
   {
@@ -138,18 +143,18 @@ const SCENARIOS = [
     description: 'hosted cloud → Other: provider select → paste URL + key up front',
     steps: [
       { waitFor: /Where should AutoMem run/, send: KEY.enter }, // cloud (default)
-      { waitFor: /stand up your hosted AutoMem/, send: KEY.down }, // InstaPods → Railway
+      { waitFor: /set up your hosted AutoMem/, send: KEY.down }, // InstaPods → Railway
       { send: KEY.down }, // Railway → Other
       { send: KEY.enter },
       { waitFor: /AutoMem API URL/, send: ENDPOINT },
       { send: KEY.enter },
       { waitFor: /AutoMem API key/, send: KEY.enter }, // blank
-      { waitFor: /which agents/, send: KEY.enter }, // none selected
+      { waitFor: /which AI tools/, send: KEY.enter }, // none selected
       { waitFor: /Continue anyway/, send: 'y' }, // zero-agent guard confirm
       { send: KEY.enter },
     ],
     // 'other' pastes up front like an existing endpoint — verify, no provision step.
-    expect: [/Verify AutoMem endpoint/, /Install review/, /mode\s+cloud/, /Dry run only/],
+    expect: [/Verify AutoMem endpoint/, /Install review/, /setup\s+hosted cloud/, /Dry run only/],
     notExpect: [
       /Set up AutoMem on InstaPods/,
       /Deploy AutoMem on Railway/,
@@ -161,15 +166,15 @@ const SCENARIOS = [
     description: 'hosted cloud → Railway (guided): provider select → no paste → provision plan',
     steps: [
       { waitFor: /Where should AutoMem run/, send: KEY.enter }, // cloud (default)
-      { waitFor: /stand up your hosted AutoMem/, send: KEY.down }, // InstaPods → Railway
+      { waitFor: /set up your hosted AutoMem/, send: KEY.down }, // InstaPods → Railway
       { send: KEY.enter },
-      { waitFor: /which agents/, send: KEY.enter }, // none selected
+      { waitFor: /which AI tools/, send: KEY.enter }, // none selected
       { waitFor: /Continue anyway/, send: 'y' }, // zero-agent guard confirm
       { send: KEY.enter },
     ],
     // Railway provisions endpoint+token during apply (via the railway CLI), so
     // dry-run shows the provision step and never prompts for a URL/token.
-    expect: [/Deploy AutoMem on Railway/, /Install review/, /mode\s+cloud/, /Dry run only/],
+    expect: [/Deploy AutoMem on Railway/, /Install review/, /setup\s+hosted cloud/, /Dry run only/],
     notExpect: [/AutoMem API URL/, /Deploy AutoMem on InstaPods/, /AutoMem install canceled/],
   },
   {
@@ -179,11 +184,11 @@ const SCENARIOS = [
       { waitFor: /Where should AutoMem run/, send: KEY.down }, // cloud → local
       { send: KEY.enter },
       { waitFor: /Local AutoMem server directory/, send: KEY.enter }, // accept default
-      { waitFor: /which agents/, send: KEY.enter }, // none
+      { waitFor: /which AI tools/, send: KEY.enter }, // none
       { waitFor: /Continue anyway/, send: 'y' }, // zero-agent guard confirm
       { send: KEY.enter },
     ],
-    expect: [/Prepare local AutoMem server/, /mode\s+local/, /Dry run only/],
+    expect: [/Prepare local AutoMem server/, /setup\s+local docker/, /Dry run only/],
     notExpect: [/AutoMem install canceled/],
   },
   {
@@ -197,7 +202,7 @@ const SCENARIOS = [
       { waitFor: /AutoMem API URL/, send: ENDPOINT },
       { send: KEY.enter },
       { waitFor: /AutoMem API key/, send: KEY.enter }, // blank
-      { waitFor: /which agents/, send: KEY.down }, // codex → claude-code
+      { waitFor: /which AI tools/, send: KEY.down }, // codex → claude-code
       { send: KEY.down }, // claude-code → cursor
       { send: KEY.down }, // cursor → openclaw
       { send: KEY.down }, // openclaw → hermes
@@ -217,7 +222,7 @@ const SCENARIOS = [
       /Dry run only/,
       // On a TTY, dropping --dry-run is enough to apply; the headless variant
       // (which also needs --yes) must not leak into the interactive closer.
-      /To apply, drop --dry-run and re-run\./,
+      /run the same command without --dry-run/,
     ],
     notExpect: [
       /AutoMem install canceled/,
@@ -236,7 +241,7 @@ const SCENARIOS = [
       { waitFor: /AutoMem API URL/, send: ENDPOINT },
       { send: KEY.enter },
       { waitFor: /AutoMem API key/, send: KEY.enter }, // blank
-      { waitFor: /which agents/, send: KEY.enter }, // submit empty
+      { waitFor: /which AI tools/, send: KEY.enter }, // submit empty
       { waitFor: /Continue anyway/, send: 'y' },
       { send: KEY.enter },
     ],


### PR DESCRIPTION
## What this is

A design pass over every route of the guided installer, aimed at the first-time user who ran `curl -fsSL get.automem.ai | sh` off a blog post and doesn't know what an endpoint, API key, or agent is. Method: PTY transcripts were captured for **all 16 flow states** (every route + splash animation, apply confirm/decline, live checklist, HTTP-500 failure, Ctrl-C, URL validation, 80×24), reviewed through 9 design lenses (tui-design + cli-installer-ux rubrics, 46 findings), implemented, then adversarially re-reviewed by 3 independent passes over the final diff (which caught 1 blocker + 7 more, all addressed in the last commit).

**Stacked on #200** (uses `dryRunApplyHint` and the grok PTY route) — merge that first.

## The four problems it fixes

1. **Dead ends.** Failed endpoint verify printed a raw HTTP diagnostic and exited; declining the apply confirm evaporated all wizard answers; the success card had no next step. Every ending now says what happened to the machine and hands back the exact re-run command (`equivalentInstallCommand` reconstructs it from the wizard answers; API key always a shell-safe placeholder). The success card names the tools that were wired, says to restart them, and gives a way to see memory working.
2. **Silent zero-agent installs.** Empty multiselect + Enter used to sail through to "AutoMem is installed". Now: one explicit confirm (No re-opens the list), a warn row in the review, and a distinct success-card title. Deliberate `--no-agent-install` runs are exempt.
3. **Uncaptioned jargon.** Framing line up front ("About 2 minutes. Nothing is written until you approve the plan at the end."), `(recommended)` on the default, Docker-aware Local hint, plain-language captions on URL/key prompts, costs at the decision point (both provider hints + an InstaPods billing confirm matching Railway's), review screen speaks the user's labels ("hosted cloud", not "cloud"; "setup", not "mode").
4. **Light-terminal fragility.** All color was hardcoded truecolor. `COLORTERM` now gates a two-tier palette — ANSI-16 (gold→bright yellow) everywhere truecolor isn't signaled — and load-bearing text (success card content, `y/N` default, multi-line error hints) lost its `dim`.

Plus: Docker checked at decision time **including the daemon** (`docker info` — Docker-Desktop-installed-but-quit is the top local failure), `docker compose` output contained to `install.log` with a 15-line tail on failure, the discarded Claude-plugin plan detail restored (`renderActionDetail` returned `[]` unconditionally), verify retries visible as a counter, stdin drained before the apply confirm (a buffered Enter used to silently decline the wizard), splash trimmed to fit 80×24 with the first prompt.

## The adversarial round's blocker (worth reading)

The first version of the verify-failure closer rebuilt its retry command from resolve-time options — for a cloud run whose freshly provisioned endpoint flaked the final health check, that command would have **re-provisioned a second paid deployment** instead of reconnecting to the one that exists. It now retries `--target existing --endpoint <live endpoint>` and the machine-state line is target-aware.

## Verification

- 987 unit tests / 55 files pass (`npm test`)
- 9/9 PTY routes pass, including new `existing-none` (zero-agent guard) — clean env and with `GROK_HOME`/`HERMES_HOME` exported
- 14/14 e2e matrix scenarios pass against a freshly packed tarball
- All 16 PTY transcripts regenerated post-change and eyeballed against the review's originals
- Three deliberate judgment calls documented in commits: promptCaption stays dim (auxiliary, not load-bearing), `[agent]` stage tag unchanged, splash charm kept (trimmed, not removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)