### PR TITLE
fix(client): retry truncated GET JSON bodies from AutoMem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 * **installer:** choosing Local Docker no longer treats an inherited `AUTOMEM_API_URL` (for example from a project `.env`) as `--endpoint`.
 * **installer:** when the local stack starts but `/health` never answers, print a recovery block (likely causes, docker commands, retry line) instead of the raw wait error. Cap the wait at 60s even if `/health` hangs, and quote `--local-dir` in those recovery commands.
 * **recall:** show content previews in budgeted formats instead of replacing them with AutoMem summaries; keep relation stubs, metadata_keys, and the 18k-token budget. Empty content falls back to summary in the text channel.
-* **client:** retry truncated 200/5xx JSON bodies (HTTP/2 framing cuts) instead of surfacing `Invalid JSON response (200)` on the first incomplete read.
+* **client:** retry truncated GET 2xx and 5xx JSON bodies (HTTP/2 framing cuts) instead of surfacing `Invalid JSON response (200)` on the first incomplete read. Successful POST/PATCH/DELETE bodies that fail to parse are not replayed.
 
 ## [0.15.0](https://github.com/verygoodplugins/mcp-automem/compare/mcp-automem-v0.14.0...mcp-automem-v0.15.0) (2026-06-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 * **installer:** choosing Local Docker no longer treats an inherited `AUTOMEM_API_URL` (for example from a project `.env`) as `--endpoint`.
 * **installer:** when the local stack starts but `/health` never answers, print a recovery block (likely causes, docker commands, retry line) instead of the raw wait error. Cap the wait at 60s even if `/health` hangs, and quote `--local-dir` in those recovery commands.
 * **recall:** show content previews in budgeted formats instead of replacing them with AutoMem summaries; keep relation stubs, metadata_keys, and the 18k-token budget. Empty content falls back to summary in the text channel.
-* **client:** retry truncated GET 2xx and 5xx JSON bodies (HTTP/2 framing cuts) instead of surfacing `Invalid JSON response (200)` on the first incomplete read. Successful POST/PATCH/DELETE bodies that fail to parse are not replayed.
+* **client:** retry truncated GET 2xx/5xx JSON bodies (HTTP/2 framing cuts) instead of surfacing `Invalid JSON response (200)` on the first incomplete read. Parse failures on POST/PATCH/DELETE are not replayed.
 
 ## [0.15.0](https://github.com/verygoodplugins/mcp-automem/compare/mcp-automem-v0.14.0...mcp-automem-v0.15.0) (2026-06-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 * **installer:** choosing Local Docker no longer treats an inherited `AUTOMEM_API_URL` (for example from a project `.env`) as `--endpoint`.
 * **installer:** when the local stack starts but `/health` never answers, print a recovery block (likely causes, docker commands, retry line) instead of the raw wait error. Cap the wait at 60s even if `/health` hangs, and quote `--local-dir` in those recovery commands.
 * **recall:** show content previews in budgeted formats instead of replacing them with AutoMem summaries; keep relation stubs, metadata_keys, and the 18k-token budget. Empty content falls back to summary in the text channel.
+* **client:** retry truncated 200/5xx JSON bodies (HTTP/2 framing cuts) instead of surfacing `Invalid JSON response (200)` on the first incomplete read.
 
 ## [0.15.0](https://github.com/verygoodplugins/mcp-automem/compare/mcp-automem-v0.14.0...mcp-automem-v0.15.0) (2026-06-26)
 

--- a/src/automem-client.test.ts
+++ b/src/automem-client.test.ts
@@ -1199,4 +1199,75 @@ describe('AutoMemClient', () => {
       expect(headers.Authorization).toBeUndefined();
     });
   });
+
+  describe('makeRequest — truncated JSON bodies', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('retries a 200 response whose body is truncated JSON, then succeeds', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => {
+            throw new SyntaxError('Unexpected end of JSON input');
+          },
+        } as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ results: [], count: 0 }),
+        } as any);
+
+      const resultPromise = client.recallMemory({ query: 'sweep' });
+      await vi.advanceTimersByTimeAsync(500);
+      const result = await resultPromise;
+
+      expect(result.count).toBe(0);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries invalid JSON on 503 then succeeds', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 503,
+          json: async () => {
+            throw new SyntaxError('Unexpected token < in JSON');
+          },
+        } as any)
+        .mockResolvedValueOnce({
+          ok: true,
+          status: 200,
+          json: async () => ({ results: [], count: 0 }),
+        } as any);
+
+      const resultPromise = client.recallMemory({ query: 'sweep' });
+      await vi.advanceTimersByTimeAsync(500);
+      const result = await resultPromise;
+
+      expect(result.count).toBe(0);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not retry invalid JSON on 400', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: async () => {
+          throw new SyntaxError('Unexpected token < in JSON');
+        },
+      } as any);
+
+      await expect(client.storeMemory({ content: 'x' })).rejects.toThrow(
+        'Invalid JSON response (400)'
+      );
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/automem-client.test.ts
+++ b/src/automem-client.test.ts
@@ -1269,5 +1269,20 @@ describe('AutoMemClient', () => {
       );
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
+
+    it('does not replay a truncated 201 from POST /memory', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 201,
+        json: async () => {
+          throw new SyntaxError('Unexpected end of JSON input');
+        },
+      } as any);
+
+      await expect(client.storeMemory({ content: 'x' })).rejects.toThrow(
+        'Invalid JSON response (201)'
+      );
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/automem-client.test.ts
+++ b/src/automem-client.test.ts
@@ -1284,5 +1284,20 @@ describe('AutoMemClient', () => {
       );
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
+
+    it('does not replay POST /memory when a 503 body is not JSON', async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: async () => {
+          throw new SyntaxError('Unexpected token < in JSON');
+        },
+      } as any);
+
+      await expect(client.storeMemory({ content: 'x' })).rejects.toThrow(
+        'Invalid JSON response (503)'
+      );
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/automem-client.ts
+++ b/src/automem-client.ts
@@ -204,15 +204,15 @@ export class AutoMemClient {
 
       let data: any;
       try {
-        // Truncated HTTP/2 bodies arrive as 2xx with invalid JSON. Retry GET
-        // (recall/health) the same way as a dropped connection. Do not replay
-        // POST/PATCH after a committed write whose body was cut — AutoMem
-        // mints a new UUID per store. 5xx parse failures stay retryable for
-        // every method, matching the existing 5xx JSON retry.
+        // Truncated HTTP/2 bodies arrive as 2xx/5xx with invalid JSON. Retry
+        // GET (recall/health) like a dropped connection. Never replay POST,
+        // PATCH, or DELETE after a parse failure: a committed store whose 201
+        // or gateway 5xx body was cut would mint a second UUID. 5xx responses
+        // that parse as JSON still retry for every method, as before.
         data = await response.json();
       } catch {
         const isRetryableParse =
-          (response.ok && method === 'GET') || (response.status >= 500 && response.status < 600);
+          method === 'GET' && (response.ok || (response.status >= 500 && response.status < 600));
         if (isRetryableParse && retryCount < maxRetries) {
           return retryAfter(`Invalid JSON response (${response.status})`);
         }

--- a/src/automem-client.ts
+++ b/src/automem-client.ts
@@ -204,11 +204,15 @@ export class AutoMemClient {
 
       let data: any;
       try {
-        // Truncated HTTP/2 bodies arrive as 200 with invalid JSON. Retry those
-        // (and 5xx HTML/error pages) the same way as a dropped connection.
+        // Truncated HTTP/2 bodies arrive as 2xx with invalid JSON. Retry GET
+        // (recall/health) the same way as a dropped connection. Do not replay
+        // POST/PATCH after a committed write whose body was cut — AutoMem
+        // mints a new UUID per store. 5xx parse failures stay retryable for
+        // every method, matching the existing 5xx JSON retry.
         data = await response.json();
       } catch {
-        const isRetryableParse = response.ok || (response.status >= 500 && response.status < 600);
+        const isRetryableParse =
+          (response.ok && method === 'GET') || (response.status >= 500 && response.status < 600);
         if (isRetryableParse && retryCount < maxRetries) {
           return retryAfter(`Invalid JSON response (${response.status})`);
         }

--- a/src/automem-client.ts
+++ b/src/automem-client.ts
@@ -179,62 +179,68 @@ export class AutoMemClient {
     const maxRetries = 3;
     const baseDelay = 500; // 500ms base delay
 
-    // Network errors (fetch) should be retried; HTTP errors handled below
-    let response;
+    const retryAfter = async (reason: string): Promise<any> => {
+      const delay = baseDelay * Math.pow(2, retryCount);
+      console.error(
+        `[AutoMem] ${reason}, retrying after ${delay}ms (attempt ${retryCount + 1}/${maxRetries})...`
+      );
+      await new Promise((resolve) => setTimeout(resolve, delay));
+      return this.makeRequest(method, path, body, retryCount + 1);
+    };
+
     try {
-      response = await fetch(url, options);
-    } catch (error) {
+      // Network errors (fetch) should be retried; HTTP errors handled below
+      let response;
+      try {
+        response = await fetch(url, options);
+      } catch (error) {
+        if (error instanceof Error && retryCount < maxRetries) {
+          return retryAfter('Network error');
+        }
+
+        console.error(`AutoMem API error (${method} ${url}):`, error);
+        throw error;
+      }
+
+      let data: any;
+      try {
+        // Truncated HTTP/2 bodies arrive as 200 with invalid JSON. Retry those
+        // (and 5xx HTML/error pages) the same way as a dropped connection.
+        data = await response.json();
+      } catch {
+        const isRetryableParse = response.ok || (response.status >= 500 && response.status < 600);
+        if (isRetryableParse && retryCount < maxRetries) {
+          return retryAfter(`Invalid JSON response (${response.status})`);
+        }
+        throw new Error(`Invalid JSON response (${response.status})`);
+      }
+
+      if (!response.ok) {
+        // Retry on 5xx only
+        const isRetryable = response.status >= 500 && response.status < 600;
+
+        if (isRetryable && retryCount < maxRetries) {
+          return retryAfter(`HTTP ${response.status}`);
+        }
+
+        const baseMessage =
+          (data as any)?.message || (data as any)?.detail || `HTTP ${response.status}`;
+
+        const hint =
+          response.status === 401 || response.status === 403
+            ? ' (check AUTOMEM_API_KEY or AUTOMEM_API_TOKEN is set for the MCP server process)'
+            : '';
+
+        const error = new Error(`${baseMessage}${hint}`) as Error & { status?: number };
+        error.status = response.status;
+        console.error(`AutoMem API error (${method} ${url}):`, error);
+        throw error;
+      }
+
+      return data;
+    } finally {
       clearTimeout(timeoutId);
-      if (error instanceof Error && retryCount < maxRetries) {
-        const delay = baseDelay * Math.pow(2, retryCount);
-        console.error(
-          `[AutoMem] Network error, retrying after ${delay}ms (attempt ${retryCount + 1}/${maxRetries})...`
-        );
-        await new Promise((resolve) => setTimeout(resolve, delay));
-        return this.makeRequest(method, path, body, retryCount + 1);
-      }
-
-      console.error(`AutoMem API error (${method} ${url}):`, error);
-      throw error;
     }
-    clearTimeout(timeoutId);
-
-    let data: any;
-    try {
-      // Some error responses may not be JSON; treat parse errors as non-retryable
-      data = await response.json();
-    } catch {
-      throw new Error(`Invalid JSON response (${response.status})`);
-    }
-
-    if (!response.ok) {
-      // Retry on 5xx only
-      const isRetryable = response.status >= 500 && response.status < 600;
-
-      if (isRetryable && retryCount < maxRetries) {
-        const delay = baseDelay * Math.pow(2, retryCount); // 500ms, 1s, 2s
-        console.error(
-          `[AutoMem] Retrying after ${delay}ms (attempt ${retryCount + 1}/${maxRetries})...`
-        );
-        await new Promise((resolve) => setTimeout(resolve, delay));
-        return this.makeRequest(method, path, body, retryCount + 1);
-      }
-
-      const baseMessage =
-        (data as any)?.message || (data as any)?.detail || `HTTP ${response.status}`;
-
-      const hint =
-        response.status === 401 || response.status === 403
-          ? ' (check AUTOMEM_API_KEY or AUTOMEM_API_TOKEN is set for the MCP server process)'
-          : '';
-
-      const error = new Error(`${baseMessage}${hint}`) as Error & { status?: number };
-      error.status = response.status;
-      console.error(`AutoMem API error (${method} ${url}):`, error);
-      throw error;
-    }
-
-    return data;
   }
 
   async storeMemory(args: StoreMemoryArgs): Promise<StoreMemoryResult> {


### PR DESCRIPTION
## Summary
- `recall_memory` was failing with `Invalid JSON response (200)` when Node `fetch` got a truncated HTTP/2 body, even though AutoMem `/recall` itself returned valid JSON.
- Retry invalid JSON on **GET** 2xx/5xx (recall/health) with the same backoff as dropped connections.
- Do **not** replay POST/PATCH/DELETE after a parse failure — a committed `POST /memory` whose 201 or gateway 5xx body was cut would mint a second UUID.

## Test plan
- [x] `npx vitest run src/automem-client.test.ts` — GET truncated 200 retries; GET 503 invalid JSON retries; POST truncated 201 does not retry; POST 503 HTML does not retry; POST 400 does not retry
- [ ] Live recall against a large `/recall` still succeeds after an intermittent truncated 200 (cannot force HTTP/2 cuts in unit tests)