### PR TITLE
chore(deps): align prettier pin and apply 3.9 formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "eslint": "^10.2.1",
         "husky": "^9.1.7",
         "node-pty": "^1.0.0",
-        "prettier": "3.4.2",
+        "prettier": "3.9.6",
         "tsx": "^4.6.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.0",
@@ -4722,9 +4722,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "eslint": "^10.2.1",
     "husky": "^9.1.7",
     "node-pty": "^1.0.0",
-    "prettier": "3.4.2",
+    "prettier": "3.9.6",
     "tsx": "^4.6.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.0",

--- a/src/cli/cloud/railway.ts
+++ b/src/cli/cloud/railway.ts
@@ -167,8 +167,7 @@ export function parseVariable(stdout: string, key: string): string | undefined {
     const body = JSON.parse(stdout) as unknown;
     if (Array.isArray(body)) {
       const hit = body.find((v) => (v as { name?: string }).name === key) as
-        | { value?: string }
-        | undefined;
+        { value?: string } | undefined;
       return hit?.value;
     }
     if (body && typeof body === 'object') {

--- a/src/cli/cloud/types.ts
+++ b/src/cli/cloud/types.ts
@@ -97,8 +97,7 @@ export interface CloudProvider {
 
 // What the apply phase should do, decided interactively during the resolve phase.
 export type CloudIntent =
-  | { kind: 'reuse'; deployment: CloudDeployment }
-  | { kind: 'deploy'; planSlug?: string };
+  { kind: 'reuse'; deployment: CloudDeployment } | { kind: 'deploy'; planSlug?: string };
 
 export interface CloudProvisionResult {
   endpoint: string;

--- a/src/cli/host-toolkit.ts
+++ b/src/cli/host-toolkit.ts
@@ -551,8 +551,7 @@ export function detectProjectName(cwd: string = process.cwd()): string {
 }
 
 export type ExtraFlag =
-  | { kind: 'value'; set: (value: string) => void }
-  | { kind: 'boolean'; set: () => void };
+  { kind: 'value'; set: (value: string) => void } | { kind: 'boolean'; set: () => void };
 
 /**
  * Shared parser for the flags every host handler uses:

--- a/src/env.ts
+++ b/src/env.ts
@@ -26,10 +26,7 @@ export function readAutoMemApiKeyFromEnv(env: NodeJS.ProcessEnv = process.env): 
 export const DEFAULT_AUTOMEM_API_URL = 'http://127.0.0.1:8001';
 
 export type AutoMemApiUrlSource =
-  | 'AUTOMEM_API_URL'
-  | 'CLAUDE_PLUGIN_OPTION_API_URL'
-  | 'AUTOMEM_ENDPOINT'
-  | 'default';
+  'AUTOMEM_API_URL' | 'CLAUDE_PLUGIN_OPTION_API_URL' | 'AUTOMEM_ENDPOINT' | 'default';
 
 // Precedence: the documented env var beats the plugin prompt (a user who
 // exports AUTOMEM_API_URL has configured explicitly); the plugin prompt

--- a/src/memory-policy/shared.ts
+++ b/src/memory-policy/shared.ts
@@ -433,8 +433,7 @@ function quote(value: string): string {
  * model cannot execute — the failure mode that shipped for Copilot in #186.
  */
 export type ToolCallStyle =
-  | { kind: 'direct'; toolPrefix: string }
-  | { kind: 'wrapped'; wrapper: string; toolPrefix: string };
+  { kind: 'direct'; toolPrefix: string } | { kind: 'wrapped'; wrapper: string; toolPrefix: string };
 
 function directStyle(toolPrefix: string): ToolCallStyle {
   return { kind: 'direct', toolPrefix };


### PR DESCRIPTION
## Summary
- Supersedes Dependabot #195 after concurrent merges left the branch conflicted
- Pins `prettier` to 3.9.6 (other dev-deps from the group already landed on main)
- Applies Prettier 3.9 formatting to the four files that failed `format:check`

## Context
#195 CI failed on `npm run format:check` after the Prettier bump. Rebasing #195 onto main after #196 + other dep merges produced lockfile conflicts and CI did not re-run on manual pushes.

## Test plan
- [x] `npm run format:check`
- [ ] CI green