### PR TITLE
fix(install): explain local health timeouts with recovery steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Bug Fixes
 
 * **installer:** choosing Local Docker no longer treats an inherited `AUTOMEM_API_URL` (for example from a project `.env`) as `--endpoint`.
-* **installer:** when the local stack starts but `/health` never answers, print a recovery block (likely causes, docker commands, retry line) instead of the raw wait error.
+* **installer:** when the local stack starts but `/health` never answers, print a recovery block (likely causes, docker commands, retry line) instead of the raw wait error. Cap the wait at 60s even if `/health` hangs, and quote `--local-dir` in those recovery commands.
 * **recall:** show content previews in budgeted formats instead of replacing them with AutoMem summaries; keep relation stubs, metadata_keys, and the 18k-token budget. Empty content falls back to summary in the text channel.
 
 ## [0.15.0](https://github.com/verygoodplugins/mcp-automem/compare/mcp-automem-v0.14.0...mcp-automem-v0.15.0) (2026-06-26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
+* **installer:** choosing Local Docker no longer treats an inherited `AUTOMEM_API_URL` (for example from a project `.env`) as `--endpoint`.
+* **installer:** when the local stack starts but `/health` never answers, print a recovery block (likely causes, docker commands, retry line) instead of the raw wait error.
 * **recall:** show content previews in budgeted formats instead of replacing them with AutoMem summaries; keep relation stubs, metadata_keys, and the 18k-token budget. Empty content falls back to summary in the text channel.
 
 ## [0.15.0](https://github.com/verygoodplugins/mcp-automem/compare/mcp-automem-v0.14.0...mcp-automem-v0.15.0) (2026-06-26)

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -8,11 +8,14 @@ import {
   DEFAULT_AGENT_CLIENTS,
   InstallError,
   buildInstallPlan,
+  pinLocalInstallOptions,
   claudePluginInstallArgs,
   claudePluginMarketplaceAddArgs,
   detectInstallEnvironment,
   formatEnvValue,
   formatInstallError,
+  localHealthTimeoutError,
+  localHealthRecoveryHint,
   installClaudeCodePlugin,
   manualFixHint,
   parseInstallArgs,
@@ -69,6 +72,8 @@ describe('guided install helpers', () => {
       dryRun: true,
       yes: true,
       noAgentInstall: true,
+      endpointFromFlag: true,
+      apiKeyFromFlag: true,
     });
   });
 
@@ -1050,6 +1055,32 @@ describe('guided install helpers', () => {
     if (!result.ok) expect(result.message).toContain('HTTP 500');
   });
 
+  it('accepts degraded /health by default but rejects it when requireHealthy is set', async () => {
+    const fetchFn = async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        status: 'degraded',
+        falkordb: 'disconnected',
+        qdrant: 'disconnected',
+      }),
+    });
+    await expect(
+      verifyAutoMemEndpoint({ endpoint: 'http://127.0.0.1:8001', fetchFn })
+    ).resolves.toEqual({ ok: true });
+    const strict = await verifyAutoMemEndpoint({
+      endpoint: 'http://127.0.0.1:8001',
+      fetchFn,
+      requireHealthy: true,
+    });
+    expect(strict.ok).toBe(false);
+    if (!strict.ok) {
+      expect(strict.message).toContain('degraded');
+      expect(strict.message).toContain('FalkorDB disconnected');
+      expect(strict.message).toContain('Qdrant disconnected');
+    }
+  });
+
   it('fails fast with a clean message when the endpoint hangs (abort timeout)', async () => {
     // A fetch that never resolves on its own, but rejects when the abort fires.
     const hangingFetch = (_url: string, init?: { signal?: AbortSignal }) =>
@@ -1277,11 +1308,68 @@ describe('guided install helpers', () => {
     }
   });
 
+  it('localHealthRecoveryHint explains a fetch-failed wait and lists recovery commands', () => {
+    const hint = localHealthRecoveryHint({
+      endpoint: 'http://127.0.0.1:8001',
+      localDir: '/Users/me/.automem/server',
+      waitMessage: 'Could not reach AutoMem endpoint http://127.0.0.1:8001: fetch failed',
+      retryCommand:
+        'npx @verygoodplugins/mcp-automem install --target local --local-dir ~/.automem/server --clients cursor --yes',
+      inspect: {
+        composePs: 'flask-api   Restarting (1) 0 seconds ago',
+        apiLogs: 'Authorization: Bearer super-secret-token\nValueError: boom',
+      },
+    });
+    expect(hint).toMatch(/Nothing accepted the connection/);
+    expect(hint).toContain('What to try:');
+    expect(hint).toContain('docker compose ps');
+    expect(hint).toContain('docker compose logs flask-api');
+    expect(hint).toContain('lsof -iTCP:8001');
+    expect(hint).toContain('--target local');
+    expect(hint).toContain('Hosted Cloud');
+    expect(hint).toContain('flask-api   Restarting');
+    expect(hint).toContain('ValueError: boom');
+    expect(hint).not.toContain('super-secret-token');
+    expect(hint).toContain('Bearer ***');
+  });
+
+  it('localHealthTimeoutError is a recovery-styled InstallError, not the raw wait string', () => {
+    const err = localHealthTimeoutError({
+      endpoint: 'http://127.0.0.1:8001',
+      localDir: '/tmp/automem-server',
+      waitMessage: 'AutoMem endpoint did not become healthy after 30 attempts: fetch failed',
+      retryCommand: 'npx @verygoodplugins/mcp-automem install --target local --yes',
+      inspect: {},
+    });
+    expect(err).toBeInstanceOf(InstallError);
+    expect(err.message).toMatch(/never answered at http:\/\/127\.0\.0\.1:8001/);
+    expect(err.message).not.toMatch(/30 attempts/);
+    const out = formatInstallError(err, process.stderr);
+    expect(out).toContain('What to try:');
+    expect(out).toContain('docker compose ps');
+    expect(out).not.toMatch(/\n\s+at\s/);
+  });
+
+  it('localHealthRecoveryHint tells you to recreate the stack when stores are disconnected', () => {
+    const hint = localHealthRecoveryHint({
+      endpoint: 'http://127.0.0.1:8001',
+      localDir: '/Users/me/.automem/server',
+      waitMessage: 'AutoMem is degraded (FalkorDB disconnected, Qdrant disconnected).',
+      retryCommand: 'npx @verygoodplugins/mcp-automem install --target local --yes',
+      inspect: {
+        apiLogs:
+          'redis.exceptions.ConnectionError: Error -2 connecting to falkordb:6379. Name or service not known.',
+      },
+    });
+    expect(hint).toMatch(/FalkorDB or Qdrant is not connected/);
+    expect(hint).toContain('docker compose down && docker compose up -d --build');
+  });
+
   it('rejects a custom --endpoint with target local so the plan matches what is written', () => {
     const environment = detectInstallEnvironment();
     expect(() =>
       buildInstallPlan({
-        options: { ...parseInstallArgs([], {}), target: 'local', endpoint: 'http://custom:9000' },
+        options: { ...parseInstallArgs(['--endpoint', 'http://custom:9000'], {}), target: 'local' },
         environment,
       })
     ).toThrow(/not supported with --target local/);
@@ -1294,6 +1382,48 @@ describe('guided install helpers', () => {
       environment,
     });
     expect(plan.endpoint).toBe('http://127.0.0.1:8001');
+  });
+
+  it('does not treat an inherited AUTOMEM_API_URL as --endpoint for a local install', () => {
+    const environment = detectInstallEnvironment();
+    const parsed = parseInstallArgs([], { AUTOMEM_API_URL: 'https://env.example' });
+    expect(parsed.endpointFromFlag).toBe(false);
+    const plan = buildInstallPlan({
+      options: { ...parsed, target: 'local' },
+      environment,
+    });
+    expect(plan.endpoint).toBe('http://127.0.0.1:8001');
+  });
+
+  it('drops an inherited key paired to a foreign URL when pinning local Docker', () => {
+    const pinned = pinLocalInstallOptions({
+      ...parseInstallArgs([], {
+        AUTOMEM_API_URL: 'https://env.example',
+        AUTOMEM_API_KEY: 'env-secret',
+      }),
+      target: 'local',
+    });
+    expect(pinned.endpoint).toBe('http://127.0.0.1:8001');
+    expect(pinned.apiKey).toBeUndefined();
+  });
+
+  it('keeps an inherited key when AUTOMEM_API_URL is already the local bind', () => {
+    const pinned = pinLocalInstallOptions({
+      ...parseInstallArgs([], {
+        AUTOMEM_API_URL: 'http://127.0.0.1:8001',
+        AUTOMEM_API_KEY: 'local-secret',
+      }),
+      target: 'local',
+    });
+    expect(pinned.apiKey).toBe('local-secret');
+  });
+
+  it('keeps an explicit --api-key when pinning away from an inherited URL', () => {
+    const pinned = pinLocalInstallOptions({
+      ...parseInstallArgs(['--api-key', 'flag-key'], { AUTOMEM_API_URL: 'https://env.example' }),
+      target: 'local',
+    });
+    expect(pinned.apiKey).toBe('flag-key');
   });
 
   it('reuses the existing local .env token on re-run instead of rotating it', async () => {

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -1139,6 +1139,96 @@ describe('guided install helpers', () => {
     }
   });
 
+  it('gives the authenticated recall probe a fresh timeout after a slow health body', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchFn = async (url: string, init?: { signal?: AbortSignal }) => {
+        if (url.includes('/health')) {
+          return {
+            ok: true,
+            status: 200,
+            json: () =>
+              new Promise((resolve) => {
+                setTimeout(() => resolve({ status: 'healthy' }), 30);
+              }),
+          };
+        }
+        return new Promise((resolve, reject) => {
+          const timer = setTimeout(
+            () => resolve({ ok: true, status: 200, json: async () => ({}) }),
+            30
+          );
+          init?.signal?.addEventListener('abort', () => {
+            clearTimeout(timer);
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        });
+      };
+
+      const resultPromise = verifyAutoMemEndpoint({
+        endpoint: 'https://slow-then-recall.example',
+        apiKey: 'sk-test',
+        fetchFn,
+        timeoutMs: 40,
+      });
+
+      await vi.advanceTimersByTimeAsync(30);
+      await vi.advanceTimersByTimeAsync(30);
+      await expect(resultPromise).resolves.toEqual({ ok: true });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not let recall overrun an absolute deadline after a slow health body', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    try {
+      const fetchFn = async (url: string, init?: { signal?: AbortSignal }) => {
+        if (url.includes('/health')) {
+          return {
+            ok: true,
+            status: 200,
+            json: () =>
+              new Promise((resolve) => {
+                setTimeout(() => resolve({ status: 'healthy' }), 40);
+              }),
+          };
+        }
+        return new Promise((resolve, reject) => {
+          const timer = setTimeout(
+            () => resolve({ ok: true, status: 200, json: async () => ({}) }),
+            40
+          );
+          init?.signal?.addEventListener('abort', () => {
+            clearTimeout(timer);
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        });
+      };
+
+      const resultPromise = verifyAutoMemEndpoint({
+        endpoint: 'https://deadline-overrun.example',
+        apiKey: 'sk-test',
+        fetchFn,
+        timeoutMs: 100,
+        deadlineAt: 50,
+      });
+
+      await vi.advanceTimersByTimeAsync(40);
+      await vi.advanceTimersByTimeAsync(40);
+      const result = await resultPromise;
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.message).toContain('timed out');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('waits for a local endpoint to become healthy before continuing', async () => {
     let attempts = 0;
     const fetchFn = async () => {

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -1204,6 +1204,33 @@ describe('guided install helpers', () => {
     expect(recallCalls).toBe(4);
   });
 
+  it('waitForAutoMemEndpoint with requireHealthy keeps waiting through degraded /health', async () => {
+    let attempts = 0;
+    const fetchFn = async () => {
+      attempts += 1;
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          status: attempts === 3 ? 'healthy' : 'degraded',
+          falkordb: attempts === 3 ? 'connected' : 'disconnected',
+          qdrant: attempts === 3 ? 'connected' : 'disconnected',
+        }),
+      };
+    };
+
+    await expect(
+      waitForAutoMemEndpoint({
+        endpoint: 'http://127.0.0.1:8001',
+        fetchFn,
+        attempts: 3,
+        intervalMs: 1,
+        requireHealthy: true,
+      })
+    ).resolves.toEqual({ ok: true });
+    expect(attempts).toBe(3);
+  });
+
   it('turns a docker compose failure into a clean InstallError with a port hint', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'automem-local-prep-'));
     try {

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -550,6 +550,20 @@ describe('guided install helpers', () => {
     expect(cmd).toContain('--api-key YOUR_KEY_HERE');
   });
 
+  it('a local retry command omits --api-key when the key was inherited from the environment', () => {
+    // pinLocalInstallOptions can keep an env-provided key; the retry command
+    // must still omit --api-key so prepareLocalServer reuses localDir/.env
+    // instead of writing the placeholder literal.
+    const cmd = equivalentInstallCommand({
+      target: 'local',
+      clients: ['cursor'],
+      localDir: '/Users/tester/.automem/server',
+      yes: true,
+      apiKeyProvided: false,
+    });
+    expect(cmd).not.toContain('--api-key');
+  });
+
   // Both cancel-style endings (declined confirm, failed verify) hand the user
   // their answers back as a runnable command so six prompts of work never
   // evaporates. The command must reconstruct flags from resolved options and
@@ -1427,6 +1441,18 @@ describe('guided install helpers', () => {
     });
     expect(hint).toContain("cd '/tmp/AutoMem Server' && docker compose ps");
     expect(hint).not.toContain('cd /tmp/AutoMem Server &&');
+  });
+
+  it('localHealthRecoveryHint treats a timed-out probe as a slow boot, not a refused connection', () => {
+    const hint = localHealthRecoveryHint({
+      endpoint: 'http://127.0.0.1:8001',
+      localDir: '/tmp/automem-server',
+      waitMessage: 'Could not reach AutoMem endpoint http://127.0.0.1:8001: timed out after 2s',
+      retryCommand: 'npx @verygoodplugins/mcp-automem install --target local --yes',
+      inspect: {},
+    });
+    expect(hint).toMatch(/health check timed out/i);
+    expect(hint).not.toMatch(/Nothing accepted the connection/);
   });
 
   it('localHealthTimeoutError is a recovery-styled InstallError, not the raw wait string', () => {

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -1101,6 +1101,30 @@ describe('guided install helpers', () => {
     if (!result.ok) expect(result.message).toContain('timed out');
   });
 
+  it('times out when /health headers return but the JSON body never arrives', async () => {
+    vi.useFakeTimers();
+    try {
+      const stalledBodyFetch = async () => ({
+        ok: true,
+        status: 200,
+        json: () => new Promise<never>(() => {}),
+      });
+
+      const resultPromise = verifyAutoMemEndpoint({
+        endpoint: 'https://stalled-body.example',
+        fetchFn: stalledBodyFetch,
+        timeoutMs: 20,
+      });
+
+      await vi.advanceTimersByTimeAsync(20);
+      const result = await resultPromise;
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.message).toContain('timed out after 0.02s');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('waits for a local endpoint to become healthy before continuing', async () => {
     let attempts = 0;
     const fetchFn = async () => {
@@ -1173,6 +1197,39 @@ describe('guided install helpers', () => {
       const result = await resultPromise;
       expect(result.ok).toBe(false);
       if (!result.ok) expect(result.message).toContain('timed out after 0.02s');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('waitForAutoMemEndpoint deadlineMs stops a hung /health before attempts * default timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const hangingFetch = (_url: string, init?: { signal?: AbortSignal }) =>
+        new Promise<never>((_, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        });
+
+      const resultPromise = waitForAutoMemEndpoint({
+        endpoint: 'https://stalled.example',
+        fetchFn: hangingFetch,
+        attempts: 60,
+        timeoutMs: 10_000,
+        intervalMs: 1_000,
+        deadlineMs: 50,
+      });
+
+      await vi.advanceTimersByTimeAsync(50);
+      const result = await resultPromise;
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.message).toMatch(/after 1 attempts/);
+        expect(result.message).not.toMatch(/after 60 attempts/);
+      }
     } finally {
       vi.useRealTimers();
     }
@@ -1358,6 +1415,18 @@ describe('guided install helpers', () => {
     expect(hint).toContain('ValueError: boom');
     expect(hint).not.toContain('super-secret-token');
     expect(hint).toContain('Bearer ***');
+  });
+
+  it('localHealthRecoveryHint quotes localDir so a path with spaces pastes as one argument', () => {
+    const hint = localHealthRecoveryHint({
+      endpoint: 'http://127.0.0.1:8001',
+      localDir: '/tmp/AutoMem Server',
+      waitMessage: 'Could not reach AutoMem endpoint http://127.0.0.1:8001: fetch failed',
+      retryCommand: 'npx @verygoodplugins/mcp-automem install --target local --yes',
+      inspect: {},
+    });
+    expect(hint).toContain("cd '/tmp/AutoMem Server' && docker compose ps");
+    expect(hint).not.toContain('cd /tmp/AutoMem Server &&');
   });
 
   it('localHealthTimeoutError is a recovery-styled InstallError, not the raw wait string', () => {

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -250,6 +250,13 @@ type VerifyEndpointOptions = {
    * any AutoMem status string (the original identity check).
    */
   requireHealthy?: boolean;
+  /**
+   * Absolute `Date.now()` cutoff for the whole verify (health + optional recall).
+   * Each probe aborts when this instant is reached so a slow health body cannot
+   * hand recall a fresh full `timeoutMs` and overrun `waitForAutoMemEndpoint`'s
+   * `deadlineMs`.
+   */
+  deadlineAt?: number;
 };
 
 type WaitEndpointOptions = VerifyEndpointOptions & {
@@ -1086,44 +1093,75 @@ export async function verifyAutoMemEndpoint(
     return { ok: false, message: 'fetch is not available in this Node runtime.' };
   }
 
-  // Bound the whole probe — headers AND body — with one AbortController. Clearing
-  // the timer when fetch() returns would let a 200 with a stalled JSON body hang
-  // past waitForAutoMemEndpoint's remaining-ms deadline.
+  // Bound each probe — headers AND body — with its own AbortController. Sharing
+  // one timer across /health then /recall would let a slow health body steal the
+  // recall budget (Codex: 7s health + 4s recall against a 10s per-request cap).
   const timeoutMs = options.timeoutMs ?? 10_000;
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  const raceAbort = async <T>(promise: Promise<T>): Promise<T> => {
-    if (controller.signal.aborted) {
+  const runTimed = async <T>(
+    work: (helpers: {
+      signal: AbortSignal;
+      raceAbort: <U>(promise: Promise<U>) => Promise<U>;
+    }) => Promise<T>
+  ): Promise<T> => {
+    const controller = new AbortController();
+    const remainingMs =
+      options.deadlineAt === undefined ? timeoutMs : options.deadlineAt - Date.now();
+    if (remainingMs <= 0) {
       const err = new Error('aborted');
       err.name = 'AbortError';
       throw err;
     }
-    return await new Promise<T>((resolve, reject) => {
-      const onAbort = () => {
+    const probeTimeoutMs = Math.min(timeoutMs, remainingMs);
+    const timer = setTimeout(() => controller.abort(), probeTimeoutMs);
+    const raceAbort = async <U>(promise: Promise<U>): Promise<U> => {
+      if (controller.signal.aborted) {
         const err = new Error('aborted');
         err.name = 'AbortError';
-        reject(err);
-      };
-      controller.signal.addEventListener('abort', onAbort, { once: true });
-      promise.then(resolve, reject).finally(() => {
-        controller.signal.removeEventListener('abort', onAbort);
+        throw err;
+      }
+      return await new Promise<U>((resolve, reject) => {
+        const onAbort = () => {
+          const err = new Error('aborted');
+          err.name = 'AbortError';
+          reject(err);
+        };
+        controller.signal.addEventListener('abort', onAbort, { once: true });
+        promise.then(resolve, reject).finally(() => {
+          controller.signal.removeEventListener('abort', onAbort);
+        });
       });
-    });
+    };
+    try {
+      return await work({ signal: controller.signal, raceAbort });
+    } finally {
+      clearTimeout(timer);
+    }
   };
-  const withTimeout = async (
-    url: string,
-    init?: { headers?: Record<string, string> }
-  ): Promise<{
-    ok: boolean;
-    status: number;
-    json?: () => Promise<unknown>;
-    text?: () => Promise<string>;
-  }> => fetchFn(url, { ...init, signal: controller.signal });
 
   try {
-    const health = await withTimeout(`${endpoint}/health`);
-    if (!health.ok) {
-      return { ok: false, message: `Health check failed with HTTP ${health.status}.` };
+    const health = await runTimed(async ({ signal, raceAbort }) => {
+      const res = await fetchFn(`${endpoint}/health`, { signal });
+      let body: unknown;
+      try {
+        body = typeof res.json === 'function' ? await raceAbort(res.json()) : undefined;
+      } catch (error) {
+        const err = error as Error;
+        if (err.name === 'AbortError') throw err;
+        return {
+          kind: 'not-json' as const,
+          status: res.status,
+        };
+      }
+      return { kind: 'ok' as const, res, body };
+    });
+    if (health.kind === 'not-json') {
+      return {
+        ok: false,
+        message: `Health check returned HTTP ${health.status} but the body was not JSON — is ${endpoint} really an AutoMem endpoint?`,
+      };
+    }
+    if (!health.res.ok) {
+      return { ok: false, message: `Health check failed with HTTP ${health.res.status}.` };
     }
 
     // A 200 alone is not proof this is AutoMem — a reverse-proxy login wall,
@@ -1131,18 +1169,7 @@ export async function verifyAutoMemEndpoint(
     // Require a JSON body carrying a string `status` field. AutoMem returns
     // "healthy" or "degraded" (when Qdrant is down); accept any status string,
     // reject non-JSON bodies and JSON without a status.
-    let healthBody: unknown;
-    try {
-      healthBody = typeof health.json === 'function' ? await raceAbort(health.json()) : undefined;
-    } catch (error) {
-      const err = error as Error;
-      if (err.name === 'AbortError') throw err;
-      return {
-        ok: false,
-        message: `Health check returned HTTP ${health.status} but the body was not JSON — is ${endpoint} really an AutoMem endpoint?`,
-      };
-    }
-    const healthPayload = healthBody as {
+    const healthPayload = health.body as {
       status?: unknown;
       falkordb?: unknown;
       qdrant?: unknown;
@@ -1151,7 +1178,7 @@ export async function verifyAutoMemEndpoint(
     if (typeof status !== 'string') {
       return {
         ok: false,
-        message: `Health check returned HTTP ${health.status} without an AutoMem status field — is ${endpoint} really an AutoMem endpoint?`,
+        message: `Health check returned HTTP ${health.res.status} without an AutoMem status field — is ${endpoint} really an AutoMem endpoint?`,
       };
     }
     if (options.requireHealthy && status !== 'healthy') {
@@ -1168,11 +1195,12 @@ export async function verifyAutoMemEndpoint(
     }
 
     if (options.apiKey) {
-      const recall = await withTimeout(`${endpoint}/recall?limit=1`, {
-        headers: {
-          Authorization: `Bearer ${options.apiKey}`,
-        },
-      });
+      const recall = await runTimed(async ({ signal }) =>
+        fetchFn(`${endpoint}/recall?limit=1`, {
+          signal,
+          headers: { Authorization: `Bearer ${options.apiKey}` },
+        })
+      );
       if (!recall.ok) {
         return {
           ok: false,
@@ -1186,8 +1214,6 @@ export async function verifyAutoMemEndpoint(
     const err = error as Error;
     const reason = err.name === 'AbortError' ? `timed out after ${timeoutMs / 1000}s` : err.message;
     return { ok: false, message: `Could not reach AutoMem endpoint ${endpoint}: ${reason}` };
-  } finally {
-    clearTimeout(timer);
   }
 }
 
@@ -1227,6 +1253,7 @@ export async function waitForAutoMemEndpoint(
         remainingMs === undefined
           ? options.timeoutMs
           : Math.max(1, Math.min(defaultProbeTimeoutMs, remainingMs)),
+      deadlineAt,
       requireHealthy: options.requireHealthy,
     });
     // Require `stableChecks` CONSECUTIVE successes so a fresh deploy that flickers

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -162,6 +162,10 @@ export type ParsedInstallOptions = {
   dryRun: boolean;
   yes: boolean;
   noAgentInstall: boolean;
+  /** True only when `--endpoint` was on the argv — not when the URL came from env. */
+  endpointFromFlag: boolean;
+  /** True only when `--api-key` was on the argv — not when the key came from env. */
+  apiKeyFromFlag: boolean;
 };
 
 export type ResolvedInstallOptions = ParsedInstallOptions & {
@@ -239,6 +243,13 @@ type VerifyEndpointOptions = {
   }>;
   /** Per-request network timeout (ms). Default 10000. */
   timeoutMs?: number;
+  /**
+   * Local Docker install waits until AutoMem is actually healthy. `/health` can
+   * return 200 with `status: "degraded"` while FalkorDB/Qdrant are disconnected —
+   * that is not ready enough to wire agents. Existing/cloud verify still accepts
+   * any AutoMem status string (the original identity check).
+   */
+  requireHealthy?: boolean;
 };
 
 type WaitEndpointOptions = VerifyEndpointOptions & {
@@ -446,12 +457,143 @@ export function formatInstallError(
   const lines = [`\n${theme.style.red(theme.symbol.cross)} ${theme.style.bold(linkUrls(message))}`];
   if (err instanceof InstallError && err.hint) {
     // The hint is the recovery path — indent every line and keep it normal
-    // weight (dim recovery text is illegible on light terminals).
+    // weight (dim recovery text is illegible on light terminals). Multi-line
+    // recovery blocks get a blank line so the steps don't crowd the headline.
+    if (err.hint.includes('\n')) lines.push('');
     for (const hintLine of err.hint.split('\n')) {
       lines.push(`  ${linkUrls(hintLine)}`);
     }
   }
   return `${lines.join('\n')}\n`;
+}
+
+export type LocalHealthInspect = {
+  composePs?: string;
+  apiLogs?: string;
+};
+
+function redactLogSnippet(text: string): string {
+  return text
+    .replace(/Bearer\s+\S+/gi, 'Bearer ***')
+    .replace(/\b([A-Z][A-Z0-9_]*(?:TOKEN|KEY|SECRET|PASSWORD))\s*=\s*\S+/gi, '$1=***');
+}
+
+function runDockerCompose(localDir: string, args: string[], timeoutMs = 8_000): string | undefined {
+  const result = spawnSync('docker', ['compose', ...args], {
+    cwd: localDir,
+    encoding: 'utf8',
+    timeout: timeoutMs,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const output = `${result.stdout ?? ''}${result.status === 0 ? '' : (result.stderr ?? '')}`.trim();
+  if (!output) return undefined;
+  return output;
+}
+
+// Best-effort snapshot of the local stack after a health timeout. Never throws —
+// a hung docker CLI must not replace the recovery hint with a second crash.
+export function inspectLocalHealth(localDir: string): LocalHealthInspect {
+  if (!fs.existsSync(localDir)) return {};
+  try {
+    return {
+      composePs: runDockerCompose(localDir, ['ps', '-a']),
+      apiLogs: runDockerCompose(localDir, ['logs', '--no-color', '--tail', '12', 'flask-api']),
+    };
+  } catch {
+    return {};
+  }
+}
+
+function explainLocalHealthFailure(waitMessage: string): string {
+  const lower = waitMessage.toLowerCase();
+  if (/econnrefused|fetch failed|could not reach|enotfound/.test(lower)) {
+    return 'Nothing accepted the connection. The API container is usually still booting, crashed, or something else is bound to port 8001.';
+  }
+  if (/timed out|timeout|aborted/.test(lower)) {
+    return 'The health check timed out. First boot after a rebuild can take a couple of minutes while Python and models load.';
+  }
+  if (/degraded|falkordb|qdrant/.test(lower)) {
+    return 'The API is up, but FalkorDB or Qdrant is not connected. After a rebuild, leftover containers can sit on the wrong Docker network.';
+  }
+  if (/http \d+/.test(lower)) {
+    return `The port answered, but /health failed: ${waitMessage}`;
+  }
+  if (/not json|status field/.test(lower)) {
+    return `Something is listening on that port, but it does not look like AutoMem. ${waitMessage}`;
+  }
+  return waitMessage;
+}
+
+export function localHealthRecoveryHint(params: {
+  endpoint: string;
+  localDir: string;
+  waitMessage: string;
+  retryCommand: string;
+  inspect?: LocalHealthInspect;
+}): string {
+  const dir = tildify(params.localDir);
+  const inspect = params.inspect ?? inspectLocalHealth(params.localDir);
+  const healthUrl = `${params.endpoint.replace(/\/$/, '')}/health`;
+  const lines = [
+    `Docker Compose started the containers, then we waited for GET ${healthUrl}.`,
+    explainLocalHealthFailure(params.waitMessage),
+    '',
+    'What to try:',
+    '1. Confirm Docker Desktop is running (whale icon in the menu bar).',
+    '2. Check containers:',
+    `     cd ${dir} && docker compose ps`,
+    '3. If flask-api is Exited or Restarting, read the crash:',
+    `     cd ${dir} && docker compose logs flask-api --tail 80`,
+    '4. If port 8001 is taken by something else:',
+    '     docker ps    # or: lsof -iTCP:8001 -sTCP:LISTEN',
+    '     Stop that process, then re-run.',
+    '5. First start after a rebuild can take a couple of minutes. Watch logs, wait until /health works, then:',
+    `     ${params.retryCommand}`,
+  ];
+  const inspectBlob =
+    `${params.waitMessage}\n${inspect.composePs ?? ''}\n${inspect.apiLogs ?? ''}`.toLowerCase();
+  if (
+    /falkordb|qdrant/.test(inspectBlob) &&
+    /disconnected|name or service not known|connection refused|connectionerror|degraded/.test(
+      inspectBlob
+    )
+  ) {
+    lines.push(
+      '6. If the API is up but FalkorDB/Qdrant show disconnected, recreate the whole stack (old containers can sit on the wrong Docker network):',
+      `     cd ${dir} && docker compose down && docker compose up -d --build`
+    );
+  }
+  lines.push('', 'Or skip Docker and pick Hosted Cloud on the next run.');
+  if (inspect.composePs) {
+    lines.push('', 'Containers right now:');
+    for (const row of inspect.composePs.split('\n').slice(0, 8)) {
+      lines.push(`  ${row}`);
+    }
+  }
+  if (inspect.apiLogs) {
+    lines.push('', 'Recent flask-api logs:');
+    for (const row of redactLogSnippet(inspect.apiLogs).split('\n').slice(-8)) {
+      lines.push(`  ${row}`);
+    }
+  }
+  const logFile = path.join(params.localDir, 'install.log');
+  if (fs.existsSync(logFile)) {
+    lines.push('', `Full compose log: ${tildify(logFile)}`);
+  }
+  return lines.join('\n');
+}
+
+export function localHealthTimeoutError(params: {
+  endpoint: string;
+  localDir: string;
+  waitMessage: string;
+  retryCommand: string;
+  inspect?: LocalHealthInspect;
+}): InstallError {
+  return new InstallError(
+    `The local server started, but AutoMem never answered at ${params.endpoint.replace(/\/$/, '')}.`,
+    localHealthRecoveryHint(params)
+  );
 }
 
 function parseBooleanEnv(value: string | undefined): boolean {
@@ -516,8 +658,9 @@ export function parseInstallArgs(
   const envApiKey = env.AUTOMEM_API_KEY || env.AUTOMEM_API_TOKEN;
   let endpoint = envEndpoint;
   let apiKey = envApiKey;
-  // Whether the key came from --api-key rather than the environment. An explicit flag
-  // is the operator naming the credential for this run; an inherited one is not.
+  // Whether the URL/key came from argv rather than the environment. An explicit
+  // flag is the operator naming the value for this run; an inherited one is not.
+  let endpointFromFlag = false;
   let apiKeyFromFlag = false;
   let localDir = env.AUTOMEM_LOCAL_DIR;
   let hermesMode = parseHermesMode(env.AUTOMEM_HERMES_MODE);
@@ -547,6 +690,7 @@ export function parseInstallArgs(
         break;
       case '--endpoint':
         endpoint = assertValue(args, i, arg);
+        endpointFromFlag = true;
         i += 1;
         break;
       case '--api-key':
@@ -607,6 +751,8 @@ export function parseInstallArgs(
     dryRun,
     yes,
     noAgentInstall,
+    endpointFromFlag,
+    apiKeyFromFlag,
   };
 }
 
@@ -724,18 +870,38 @@ function displayKey(apiKey: string | undefined): string | undefined {
   return apiKey ? REDACTED : undefined;
 }
 
+// Local Docker always binds DEFAULT_AUTOMEM_API_URL. An inherited AUTOMEM_API_URL
+// from a project .env is not `--endpoint` — treating it as such aborted the
+// interactive Local Docker path. Pin unless the operator passed `--endpoint`.
+// A key inherited alongside a foreign URL is paired to that URL, so drop it
+// unless `--api-key` named a credential for this run.
+export function pinLocalInstallOptions(options: ResolvedInstallOptions): ResolvedInstallOptions {
+  if (options.target !== 'local') return options;
+  if (options.endpointFromFlag) return options;
+  const foreign =
+    Boolean(options.endpoint) && !sameEndpoint(options.endpoint, DEFAULT_AUTOMEM_API_URL);
+  return {
+    ...options,
+    endpoint: DEFAULT_AUTOMEM_API_URL,
+    apiKey: foreign && !options.apiKeyFromFlag ? undefined : options.apiKey,
+  };
+}
+
 export function buildInstallPlan(params: {
   options: ResolvedInstallOptions;
   environment: InstallEnvironment;
 }): InstallPlan {
-  const { options, environment } = params;
+  const options = pinLocalInstallOptions(params.options);
+  const { environment } = params;
   const localDir = options.localDir ?? defaultLocalDir(environment.homeDir);
   // The local server always binds DEFAULT_AUTOMEM_API_URL (docker compose). A custom
   // --endpoint with --target local would be shown in the approved plan but silently
   // discarded at write time, so reject the contradiction up front rather than
-  // persisting a different endpoint than the user approved.
+  // persisting a different endpoint than the user approved. Inherited env URLs are
+  // pinned above — only an explicit `--endpoint` flag is this contradiction.
   if (
     options.target === 'local' &&
+    options.endpointFromFlag &&
     options.endpoint &&
     options.endpoint.replace(/\/$/, '') !== DEFAULT_AUTOMEM_API_URL.replace(/\/$/, '')
   ) {
@@ -952,11 +1118,28 @@ export async function verifyAutoMemEndpoint(
         message: `Health check returned HTTP ${health.status} but the body was not JSON — is ${endpoint} really an AutoMem endpoint?`,
       };
     }
-    const status = (healthBody as { status?: unknown } | null | undefined)?.status;
+    const healthPayload = healthBody as {
+      status?: unknown;
+      falkordb?: unknown;
+      qdrant?: unknown;
+    } | null;
+    const status = healthPayload?.status;
     if (typeof status !== 'string') {
       return {
         ok: false,
         message: `Health check returned HTTP ${health.status} without an AutoMem status field — is ${endpoint} really an AutoMem endpoint?`,
+      };
+    }
+    if (options.requireHealthy && status !== 'healthy') {
+      const stores = [
+        typeof healthPayload?.falkordb === 'string' ? `FalkorDB ${healthPayload.falkordb}` : '',
+        typeof healthPayload?.qdrant === 'string' ? `Qdrant ${healthPayload.qdrant}` : '',
+      ].filter(Boolean);
+      return {
+        ok: false,
+        message: stores.length
+          ? `AutoMem is ${status} (${stores.join(', ')}).`
+          : `AutoMem is ${status}, not healthy yet.`,
       };
     }
 
@@ -1816,11 +1999,11 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
   }
 
   if (shouldUseNonInteractivePreview({ interactive, yes: parsed.yes, dryRun: parsed.dryRun })) {
-    const fallback: ResolvedInstallOptions = {
+    const fallback: ResolvedInstallOptions = pinLocalInstallOptions({
       ...parsed,
       target: parsed.target ?? 'existing',
       dryRun: true,
-    };
+    });
     const plan = buildInstallPlan({ options: fallback, environment });
     process.stdout.write(`\n${renderInstallPlan(plan)}\n`);
     writeStatus('No TTY detected. Re-run with --yes (or AUTOMEM_YES=1) to apply automatically.');
@@ -1837,15 +2020,17 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
         `  ${theme.style.dim('About 2 minutes. Nothing is written until you approve the plan at the end.')}\n`
       );
     }
-    const resolved = interactive
-      ? await resolveInteractiveOptions(
-          parsed,
-          environment,
-          clientsExplicit,
-          hermesModeExplicit,
-          claudeCodeModeExplicit
-        )
-      : ({ ...parsed, target: parsed.target ?? 'existing' } as ResolvedInstallOptions);
+    const resolved = pinLocalInstallOptions(
+      interactive
+        ? await resolveInteractiveOptions(
+            parsed,
+            environment,
+            clientsExplicit,
+            hermesModeExplicit,
+            claudeCodeModeExplicit
+          )
+        : ({ ...parsed, target: parsed.target ?? 'existing' } as ResolvedInstallOptions)
+    );
     const missingPrerequisites = validateInstallPrerequisites(resolved, environment);
     if (!resolved.dryRun && missingPrerequisites.length > 0) {
       throw new InstallError(
@@ -1910,19 +2095,29 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
       const local = await prepareLocalServer({ localDir: plan.localDir, apiKey, dryRun: false });
       endpoint = local.endpoint;
       apiKey = local.apiKey;
-      process.stdout.write(
-        `  ${theme.style.gold(theme.symbol.check)} Local AutoMem server ready\n`
-      );
+      process.stdout.write(`  ${theme.style.gold(theme.symbol.check)} Local containers started\n`);
 
-      const waiting = 'Waiting for AutoMem to come online…';
+      const waiting = 'Waiting for AutoMem to come online (first start can take a minute)…';
       const spin = startSpinner(waiting);
       const ready = await waitForAutoMemEndpoint({
         endpoint,
+        attempts: 60,
+        requireHealthy: true,
         onAttempt: (attempt, attempts) => spin.update(`${waiting} (${attempt}/${attempts})`),
       });
       if (!ready.ok) {
         spin.error('AutoMem did not come online');
-        throw new InstallError('AutoMem did not become healthy in time.', ready.message);
+        throw localHealthTimeoutError({
+          endpoint,
+          localDir: plan.localDir,
+          waitMessage: ready.message,
+          retryCommand: equivalentInstallCommand({
+            ...resolved,
+            localDir: plan.localDir,
+            yes: true,
+            apiKeyProvided: localRetryHasExplicitApiKey(resolved.apiKey),
+          }),
+        });
       }
       spin.stop('AutoMem is online');
     }

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -512,11 +512,15 @@ export function inspectLocalHealth(localDir: string): LocalHealthInspect {
 
 function explainLocalHealthFailure(waitMessage: string): string {
   const lower = waitMessage.toLowerCase();
-  if (/econnrefused|fetch failed|could not reach|enotfound/.test(lower)) {
-    return 'Nothing accepted the connection. The API container is usually still booting, crashed, or something else is bound to port 8001.';
-  }
+  // Timeout first: verifyAutoMemEndpoint formats hangs as
+  // "Could not reach AutoMem endpoint …: timed out after Ns", so the
+  // reachability pattern would otherwise steal those and send people looking
+  // for a crash or a port conflict.
   if (/timed out|timeout|aborted/.test(lower)) {
     return 'The health check timed out. First boot after a rebuild can take a couple of minutes while Python and models load.';
+  }
+  if (/econnrefused|fetch failed|could not reach|enotfound/.test(lower)) {
+    return 'Nothing accepted the connection. The API container is usually still booting, crashed, or something else is bound to port 8001.';
   }
   if (/degraded|falkordb|qdrant/.test(lower)) {
     return 'The API is up, but FalkorDB or Qdrant is not connected. After a rebuild, leftover containers can sit on the wrong Docker network.';
@@ -2158,7 +2162,7 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
             ...resolved,
             localDir: plan.localDir,
             yes: true,
-            apiKeyProvided: localRetryHasExplicitApiKey(resolved.apiKey),
+            apiKeyProvided: resolved.apiKeyFromFlag,
           }),
         });
       }
@@ -2267,7 +2271,7 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
           resolved.target === 'local'
             ? equivalentInstallCommand({
                 ...resolved,
-                apiKeyProvided: localRetryHasExplicitApiKey(resolved.apiKey),
+                apiKeyProvided: resolved.apiKeyFromFlag,
               })
             : equivalentInstallCommand({
                 ...resolved,

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -1190,6 +1190,7 @@ export async function waitForAutoMemEndpoint(
       apiKey: options.apiKey,
       fetchFn: options.fetchFn,
       timeoutMs: options.timeoutMs,
+      requireHealthy: options.requireHealthy,
     });
     // Require `stableChecks` CONSECUTIVE successes so a fresh deploy that flickers
     // during early boot (health up, auth'd recall flapping) isn't declared ready on a

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -255,6 +255,12 @@ type VerifyEndpointOptions = {
 type WaitEndpointOptions = VerifyEndpointOptions & {
   attempts?: number;
   intervalMs?: number;
+  /**
+   * Wall-clock cap for the whole wait (ms). Hung `/health` probes otherwise
+   * each burn `timeoutMs` (default 10s) plus `intervalMs`, so `attempts: 60`
+   * can stretch to ~11 minutes instead of the intended minute.
+   */
+  deadlineMs?: number;
   // Called before each attempt — lets the caller surface retry progress.
   onAttempt?: (attempt: number, attempts: number) => void;
   /**
@@ -531,7 +537,7 @@ export function localHealthRecoveryHint(params: {
   retryCommand: string;
   inspect?: LocalHealthInspect;
 }): string {
-  const dir = tildify(params.localDir);
+  const dir = shellQuote(params.localDir);
   const inspect = params.inspect ?? inspectLocalHealth(params.localDir);
   const healthUrl = `${params.endpoint.replace(/\/$/, '')}/health`;
   const lines = [
@@ -1076,10 +1082,30 @@ export async function verifyAutoMemEndpoint(
     return { ok: false, message: 'fetch is not available in this Node runtime.' };
   }
 
-  // Bound every probe with an AbortController (same pattern as automem-client.ts)
-  // so a hung endpoint (bad DNS, stalled connect, dead proxy) fails fast instead
-  // of blocking the installer at the verify step.
+  // Bound the whole probe — headers AND body — with one AbortController. Clearing
+  // the timer when fetch() returns would let a 200 with a stalled JSON body hang
+  // past waitForAutoMemEndpoint's remaining-ms deadline.
   const timeoutMs = options.timeoutMs ?? 10_000;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const raceAbort = async <T>(promise: Promise<T>): Promise<T> => {
+    if (controller.signal.aborted) {
+      const err = new Error('aborted');
+      err.name = 'AbortError';
+      throw err;
+    }
+    return await new Promise<T>((resolve, reject) => {
+      const onAbort = () => {
+        const err = new Error('aborted');
+        err.name = 'AbortError';
+        reject(err);
+      };
+      controller.signal.addEventListener('abort', onAbort, { once: true });
+      promise.then(resolve, reject).finally(() => {
+        controller.signal.removeEventListener('abort', onAbort);
+      });
+    });
+  };
   const withTimeout = async (
     url: string,
     init?: { headers?: Record<string, string> }
@@ -1088,15 +1114,7 @@ export async function verifyAutoMemEndpoint(
     status: number;
     json?: () => Promise<unknown>;
     text?: () => Promise<string>;
-  }> => {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), timeoutMs);
-    try {
-      return await fetchFn(url, { ...init, signal: controller.signal });
-    } finally {
-      clearTimeout(timer);
-    }
-  };
+  }> => fetchFn(url, { ...init, signal: controller.signal });
 
   try {
     const health = await withTimeout(`${endpoint}/health`);
@@ -1111,8 +1129,10 @@ export async function verifyAutoMemEndpoint(
     // reject non-JSON bodies and JSON without a status.
     let healthBody: unknown;
     try {
-      healthBody = typeof health.json === 'function' ? await health.json() : undefined;
-    } catch {
+      healthBody = typeof health.json === 'function' ? await raceAbort(health.json()) : undefined;
+    } catch (error) {
+      const err = error as Error;
+      if (err.name === 'AbortError') throw err;
       return {
         ok: false,
         message: `Health check returned HTTP ${health.status} but the body was not JSON — is ${endpoint} really an AutoMem endpoint?`,
@@ -1162,6 +1182,8 @@ export async function verifyAutoMemEndpoint(
     const err = error as Error;
     const reason = err.name === 'AbortError' ? `timed out after ${timeoutMs / 1000}s` : err.message;
     return { ok: false, message: `Could not reach AutoMem endpoint ${endpoint}: ${reason}` };
+  } finally {
+    clearTimeout(timer);
   }
 }
 
@@ -1177,19 +1199,30 @@ export async function waitForAutoMemEndpoint(
   const attempts = options.attempts ?? 30;
   const intervalMs = options.intervalMs ?? 1000;
   const stableChecks = Math.max(1, options.stableChecks ?? 1);
+  const deadlineAt = options.deadlineMs === undefined ? undefined : Date.now() + options.deadlineMs;
+  const defaultProbeTimeoutMs = options.timeoutMs ?? 10_000;
   let last: { ok: true } | { ok: false; message: string } = {
     ok: false,
     message: 'AutoMem endpoint was not checked.',
   };
   let streak = 0;
+  let attempted = 0;
 
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const remainingMs = deadlineAt === undefined ? undefined : deadlineAt - Date.now();
+    if (remainingMs !== undefined && remainingMs <= 0) {
+      break;
+    }
+    attempted = attempt;
     options.onAttempt?.(attempt, attempts);
     last = await verifyAutoMemEndpoint({
       endpoint: options.endpoint,
       apiKey: options.apiKey,
       fetchFn: options.fetchFn,
-      timeoutMs: options.timeoutMs,
+      timeoutMs:
+        remainingMs === undefined
+          ? options.timeoutMs
+          : Math.max(1, Math.min(defaultProbeTimeoutMs, remainingMs)),
       requireHealthy: options.requireHealthy,
     });
     // Require `stableChecks` CONSECUTIVE successes so a fresh deploy that flickers
@@ -1200,7 +1233,14 @@ export async function waitForAutoMemEndpoint(
       return last;
     }
     if (attempt < attempts) {
-      await sleep(intervalMs);
+      const sleepFor =
+        deadlineAt === undefined
+          ? intervalMs
+          : Math.min(intervalMs, Math.max(0, deadlineAt - Date.now()));
+      if (sleepFor <= 0) {
+        break;
+      }
+      await sleep(sleepFor);
     }
   }
 
@@ -1211,7 +1251,7 @@ export async function waitForAutoMemEndpoint(
     : last.message;
   return {
     ok: false,
-    message: `AutoMem endpoint did not become healthy after ${attempts} attempts: ${detail}`,
+    message: `AutoMem endpoint did not become healthy after ${attempted || attempts} attempts: ${detail}`,
   };
 }
 
@@ -2103,6 +2143,8 @@ async function runGuidedInstall(args: string[] = []): Promise<void> {
       const ready = await waitForAutoMemEndpoint({
         endpoint,
         attempts: 60,
+        timeoutMs: 2_000,
+        deadlineMs: 60_000,
         requireHealthy: true,
         onAttempt: (attempt, attempts) => spin.update(`${waiting} (${attempt}/${attempts})`),
       });


### PR DESCRIPTION
## Summary
- Follow-up to #203: when Local Docker compose succeeds but `/health` never becomes ready, print a diagnosed recovery block instead of a raw `fetch failed` wait error.
- Wait up to 60s and require `status: "healthy"` so a 200 with `degraded` (FalkorDB/Qdrant disconnected) does not count as installed.
- If compose logs show store DNS/connection failures, include the recreate-the-stack command.

## Test plan
- [x] `npx vitest run src/cli/install.test.ts` (175 passing)
- [x] Local Codex review after forwarding `requireHealthy` through `waitForAutoMemEndpoint`
- [ ] Re-run `node dist/index.js install` with Local Docker after `cd ~/.automem/server && docker compose down && docker compose up -d --build`