### PR TITLE
feat(install): add clickable terminal links and live wait counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Features
+
+* **installer:** clickable terminal hyperlinks on actionable URLs, plus live attempt counters on the local and cloud wait spinners.
+
 ### Bug Fixes
 
 * **recall:** show content previews in budgeted formats instead of replacing them with AutoMem summaries; keep relation stubs, metadata_keys, and the 18k-token budget. Empty content falls back to summary in the text channel.

--- a/src/cli/cloud/installer-bridge.ts
+++ b/src/cli/cloud/installer-bridge.ts
@@ -10,6 +10,7 @@
 //     API); the create-page is the real, working flow.
 
 import { noteBox } from '../ui/messages.js';
+import { makeTheme } from '../ui/theme.js';
 import {
   cancelable,
   promptCaption,
@@ -41,6 +42,10 @@ import {
 // InstaPods AutoMem one-click setup: deploys the app and emails the URL + token.
 export const INSTAPODS_CREATE_URL =
   'https://app.instapods.com/dashboard/pods/create?app=automem&utm_source=automem_installer&ref=jack';
+
+function linkedUrl(url: string): string {
+  return makeTheme(process.stdout).link(url);
+}
 
 const REUSE_PREFIX = 'reuse:';
 
@@ -138,7 +143,7 @@ export async function provisionViaInstaPodsLink(
         'it deploys AutoMem and emails you your API URL + key.',
         'Paste them below once you have them.',
         '',
-        INSTAPODS_CREATE_URL,
+        linkedUrl(INSTAPODS_CREATE_URL),
       ])
     );
     log('  Waiting — the email can take a minute or two. Paste here when it arrives.');
@@ -323,7 +328,7 @@ async function railwayDeployOrPaste(params: {
         '',
         'Then paste them below.',
         '',
-        RAILWAY_DEPLOY_URL,
+        linkedUrl(RAILWAY_DEPLOY_URL),
       ])
     );
   }
@@ -408,7 +413,7 @@ export async function provisionViaRailway(
           "Then come back here — I'll link your railway CLI to the new project and",
           'read its URL + API token automatically.',
           '',
-          RAILWAY_DEPLOY_URL,
+          linkedUrl(RAILWAY_DEPLOY_URL),
         ])
       );
       if (!params.interactive) return;

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -1092,6 +1092,29 @@ describe('guided install helpers', () => {
     expect(attempts).toBe(3);
   });
 
+  it('waitForAutoMemEndpoint reports each attempt to onAttempt', async () => {
+    const seen: Array<[number, number]> = [];
+    const fetchFn = async () => ({
+      ok: false,
+      status: 503,
+      json: async () => ({ status: 'unhealthy' }),
+    });
+
+    await waitForAutoMemEndpoint({
+      endpoint: 'http://127.0.0.1:8001',
+      fetchFn,
+      attempts: 3,
+      intervalMs: 1,
+      onAttempt: (attempt, attempts) => seen.push([attempt, attempts]),
+    });
+
+    expect(seen).toEqual([
+      [1, 3],
+      [2, 3],
+      [3, 3],
+    ]);
+  });
+
   it('passes a custom timeout through every wait probe', async () => {
     vi.useFakeTimers();
     try {

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -1267,7 +1267,7 @@ describe('guided install helpers', () => {
         new InstallError('Could not reach http://127.0.0.1:8001: still starting.', ''),
         tty
       );
-      expect(out).toMatch(/\x1b]8;;http:\/\/127\.0\.0\.1:8001\/?\x1b\\/);
+      expect(out).toContain('\x1b]8;;http://127.0.0.1:8001');
       expect(out).not.toContain('\x1b]8;;http://127.0.0.1:8001:');
     } finally {
       if (prevTerm === undefined) delete process.env.TERM;

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -1240,6 +1240,43 @@ describe('guided install helpers', () => {
     expect(out).toContain('AutoMem install failed');
   });
 
+  it('formatInstallError keeps URLs plain on a non-TTY stream', () => {
+    const notty = {
+      isTTY: false,
+      write: () => true,
+    } as unknown as NodeJS.WriteStream;
+    const out = formatInstallError(
+      new InstallError(
+        'AutoMem deployed, but https://fresh.example is not responding yet.',
+        'Finish with --endpoint https://fresh.example'
+      ),
+      notty
+    );
+    expect(out).toContain('https://fresh.example');
+    expect(out).not.toContain('\x1b]8;');
+  });
+
+  it('formatInstallError strips trailing prose punctuation from linked URLs', () => {
+    const prevTerm = process.env.TERM;
+    const prevNoColor = process.env.NO_COLOR;
+    process.env.TERM = 'xterm-256color';
+    delete process.env.NO_COLOR;
+    try {
+      const tty = { isTTY: true, write: () => true } as unknown as NodeJS.WriteStream;
+      const out = formatInstallError(
+        new InstallError('Could not reach http://127.0.0.1:8001: still starting.', ''),
+        tty
+      );
+      expect(out).toMatch(/\x1b]8;;http:\/\/127\.0\.0\.1:8001\/?\x1b\\/);
+      expect(out).not.toContain('\x1b]8;;http://127.0.0.1:8001:');
+    } finally {
+      if (prevTerm === undefined) delete process.env.TERM;
+      else process.env.TERM = prevTerm;
+      if (prevNoColor === undefined) delete process.env.NO_COLOR;
+      else process.env.NO_COLOR = prevNoColor;
+    }
+  });
+
   it('rejects a custom --endpoint with target local so the plan matches what is written', () => {
     const environment = detectInstallEnvironment();
     expect(() =>

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -1353,7 +1353,9 @@ function renderActionDetail(
   const endpoint = (plan.endpoint ?? '<prompted>').replace(/\/$/, '');
   switch (action.kind) {
     case 'verify-endpoint':
-      return [detail(`${endpoint}/health${plan.apiKeyProvided ? '  + auth probe' : ''}`)];
+      return [
+        detail(`${theme.link(`${endpoint}/health`)}${plan.apiKeyProvided ? '  + auth probe' : ''}`),
+      ];
     case 'write-env':
       return [
         detail(
@@ -1431,7 +1433,8 @@ export function renderInstallPlan(
     );
     out.push(...renderActionDetail(action, plan, theme));
     for (const cmd of action.commands ?? []) {
-      out.push(`     ${theme.style.gold('$')} ${cmd}`);
+      const displayed = cmd.replace(/(https?:\/\/\S+)/g, (url) => theme.link(url));
+      out.push(`     ${theme.style.gold('$')} ${displayed}`);
     }
     // One dim path line per file — no per-file backup line (mentioned once below).
     for (const filePath of action.paths) {
@@ -1536,7 +1539,7 @@ async function resolveInteractiveOptions(
     if (!environment.prerequisites.docker) {
       throw new InstallError(
         "AutoMem's local option needs Docker on this machine.",
-        `Get Docker Desktop (free): https://www.docker.com/products/docker-desktop\n` +
+        `Get Docker Desktop (free): ${makeTheme(process.stderr).link('https://www.docker.com/products/docker-desktop')}\n` +
           `Install it, open it once so it's running, then re-run this installer.\n` +
           `Or pick Hosted Cloud — no Docker needed.`
       );
@@ -1901,8 +1904,12 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
         `  ${theme.style.gold(theme.symbol.check)} Local AutoMem server ready\n`
       );
 
-      const spin = startSpinner('Waiting for AutoMem to come online…');
-      const ready = await waitForAutoMemEndpoint({ endpoint });
+      const waiting = 'Waiting for AutoMem to come online…';
+      const spin = startSpinner(waiting);
+      const ready = await waitForAutoMemEndpoint({
+        endpoint,
+        onAttempt: (attempt, attempts) => spin.update(`${waiting} (${attempt}/${attempts})`),
+      });
       if (!ready.ok) {
         spin.error('AutoMem did not come online');
         throw new InstallError('AutoMem did not become healthy in time.', ready.message);
@@ -1933,9 +1940,9 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
       // domain needs DNS). Budget ~5 min (150 × 2s) so we don't false-fail verify on a
       // still-booting deployment (the embedding-model download is the long pole).
       if (endpoint) {
-        const spin = startSpinner(
-          'Waiting for AutoMem to come online (a fresh deploy can take a few minutes)…'
-        );
+        const waiting =
+          'Waiting for AutoMem to come online (a fresh deploy can take a few minutes)…';
+        const spin = startSpinner(waiting);
         // stableChecks: a fresh deploy flickers during early boot (health up before the
         // auth'd recall blueprint registers / the container restarts once), so require a
         // few consecutive health+recall passes before declaring it ready.
@@ -1945,13 +1952,14 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
           attempts: 150,
           intervalMs: 2000,
           stableChecks: 3,
+          onAttempt: (attempt, attempts) => spin.update(`${waiting} (${attempt}/${attempts})`),
         });
         if (ready.ok) {
           spin.stop('AutoMem is online');
         } else {
           spin.error('AutoMem is not responding yet');
           throw new InstallError(
-            `AutoMem deployed, but ${endpoint} isn't responding yet.`,
+            `AutoMem deployed, but ${theme.link(endpoint)} isn't responding yet.`,
             `A multi-service deploy can take a few minutes. Check the provider's logs (e.g. \`railway logs\`), then finish with:\n  npx @verygoodplugins/mcp-automem install --target existing --endpoint ${endpoint}${apiKey ? ' --api-key YOUR_KEY_HERE' : ''}`
           );
         }
@@ -2036,7 +2044,7 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
             `Technical detail: ${verify.message}`
         );
       }
-      list.done('verify', `Endpoint verified (${endpoint.replace(/\/$/, '')})`);
+      list.done('verify', `Endpoint verified (${theme.link(endpoint.replace(/\/$/, ''))})`);
 
       list.start('env');
       const envPath = path.join(environment.cwd, '.env');
@@ -2118,7 +2126,7 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
       throw applyErr;
     }
 
-    const nextSteps: string[] = [`endpoint  ${endpoint}`];
+    const nextSteps: string[] = [`endpoint  ${theme.link(endpoint)}`];
     // The finish line earns its box only if it says what to do NOW: restart the
     // tools that were just wired, and a concrete way to see memory working.
     // Only surface the manual /plugin commands when the auto-install didn't run or
@@ -2147,7 +2155,7 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
       );
       nextSteps.push('Try it: ask "what do you remember about me?"');
     }
-    nextSteps.push('Docs: https://automem.ai');
+    nextSteps.push(`Docs: ${theme.link('https://automem.ai')}`);
     if (claudePluginIsManual) {
       nextSteps.push('Claude Code plugin — run these inside Claude Code:');
       for (const cmd of CLAUDE_CODE_PLUGIN_COMMANDS) {

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -435,14 +435,20 @@ export function formatInstallError(
   stream: NodeJS.WriteStream = process.stderr
 ): string {
   const theme = makeTheme(stream);
+  const linkUrls = (text: string): string =>
+    text.replace(/https?:\/\/[^\s]+/g, (url) => {
+      const trimmed = url.replace(/[.,;:!?)]+$/, '');
+      const trailing = url.slice(trimmed.length);
+      return trimmed.length > 0 ? `${theme.link(trimmed)}${trailing}` : url;
+    });
   let message = err instanceof Error ? err.message : String(err);
   message = message.replace(/^Command failed:.*$/m, '').trim() || 'AutoMem install failed.';
-  const lines = [`\n${theme.style.red(theme.symbol.cross)} ${theme.style.bold(message)}`];
+  const lines = [`\n${theme.style.red(theme.symbol.cross)} ${theme.style.bold(linkUrls(message))}`];
   if (err instanceof InstallError && err.hint) {
     // The hint is the recovery path — indent every line and keep it normal
     // weight (dim recovery text is illegible on light terminals).
     for (const hintLine of err.hint.split('\n')) {
-      lines.push(`  ${hintLine}`);
+      lines.push(`  ${linkUrls(hintLine)}`);
     }
   }
   return `${lines.join('\n')}\n`;
@@ -1433,7 +1439,11 @@ export function renderInstallPlan(
     );
     out.push(...renderActionDetail(action, plan, theme));
     for (const cmd of action.commands ?? []) {
-      const displayed = cmd.replace(/(https?:\/\/\S+)/g, (url) => theme.link(url));
+      const displayed = cmd.replace(/(https?:\/\/\S+)/g, (url) => {
+        const trimmed = url.replace(/[.,;:!?)]+$/, '');
+        const trailing = url.slice(trimmed.length);
+        return trimmed.length > 0 ? `${theme.link(trimmed)}${trailing}` : url;
+      });
       out.push(`     ${theme.style.gold('$')} ${displayed}`);
     }
     // One dim path line per file — no per-file backup line (mentioned once below).
@@ -1539,7 +1549,7 @@ async function resolveInteractiveOptions(
     if (!environment.prerequisites.docker) {
       throw new InstallError(
         "AutoMem's local option needs Docker on this machine.",
-        `Get Docker Desktop (free): ${makeTheme(process.stderr).link('https://www.docker.com/products/docker-desktop')}\n` +
+        `Get Docker Desktop (free): https://www.docker.com/products/docker-desktop\n` +
           `Install it, open it once so it's running, then re-run this installer.\n` +
           `Or pick Hosted Cloud — no Docker needed.`
       );
@@ -1959,7 +1969,7 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
         } else {
           spin.error('AutoMem is not responding yet');
           throw new InstallError(
-            `AutoMem deployed, but ${theme.link(endpoint)} isn't responding yet.`,
+            `AutoMem deployed, but ${endpoint} isn't responding yet.`,
             `A multi-service deploy can take a few minutes. Check the provider's logs (e.g. \`railway logs\`), then finish with:\n  npx @verygoodplugins/mcp-automem install --target existing --endpoint ${endpoint}${apiKey ? ' --api-key YOUR_KEY_HERE' : ''}`
           );
         }

--- a/src/cli/ui/theme.ts
+++ b/src/cli/ui/theme.ts
@@ -115,6 +115,15 @@ function shouldUseUnicode(stream: NodeJS.WriteStream, mode: SymbolMode): boolean
   return process.platform !== 'win32' || Boolean(process.env.WT_SESSION);
 }
 
+function shouldHyperlink(color: boolean): boolean {
+  // Color already encodes TTY / NO_COLOR. OSC 8 is a separate capability: a
+  // color TTY with TERM=dumb still cannot interpret hyperlinks, so refuse it
+  // independently (same dumb-terminal gate unicode already uses).
+  if (!color) return false;
+  if (process.env.TERM === 'dumb') return false;
+  return true;
+}
+
 const RESET = '\x1b[0m';
 
 function wrap(enabled: boolean, open: string): (text: string) => string {
@@ -158,9 +167,9 @@ export function makeTheme(
       arrow: unicode ? '→' : '->',
       line: unicode ? '─' : '-',
     },
-    // Color already encodes TTY / NO_COLOR / dumb-terminal detection, so OSC 8
-    // never leaks into pipes, CI, or --no-color transcripts.
-    link: color ? hyperlink : plainLinkText,
+    // Color encodes TTY / NO_COLOR; shouldHyperlink also refuses TERM=dumb so
+    // OSC 8 never leaks into pipes, CI, --no-color, or dumb-terminal transcripts.
+    link: shouldHyperlink(color) ? hyperlink : plainLinkText,
   };
 }
 

--- a/src/cli/ui/theme.ts
+++ b/src/cli/ui/theme.ts
@@ -46,6 +46,8 @@ export type Theme = {
     arrow: string;
     line: string;
   };
+  /** OSC 8 terminal hyperlink — clickable where supported, plain text elsewhere. */
+  link(url: string, label?: string): string;
 };
 
 // Two palettes, one shape. Truecolor carries the exact brand values; the ANSI-16
@@ -156,12 +158,20 @@ export function makeTheme(
       arrow: unicode ? '→' : '->',
       line: unicode ? '─' : '-',
     },
+    // Color already encodes TTY / NO_COLOR / dumb-terminal detection, so OSC 8
+    // never leaks into pipes, CI, or --no-color transcripts.
+    link: color ? hyperlink : plainLinkText,
   };
 }
 
 export function stripAnsi(value: string): string {
-  // eslint-disable-next-line no-control-regex -- intentional: matches the ANSI escape (ESC) sequence to strip it
-  return value.replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, '');
+  return (
+    value
+      // eslint-disable-next-line no-control-regex -- intentional: OSC hyperlink/escape sequences (see visibleLength + harness contract)
+      .replace(/\x1B][^\x07\x1B]*(\x07|\x1B\\)/g, '')
+      // eslint-disable-next-line no-control-regex -- intentional: classic ESC/CSI sequences
+      .replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, '')
+  );
 }
 
 export function visibleLength(value: string): number {
@@ -176,4 +186,48 @@ export function padEndVisible(value: string, target: number): string {
 
 export function repeatVisible(char: string, count: number): string {
   return Array.from({ length: Math.max(0, count) }, () => char).join('');
+}
+
+function encodeControlCharacters(value: string): string {
+  let encoded = '';
+  for (let i = 0; i < value.length; i += 1) {
+    const char = value[i];
+    const code = char.charCodeAt(0);
+    encoded += code <= 0x1f || code === 0x7f ? encodeURIComponent(char) : char;
+  }
+  return encoded;
+}
+
+function plainLinkText(url: string, label?: string): string {
+  return encodeControlCharacters(label && label.length > 0 ? label : url);
+}
+
+/**
+ * Terminal hyperlink (OSC 8).
+ * Renders as a clickable link in modern terminals (iTerm2, VS Code, Windows Terminal,
+ * recent macOS Terminal, etc.). Gracefully degrades everywhere else: stripAnsi /
+ * visibleLength turn it into the plain label text.
+ *
+ * Safety: only emits OSC for well-formed http/https URLs. Anything else
+ * (placeholders like "<prompted>" or non-URLs) is returned as plain text, and
+ * label/text control characters are percent-encoded to avoid terminal escape
+ * injection. Callers should prefer `theme.link(...)` for capability awareness.
+ */
+export function hyperlink(url: string, label?: string): string {
+  const rawText = label && label.length > 0 ? label : url;
+  const safeText = encodeControlCharacters(rawText);
+
+  let safeUrl: string;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return safeText;
+    }
+    safeUrl = parsed.href;
+  } catch {
+    return safeText;
+  }
+
+  // OSC 8 ; ; <url> ST <text> OSC 8 ; ; ST
+  return `\x1b]8;;${safeUrl}\x1b\\${safeText}\x1b]8;;\x1b\\`;
 }

--- a/src/cli/ui/ui.test.ts
+++ b/src/cli/ui/ui.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { makeTheme, padEndVisible, repeatVisible, stripAnsi, visibleLength } from './theme.js';
+import {
+  hyperlink,
+  makeTheme,
+  padEndVisible,
+  repeatVisible,
+  stripAnsi,
+  visibleLength,
+} from './theme.js';
 import { bulletList, keyValueRows, statusMark } from './table.js';
 import { badge, makeLogger, noteBox, sectionTitle } from './messages.js';
 import { renderSuccessCard, renderSuccessOutro } from './brand.js';
@@ -17,10 +24,14 @@ describe('ui/theme', () => {
     expect(plain.color).toBe(false);
     expect(plain.style.gold('hi')).toBe('hi');
     expect(plain.style.inverseGold('hi')).toBe('[hi]');
+    expect(plain.link('https://example.com', 'label\x1b')).toBe('label%1B');
+    expect(plain.link('https://example.com', 'label\x1b')).not.toContain('\x1b]8;');
 
     const colored = makeTheme(stream, { color: 'always', symbols: 'unicode' });
     expect(colored.style.gold('hi')).toContain('\x1b[');
     expect(stripAnsi(colored.style.gold('hi'))).toBe('hi');
+    expect(colored.link('https://example.com', 'label')).toContain('\x1b]8;');
+    expect(stripAnsi(colored.link('https://example.com', 'docs'))).toBe('docs');
   });
 
   it('switches symbol sets between unicode and ascii', () => {
@@ -47,6 +58,20 @@ describe('ui/theme', () => {
     expect(visibleLength(padEndVisible(colored, 6))).toBe(6);
     expect(repeatVisible('-', 4)).toBe('----');
     expect(repeatVisible('-', -2)).toBe('');
+  });
+
+  it('percent-encodes control characters in hyperlink labels', () => {
+    const rendered = hyperlink('https://example.com/path', 'label\x1b\x07\n\x7f');
+
+    expect(rendered).toContain('label%1B%07%0A%7F');
+    expect(stripAnsi(rendered)).toBe('label%1B%07%0A%7F');
+    expect(visibleLength(rendered)).toBe('label%1B%07%0A%7F'.length);
+  });
+
+  it('percent-encodes fallback text when hyperlink URLs are invalid', () => {
+    expect(hyperlink('not a url', 'label\x1b')).toBe('label%1B');
+    expect(hyperlink('file:///tmp/example', 'label\x07')).toBe('label%07');
+    expect(hyperlink('<prompted>/health')).toBe('<prompted>/health');
   });
 });
 

--- a/src/cli/ui/ui.test.ts
+++ b/src/cli/ui/ui.test.ts
@@ -30,8 +30,16 @@ describe('ui/theme', () => {
     const colored = makeTheme(stream, { color: 'always', symbols: 'unicode' });
     expect(colored.style.gold('hi')).toContain('\x1b[');
     expect(stripAnsi(colored.style.gold('hi'))).toBe('hi');
-    expect(colored.link('https://example.com', 'label')).toContain('\x1b]8;');
-    expect(stripAnsi(colored.link('https://example.com', 'docs'))).toBe('docs');
+    const prevTerm = process.env.TERM;
+    process.env.TERM = 'xterm-256color';
+    try {
+      const linked = makeTheme(stream, { color: 'always', symbols: 'unicode' });
+      expect(linked.link('https://example.com', 'label')).toContain('\x1b]8;');
+      expect(stripAnsi(linked.link('https://example.com', 'docs'))).toBe('docs');
+    } finally {
+      if (prevTerm === undefined) delete process.env.TERM;
+      else process.env.TERM = prevTerm;
+    }
   });
 
   it('switches symbol sets between unicode and ascii', () => {
@@ -72,6 +80,21 @@ describe('ui/theme', () => {
     expect(hyperlink('not a url', 'label\x1b')).toBe('label%1B');
     expect(hyperlink('file:///tmp/example', 'label\x07')).toBe('label%07');
     expect(hyperlink('<prompted>/health')).toBe('<prompted>/health');
+  });
+
+  it('does not emit OSC 8 when TERM=dumb even if the stream is a color TTY', () => {
+    const prev = process.env.TERM;
+    process.env.TERM = 'dumb';
+    try {
+      const tty = { isTTY: true } as unknown as NodeJS.WriteStream;
+      const theme = makeTheme(tty, { color: 'always' });
+      expect(theme.color).toBe(true);
+      expect(theme.link('https://example.com', 'docs')).toBe('docs');
+      expect(theme.link('https://example.com')).not.toContain('\x1b]8;');
+    } finally {
+      if (prev === undefined) delete process.env.TERM;
+      else process.env.TERM = prev;
+    }
   });
 });
 

--- a/tests/e2e/interactive.mjs
+++ b/tests/e2e/interactive.mjs
@@ -56,7 +56,9 @@ try {
 }
 
 const ANSI = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
-const strip = (s) => s.replace(ANSI, '');
+// Also strip OSC 8 hyperlinks (and other OSC) so expectations see clean label text.
+const OSC = /\x1B][^\x07\x1B]*(\x07|\x1B\\)/g;
+const strip = (s) => s.replace(OSC, '').replace(ANSI, '');
 const KEY = { enter: '\r', down: '\x1B[B', up: '\x1B[A', space: ' ' };
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 

--- a/tests/e2e/railway-guided-install.mjs
+++ b/tests/e2e/railway-guided-install.mjs
@@ -64,7 +64,8 @@ try {
 }
 
 const ANSI = /\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g;
-const strip = (s) => s.replace(ANSI, '');
+const OSC = /\x1B][^\x07\x1B]*(\x07|\x1B\\)/g;
+const strip = (s) => s.replace(OSC, '').replace(ANSI, '');
 const KEY = { enter: '\r' };
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 


### PR DESCRIPTION
## Summary
- Ports the leftover UX from #157 onto the post-#201 installer: OSC 8 hyperlinks (`theme.link`) on actionable URLs (install review health endpoint, success-card endpoint/docs, InstaPods/Railway noteBoxes, Docker Desktop error).
- Live `(n/total)` attempt counters on the local and cloud "Waiting for AutoMem to come online" spinners (plumbing already existed; these two waits were still static).
- Capability-aware: pipes, CI, `NO_COLOR`, and invalid/non-http URLs stay plain text. `stripAnsi` / PTY harnesses now strip OSC so visible width and e2e expectations stay correct.

Supersedes #157 (detected-clients one-liner, post-apply celebratory probe, and the rest of that PR were already replaced by #201).

## Test plan
- [x] `npx vitest run src/cli/ui/ui.test.ts src/cli/install.test.ts src/cli/cloud/installer-bridge.test.ts` (245 passing)
- [x] `npm run build`
- [ ] Visual: `npm run build && node dist/index.js install --dry-run` in iTerm2 / VS Code / Windows Terminal — Cmd/Ctrl-click the health URL in the review (and Docs / endpoint on a real apply)
- [ ] Visual: local apply wait spinner shows `(1/30)`…`(n/30)` while Docker comes up
- [ ] Visual: `NO_COLOR=1 node dist/index.js install --dry-run` — URLs are plain text, no OSC junk
- [ ] Optional: `node tests/e2e/interactive.mjs` after build